### PR TITLE
Test external link tracker

### DIFF
--- a/features/external_link_tracker.feature
+++ b/features/external_link_tracker.feature
@@ -1,0 +1,10 @@
+Feature: External Link Tracker
+
+Smoke tests
+
+  Scenario: External link tracker is redirecting a link from site search
+    Given I am testing through the full stack
+    When I try to visit "/g?url=http%3A%2F%2Fwww.cambridge.gov.uk"
+    Then I should get a 302 status code
+    And I should get a location header of "http://www.cambridge.gov.uk"
+    And I should get a cache control header of "no-cache, no-store, must-revalidate"

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -130,6 +130,10 @@ Then /^I should get a location header of "(.*)"$/ do |location|
   @response.headers[:location].should == location
 end
 
+Then /^I should get a cache control header of "(.*)"$/ do |cache_control|
+  @response.headers[:cache_control].should == cache_control
+end
+
 Then /I should get a content length of "(\d+)"/ do |length|
   @response.net_http_res['content-length'].should == length
 end


### PR DESCRIPTION
Add a test that the external link tracker is correctly redirecting a
link that exists in the search index.

Note that this should be a fairly stable test against modifications to
the set of external links held in search being modified, because even
when we remove an external link from search we don't remove it from the
external link tracker.
