### PR TITLE
Add a basic test of the Content API

### DIFF
--- a/features/content_api.feature
+++ b/features/content_api.feature
@@ -1,0 +1,10 @@
+Feature: Content API
+
+@high
+Scenario: (Public) Content API availability
+  Given the "public-contentapi" application has booted
+  And I am testing through the full stack
+  And I force a varnish cache miss
+  When I visit "/api/tags.json"
+  Then I should get a 200 status code
+  And I should see "Business Link"

--- a/features/support/base_urls.rb
+++ b/features/support/base_urls.rb
@@ -17,6 +17,7 @@ def application_base_url(app_name)
   when 'licencefinder' then "https://licencefinder.#{platform}.alphagov.co.uk/licence-finder"
   when 'licensing' then "https://licensify.#{platform}.alphagov.co.uk/apply-for-a-licence"
   when 'panopticon' then "https://panopticon.#{platform}.alphagov.co.uk/"
+  when 'public-contentapi' then "https://www.#{platform}.alphagov.co.uk/api/tags.json" # this should be changed to a Content API 'homepage' when we have one
   when 'publisher' then "https://publisher.#{platform}.alphagov.co.uk/admin"
   when 'signon' then "https://signon.#{target_platform}.alphagov.co.uk/"
   when 'smartanswers' then "http://smartanswers.#{platform}.alphagov.co.uk/maternity-benefits"


### PR DESCRIPTION
This tests it via the public route (host), but that is an nginx proxy to the
real app anyway.
