### PR TITLE
Fix EFG CSRF failure

### DIFF
--- a/features/efg.feature
+++ b/features/efg.feature
@@ -13,7 +13,7 @@ Feature: EFG
     When I visit the EFG home page
     Then the elapsed time should be less than 1 seconds
 
-  @normal @pending
+  @normal
   Scenario: Can log in
     Given the "EFG" application has booted
     When I try to login as a lender user

--- a/features/step_definitions/efg_steps.rb
+++ b/features/step_definitions/efg_steps.rb
@@ -4,7 +4,16 @@ end
 
 When /^I try to login as a lender user$/ do
   assert ENV["EFG_USERNAME"] && ENV["EFG_PASSWORD"], "Please ensure that the EFG user credentials are available in the environment"
-  @response = post_request "#{efg_base_url}/users/sign_in", :payload => "user[username]=#{ENV["EFG_USERNAME"]}&user[password]=#{ENV["EFG_PASSWORD"]}"
+
+  # Need to do it this way to comply with CSRF protection
+
+  # Not sure if there is a better way to do this?
+  page.driver.browser.agent.add_auth(efg_base_url, ENV['AUTH_USERNAME'], ENV['AUTH_PASSWORD'])
+
+  visit "#{efg_base_url}/users/sign_in"
+  fill_in "Username", :with => ENV["EFG_USERNAME"]
+  fill_in "Password", :with =>ENV["EFG_PASSWORD"]
+  click_button "Sign In"
 end
 
 When /^I visit the EFG home page$/ do


### PR DESCRIPTION
Skyscape fails correctly. Not sure why EC2 doesn't?

One minor annoyance with this change is that I don't like the explicit call to configure basic auth, but I couldn't see how else to get it to work.

Not sure what signon is doing differently?
