### PR TITLE
Switch mirror from Scenario Outline to Scenarios

### DIFF
--- a/features/mirror.feature
+++ b/features/mirror.feature
@@ -1,13 +1,21 @@
 Feature: Mirror
 
     @high
-    Scenario Outline: Test mirror response profile
+    Scenario: Check homepage is served by all the mirrors
       Given there are 2 mirrors and 2 providers
-      Then I should get a <Status> response from "<Page>" on the mirrors
+      Then I should get a 200 response from "/" on the mirrors
 
-      Examples:
-          | Page                   | Status |
-          | /                      | 200    |
-          | /council-tax-reduction | 200    |
-          | /jasdu3jjasd           | 503    |
-          | /search                | 503    |
+    @high
+    Scenario: Check a deep-linked page is served by all the mirrors
+      Given there are 2 mirrors and 2 providers
+      Then I should get a 200 response from "/council-tax-reduction" on the mirrors
+
+    @high
+    Scenario: Check a non-existent page returns a service-unavailable error from all the mirrors
+      Given there are 2 mirrors and 2 providers
+      Then I should get a 503 response from "/jasdu3jjasd" on the mirrors
+
+    @high
+    Scenario: Check that search returns an error on all the mirrors
+      Given there are 2 mirrors and 2 providers
+      Then I should get a 503 response from "/search" on the mirrors


### PR DESCRIPTION
Hilariously the Scenario Outline approach worked perfectly for Smokey, but it
doesn't seem to be supported by either the json formatter for cucumber (which
only shows one test result in the outline), nor the nagios_check_cache.py
script.

By changing these checks back to 4 individual scenarios, I should be able to
re-enable smokey checks in Nagios/Icinga without rewriting the formatter or
the cache checker just for this one check.
