### PR TITLE
Update the check for Panopticon

### DIFF
--- a/features/mainstream_publishing_tools.feature
+++ b/features/mainstream_publishing_tools.feature
@@ -19,7 +19,7 @@ Feature: Mainstream Publishing Tools
       And I go to the "panopticon" landing page
     Then I should see "GOV.UK Panopticon"
       And I should see "Signed in"
-      And I should see "Artefacts"
+      And I should see "artefacts"
 
   @high
   Scenario: Can log in to imminence


### PR DESCRIPTION
With the latest release of Panopticon, we no longer display a header with the title "Artefacts", but we do display it in lowercase next to the number of artefacts. This updates the check to stop it failing.
