### PR TITLE
Update search feature to test unified search

### DIFF
--- a/features/search.feature
+++ b/features/search.feature
@@ -10,19 +10,38 @@ Feature: Search
       | /search         |
       | /search?q=tax   |
 
-  Scenario: check search results
+  # Scenarios for tabbed search
+  # TODO: remove these once unified search has been released
+  
+  Scenario: check search results on tabbed search
     Given I am testing through the full stack
     And the "frontend" application has booted
     And I force a varnish cache miss
-    When I search for "tax"
+    When I search for "tax" using tabbed search
     Then I should see some GOV.UK results
 
-  Scenario: check organisation filtering
+  Scenario: check organisation filtering on tabbed search
     Given I am testing through the full stack
     And the "frontend" application has booted
     And I force a varnish cache miss
-    When I search for "policy"
+    When I search for "policy" using tabbed search
     Then I should see organisations in the organisation filter
+
+  # Scenarios for unified search
+
+  Scenario: check search results on unified search
+    Given I am testing through the full stack
+    And the "frontend" application has booted
+    And I force a varnish cache miss
+    When I search for "tax" using unified search
+    Then I should see some GOV.UK results
+
+  Scenario: check organisation filtering on unified search
+    Given I am testing through the full stack
+    And the "frontend" application has booted
+    And I force a varnish cache miss
+    When I search for "policy" using unified search
+    Then I should see organisations in the unified organisation filter
 
   Scenario: check sitemap
     Given I am testing through the full stack

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -64,8 +64,12 @@ When /^I visit "(.*)" (\d+) times$/ do |path, count|
   }
 end
 
-When /^I search for "(.*)"$/ do |term|
-  @response = get_request("#{@host}/search?q=#{term}", default_request_options)
+When /^I search for "(.*)" using tabbed search$/ do |term|
+  @response = get_request("#{@host}/search?q=#{term}&ui=old", default_request_options)
+end
+
+When /^I search for "(.*)" using unified search$/ do |term|
+  @response = get_request("#{@host}/search?q=#{term}&ui=unified", default_request_options)
 end
 
 When /^I request "(.*)" from Bouncer directly$/ do |url|
@@ -140,6 +144,11 @@ end
 
 Then /^I should see organisations in the organisation filter$/ do
   organisation_options = Nokogiri::HTML.parse(@response.body).css("select[name=organisation] option")
+  organisation_options.count.should >= 10
+end
+
+Then /^I should see organisations in the unified organisation filter$/ do
+  organisation_options = Nokogiri::HTML.parse(@response.body).css("#organisations-filter input")
   organisation_options.count.should >= 10
 end
 


### PR DESCRIPTION
This expands the search feature to add new tests that specifically target unified search.

For the time being, we will keep the old tests so that we can continue to test both search variants until we are happy that unified search is live.
