### PR TITLE
Updating mainstream_publishing_tools feature

### DIFF
--- a/features/mainstream_publishing_tools.feature
+++ b/features/mainstream_publishing_tools.feature
@@ -39,5 +39,5 @@ Feature: Mainstream Publishing Tools
     And I try to login as a user
     And I go to the "travel-advice-publisher" landing page
     Then I should see "GOV.UK Travel Advice Publisher"
-    And I should see "Signed in"
+    And I should see "Sign out"
     And I should see "Services"


### PR DESCRIPTION
This travel advice publisher update broke smokey - https://github.com/alphagov/travel-advice-publisher/commit/538dd5ff63c151241091bd79fc598e526b1e0f35.
