### PR TITLE
Send the Accept header with the Bearer token

### DIFF
--- a/features/support/http_requests.rb
+++ b/features/support/http_requests.rb
@@ -68,6 +68,7 @@ def do_http_request(url, method = :get, options = {}, &block)
   end
   if options[:client_auth]
     headers["Authorization"] = "Bearer #{ENV['BEARER_TOKEN']}"
+    headers["Accept"] = "application/json"
   end
 
   RestClient::Request.new(


### PR DESCRIPTION
GDS-SSO ignores the bearer token unless the format is JSON. Force this
with the Accept header.
