### PR TITLE
URLs for updated business support finder app

### DIFF
--- a/features/businesssupportfinder.feature
+++ b/features/businesssupportfinder.feature
@@ -8,12 +8,8 @@ Feature: Business Support Finder
     Then I should be able to visit:
       | Path                                                                                                                          |
       | /business-finance-support-finder                                                                                              |
-      | /business-finance-support-finder/sectors                                                                                      |
-      | /business-finance-support-finder/stage?sectors=education                                                                      |
-      | /business-finance-support-finder/size?sectors=education&stage=start-up                                                        |
-      | /business-finance-support-finder/types?sectors=education&stage=start-up&size=under-10                                         |
-      | /business-finance-support-finder/location?sectors=education&stage=start-up&size=under-10&types=finance                        |
-      | /business-finance-support-finder/support-options?location=wales&sectors=education&stage=start-up&size=under-10&types=finance  |
+      | /business-finance-support-finder/search                                                                                       |
+      | /business-finance-support-finder/search?support_types%5B%5D=finance&support_types%5B%5D=equity&support_types%5B%5D=grant&support_types%5B%5D=loan&support_types%5B%5D=expertise-and-advice&support_types%5B%5D=recognition-award&support_types_submitted=true&location=england&size=between-501-and-1000&sector=travel-and-leisure&stage=grow-and-sustain&commit=#filtered-results                          |
 
   @low
   Scenario: Quickly loading the business support finder home page


### PR DESCRIPTION
Business support finder has been rewritten. The old urls are now just
redirects. This updated version tests a real query from the new app.

More info at https://github.com/alphagov/business-support-finder/pull/41
and https://www.pivotaltracker.com/story/show/57312614

The updated app is already live at https://www.gov.uk/business-finance-support-finder (and also on preview)
