### PR TITLE
Fix nagios formatter

### DIFF
--- a/features/support/nagios.rb
+++ b/features/support/nagios.rb
@@ -10,8 +10,8 @@ module Cucumber
         @warning = []
         @io = io
       end
-  
-      def after_step_result(keyword, step_match, multiline_arg, status, exception, source_indent, background)
+
+      def after_step_result(keyword, step_match, multiline_arg, status, exception, source_indent, background, file_colon_line)
         case status
         when :passed
           @passed << step_match


### PR DESCRIPTION
the arguments to this method must have changed in some version of
cucumber. I was getting an 'argument error, 7 args for 8' when trying to
run the nagios.sh script.
