### PR TITLE
Updating the trade tariff smoke tests to pass on staging

### DIFF
--- a/features/tariff.feature
+++ b/features/tariff.feature
@@ -31,7 +31,7 @@ Feature: Trade Tariff
       And I am testing through the full stack
       And I force a varnish cache miss
     Then I should be able to visit and see:
-      | Path                            | See                          |
-      | /trade-tariff/search?t=horse    | Headings containing horse    |
-      | /trade-tariff/search?t=bovine   | Headings containing bovine   |
-      | /trade-tariff/search?t=leggings | Headings containing leggings |
+      | Path                             | See                           |
+      | /trade-tariff/search?t=animal    | Sections containing animal    |
+      | /trade-tariff/search?t=mineral   | Sections containing mineral   |
+      | /trade-tariff/search?t=vegetable | Sections containing vegetable |


### PR DESCRIPTION
Trade Tariff tests consistently fail on staging using some search terms as no results are returned. I'm tired of them failing so changing the terms will/should fix it. All these terms (old and new) work on Production.
