### PR TITLE
[#64241148] Define Cucumber tests for static mirrors

### DIFF
--- a/features/mirror.feature
+++ b/features/mirror.feature
@@ -1,0 +1,42 @@
+Feature: Mirror
+
+# These Cucumber tests run against the mirrors.
+# Despite the fact that Varnish doesn't run in static, we force cachebusts anyway in case we do run Varnish on static in future.
+
+  @high
+    Scenario: check for HTTP 200 response
+      Given I am testing through the full stack
+      And I force a varnish cache miss
+      When I visit "/"
+      Then I should get a 200 status code
+ 
+  @high
+    Scenario: check for correct homepage content
+      Given I am testing through the full stack
+      And I force a varnish cache miss
+      Then I should see the departments and policies section on the homepage
+      And I should see the services and information section on the homepage
+
+  @normal
+    Scenario: check for correct response from deep-linked page
+      Given I am testing through the full stack
+      And I force a varnish cache miss
+      When I visit "/council-tax-reduction"
+      Then I should get a 200 status code
+
+  @normal
+    Scenario: check search returns a 503
+    # Search is a separate application which will not be booted, therefore searches should return 503
+      Given I am testing through the full stack
+      And I force a varnish cache miss
+      When I search for "cheesecake"
+      Then I should get a 503 status code
+      And I should see "This page cannot be found"
+
+  @normal
+    Scenario: Return a 503 for 404s
+    # On static, we return 503s for 404s
+      Given I am testing through the full stack
+      And I force a varnish cache miss
+      When I visit "/jasdu3jjasd"
+      Then I should get a 503 status code

--- a/features/step_definitions/frontend_steps.rb
+++ b/features/step_definitions/frontend_steps.rb
@@ -1,0 +1,5 @@
+Then /^I should see the services and information section on the homepage$/ do
+  html = get_request "#{@host}/", cache_bust: @bypass_varnish
+  doc = Nokogiri::HTML(html)
+  assert doc.css('#services-and-information')
+end

--- a/features/step_definitions/whitehall_steps.rb
+++ b/features/step_definitions/whitehall_steps.rb
@@ -4,6 +4,12 @@ Then /^I should see the departments and policies section on the homepage$/ do
   assert doc.css('#departments-and-policy')
 end
 
+Then /^I should see the services and information section on the homepage$/ do
+  html = get_request "#{@host}/", cache_bust: @bypass_varnish
+  doc = Nokogiri::HTML(html)
+  assert doc.css('#services-and-information')
+end
+
 Then /^I should be able to view policies$/ do
   follow_link_to_first_policy_on_policies_page
 end


### PR DESCRIPTION
This PR:
- defines Cucumber tests for use with Smokey on the mirrors
- adds new step definition for `seeing services and information on homepage`

We don't cache using Varnish in static, but the feature file will force cachebusts. This allows the file to be somewhat futureproof in case we do start using Varnish to cache in future. Search is a separate application and will not boot when static is used, therefore ensure that we are returning 503s and `This page cannot be found` text appears on the page.
