### PR TITLE
Updating the smartanswers feature to keep smokey green

### DIFF
--- a/features/smartanswers.feature
+++ b/features/smartanswers.feature
@@ -9,11 +9,11 @@ Feature: Smart Answers
       | Path                                        |
       | /additional-commodity-code                  |
       | /become-a-driving-instructor                |
-      | /become-a-motorcycle-instructor             |
       | /calculate-employee-redundancy-pay          |
       | /calculate-married-couples-allowance        |
-      | /overseas-passports                         |
       | /calculate-your-maternity-pay               |
+      | /marriage-abroad                            |
+      | /overseas-passports                         |
       | /register-a-death                           |
 
     @normal


### PR DESCRIPTION
We're going to retire /become-a-motorcycle-instructor and redirect it to a simple smart-answer on Monday 3rd. Changing this test now so we don't break smokey.
