### PR TITLE
Remove govuk_provider condition from jenkins.sh

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -3,11 +3,7 @@
 set -x
 
 if [ -z $MYTASK ]; then
-  if [ "$FACTER_govuk_provider" = "sky" ]; then
-    MYTASK="test:skyscapenetwork"
-  else
-    MYTASK="test:localnetwork"
-  fi
+  MYTASK="test:skyscapenetwork"
 fi
 
 # This removes rbenv shims from the PATH where there is no


### PR DESCRIPTION
The `govuk_provider` env variable has been removed recently, so this was falling back to `test:localnetwork`, and therefore not excluding tests that that were tagged to not be run against production.
