### PR TITLE
Explicit timeout for Smoke tests

### DIFF
--- a/features/support/http_requests.rb
+++ b/features/support/http_requests.rb
@@ -88,6 +88,7 @@ def do_http_request(url, method = :get, options = {}, &block)
     user: user,
     password: password,
     headers: headers,
+    timeout: 10,
     payload: options[:payload]
   ).execute &block
 rescue RestClient::Unauthorized => e


### PR DESCRIPTION
To work around the enormous timeouts experienced in eba7f2756716c26077f34f37c791a073ae279435, we should set an explicit timeout for requests.

In this case it's 10 seconds, which should be enough to return a response.

cc @samjsharpe 
