### PR TITLE
Revert "Disable the scotlandoffice check"

### DIFF
--- a/features/redirector.feature
+++ b/features/redirector.feature
@@ -188,8 +188,6 @@ Smoke tests
     And I should get a location of "https://www.gov.uk/government/organisations/ministry-of-defence"
     And the elapsed time should be less than 2 seconds
 
-  #Test is broken, marking as pending
-  @pending
   @high
   Scenario: Redirect for scotlandoffice from www.scotlandoffice.gov.uk
     Given I am benchmarking


### PR DESCRIPTION
This reverts commit 6775da16dedd76e32ada156f86f36e2cb8d313d4.

DNS now appears to be pointing in the right place:

```
;; ANSWER SECTION:
www.scotlandoffice.gov.uk. 43115 IN     CNAME   redirector-cdn.production.govuk.service.gov.uk.
redirector-cdn.production.govuk.service.gov.uk. 215 IN CNAME www-gov-uk.map.fastly.net.
www-gov-uk.map.fastly.net. 26   IN      A       185.31.19.144
```

```
➜  smokey git:(master) ✗ curl -I http://www.scotlandoffice.gov.uk/
HTTP/1.1 301 Moved Permanently
Server: nginx
Content-Type: text/html
Location: https://www.gov.uk/government/organisations/scotland-office
```
