### PR TITLE
Make service manual search assertion stronger

### DIFF
--- a/features/design_principles.feature
+++ b/features/design_principles.feature
@@ -27,7 +27,7 @@ Feature: Design Principles
     When I visit "/service-manual/search?q=alpha"
     Then I should get a 200 status code
     And I should see "alpha"
-    And I should see some GOV.UK results
+    And I should see some search results
 
   @normal
   Scenario: check Transformation dashboard

--- a/features/search.feature
+++ b/features/search.feature
@@ -15,7 +15,7 @@ Feature: Search
     And the "frontend" application has booted
     And I force a varnish cache miss
     When I search for "tax" using unified search
-    Then I should see some GOV.UK results
+    Then I should see some search results
 
   Scenario: check organisation filtering on unified search
     Given I am testing through the full stack

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -156,7 +156,7 @@ When /^I try to post to "(.*)" with "(.*)"$/ do |path, payload|
   @response = post_request "#{@host}#{path}", :payload => "#{payload}"
 end
 
-Then /^I should see some GOV.UK results$/ do
+Then /^I should see some search results$/ do
   result_links = Nokogiri::HTML.parse(@response.body).css("ul.results-list li a")
   result_links.count.should >= 1
 end


### PR DESCRIPTION
I would expect to see the search text echoed back to me anyway, even if there
were no results.

I would expect to find some results for ‘alpha’ in the service manual.
