### PR TITLE
Boot the right application URL for EFG

### DIFF
--- a/features/support/base_urls.rb
+++ b/features/support/base_urls.rb
@@ -17,7 +17,7 @@ def application_base_url(app_name)
   when 'backdrop' then "https://www.#{app_domain}"
   when 'calendars' then "https://calendars.#{app_domain}/bank-holidays"
   when 'businesssupportfinder' then "https://businesssupportfinder.#{app_domain}/business-finance-support-finder"
-  when 'EFG' then "https://efg.#{app_domain}"
+  when 'EFG' then efg_base_url
   when 'frontend' then "https://frontend.#{app_domain}/"
   when 'private-frontend' then "https://private-frontend.#{app_domain}/"
   when 'imminence' then "https://imminence.#{app_domain}/"


### PR DESCRIPTION
When we try to boot EFG, we were asking for efg.app_domain. When you try that
in staging you are asking for efg.production.alphagov.co.uk which points to an
external address for production and fails.

By booting efg_base_url we are actually booting the right thing
(https://www.sflg.gov.uk) which has an internal alias and will work in 
Staging.

/cc @jabley
