### PR TITLE
Make campaign page check less brittle by only checking HTTP status

### DIFF
--- a/features/frontend.feature
+++ b/features/frontend.feature
@@ -53,7 +53,6 @@ Feature: Frontend
   Scenario: check campaign pages load
     When I visit "/workplacepensions"
     Then I should get a 200 status code
-    And I should see "Automatic enrolment into a workplace pension"
 
   @normal
   Scenario: check browse page load, and links


### PR DESCRIPTION
Campaign pages are currently static views that we fully control and
are self-contained within the Frontend application.

To this end, checking that text exists in the page is a brittle check.
