### PR TITLE
Remove backdrop negative test

### DIFF
--- a/features/backdrop.feature
+++ b/features/backdrop.feature
@@ -10,14 +10,6 @@ Feature: Backdrop
       | /performance/licensing/api/journey?group_by=foo      |
 
   @normal
-  Scenario: Raw queries are forbidden by default
-    Given I am testing "backdrop"
-      And I am testing through the full stack
-    Then I should get a 400 response when I try to visit:
-      | Path                                   |
-      | /performance/licensing/api/application |
-
-  @normal
   Scenario: Raw queries are allowed on some buckets
     Given I am testing "backdrop"
       And I am testing through the full stack


### PR DESCRIPTION
- We already have tests to check that the application is up and running
- This test pushes '400' errors to our logs
- These errors lead to red herrings

![](http://25.media.tumblr.com/6daa8841a594fe2f42e0f992ee36cf26/tumblr_mx01rzsGfN1r9qhhio1_500.jpg)
