### PR TITLE
[#58498312] Test for /robots.txt

### DIFF
--- a/features/frontend.feature
+++ b/features/frontend.feature
@@ -6,6 +6,12 @@ Feature: Frontend
     And I force a varnish cache miss
 
   @normal
+  Scenario: check robots.txt
+    When I visit "/robots.txt"
+    Then I should get a 200 status code
+    Then I should see "User-agent:"
+
+  @normal
   Scenario: check quick answers load
     When I visit "/vat-rates"
     Then I should see "VAT rates"


### PR DESCRIPTION
Since it's quite important to our site and we wouldn't want to break it
again. Technically this belongs to static, not frontend, but static doesn't
respond to `HEAD /` and there aren't any other fixed name assets.

https://github.gds/gds/puppet/pull/996
https://www.pivotaltracker.com/story/show/58498312

/cc @alext 
