### PR TITLE
Test presence of GA custom vars

### DIFF
--- a/features/frontend.feature
+++ b/features/frontend.feature
@@ -69,3 +69,8 @@ Feature: Frontend
     When I click "Teaching people to drive"
     Then I should get a 200 status code
     And I should see "Apply to become a driving instructor"
+
+  @high
+  Scenario: check google analytics custom vars added through slimmer are present
+    When I visit "/jobseekers-allowance"
+    Then google analytics custom vars set by slimmer exist

--- a/features/step_definitions/google_analytics_steps.rb
+++ b/features/step_definitions/google_analytics_steps.rb
@@ -1,0 +1,18 @@
+Then /^google analytics custom vars set by slimmer exist$/ do
+  gaq_matcher = %r{
+    _gaq.push
+      \(\[
+        "_setCustomVar",
+        \d+,              # index
+        "(Section|
+          NeedID|
+          Organisations|
+          WorldLocations|
+          Format|
+          ResultCount)",  # name
+        "[\w,<>|]+",      # value
+        \d+               # optional scope
+      \]\)
+  }x
+  @response.body.should =~ gaq_matcher
+end

--- a/features/whitehall.feature
+++ b/features/whitehall.feature
@@ -163,3 +163,9 @@ Feature: Whitehall
     And I am testing through the full stack
     When I visit "/government/uploads/system/uploads/attachment_data/file/32409/11-944-higher-education-students-at-heart-of-system.pdf"
     Then I should get a 200 status code
+
+  @normal
+  Scenario: Whitehall related google analytics custom vars added through slimmer are present
+    Given I am testing through the full stack
+    When I visit "/government/organisations/prime-ministers-office-10-downing-street"
+    Then google analytics custom vars set by slimmer exist


### PR DESCRIPTION
We had an incident where these variables went missing but it was not highlighted anywhere for a few days. The analytics team lost tracking data for those many days. Not good.

This should help us get early feedback.
