### PR TITLE
Add smokey tests for the mirrors

### DIFF
--- a/features/mirror.feature
+++ b/features/mirror.feature
@@ -1,47 +1,13 @@
 Feature: Mirror
 
-# These Cucumber tests run against the mirrors.
-# Despite the fact that Varnish doesn't run in static, we force cachebusts anyway in case we do run Varnish on static in future.
+    @medium
+    Scenario Outline: Test mirror response profile
+      Given there are 2 mirrors and 2 providers
+      Then I should get a <Status> response from "<Page>" on the mirrors
 
-  @pending
-  @high
-    Scenario: check for HTTP 200 response
-      Given I am testing through the full stack
-      And I force a varnish cache miss
-      When I visit "/"
-      Then I should get a 200 status code
-
-  @pending
-  @high
-    Scenario: check for correct homepage content
-      Given I am testing through the full stack
-      And I force a varnish cache miss
-      Then I should see the departments and policies section on the homepage
-      And I should see the services and information section on the homepage
-
-  @pending
-  @normal
-    Scenario: check for correct response from deep-linked page
-      Given I am testing through the full stack
-      And I force a varnish cache miss
-      When I visit "/council-tax-reduction"
-      Then I should get a 200 status code
-
-  @pending
-  @normal
-    Scenario: check search returns a 503
-    # Search is a separate application which will not be booted, therefore searches should return 503
-      Given I am testing through the full stack
-      And I force a varnish cache miss
-      When I search for "cheesecake"
-      Then I should get a 503 status code
-      And I should see "This page cannot be found"
-
-  @pending
-  @normal
-    Scenario: Return a 503 for 404s
-    # On static, we return 503s for 404s
-      Given I am testing through the full stack
-      And I force a varnish cache miss
-      When I visit "/jasdu3jjasd"
-      Then I should get a 503 status code
+      Examples:
+          | Page                   | Status |
+          | /                      | 200    |
+          | /council-tax-reduction | 200    |
+          | /jasdu3jjasd           | 503    |
+          | /search                | 503    |

--- a/features/step_definitions/mirror_steps.rb
+++ b/features/step_definitions/mirror_steps.rb
@@ -1,0 +1,17 @@
+Given /^there are (\d) mirrors and (\d) providers/ do |mirrors,providers|
+  @hosts = Array.new()
+  mirror_max = mirrors.to_i - 1
+  provider_max = providers.to_i - 1
+  for p in 0..provider_max do
+    for m in 0..mirror_max do
+      @hosts.push("https://mirror#{m}.mirror.provider#{p}.production.govuk.service.gov.uk")
+    end
+  end
+end
+
+Then /^I should get a (\d+) response from "(.*)" on the mirrors$/ do |status, page|
+  @hosts.each do |mirror_host|
+    response = try_get_request("#{mirror_host}#{page}", host_header: "www-origin.mirror.production.govuk.service.gov.uk")
+    response.code.should == status.to_i
+  end
+end


### PR DESCRIPTION
These steps will:
- Given a number of mirrors and providers
  - assume our default naming scheme
  - generate a list of mirror hostnames based on that scheme
- Check a list of pages on all those mirrors looking for a response code
