### PR TITLE
Update find my nearest tests

### DIFF
--- a/features/frontend.feature
+++ b/features/frontend.feature
@@ -37,7 +37,7 @@ Feature: Frontend
 
   @normal
   Scenario: check find my nearest returns results
-    When I try to post to "/ukonline-centre-internet-access-computer-training.json" with "lat=51.51502281807959&lon=-0.12151737435844158"
+    When I try to post to "/ukonline-centre-internet-access-computer-training.json" with "postcode=WC2B+6NH"
     Then I should get a 200 status code
     And I should see "Holborn Library"
 


### PR DESCRIPTION
We no longer have /locator.json, and the post request sends a postcode as a parameter, not latitude and longitude.
