### PR TITLE
Update contacts check to include a leaf page.

### DIFF
--- a/features/contacts.feature
+++ b/features/contacts.feature
@@ -3,8 +3,8 @@ Feature: Contacts
   @normal
   Scenario: check contacts app can be reached
     Given I am testing through the full stack
-    And the "contacts" application has booted
     And I force a varnish cache miss
     Then I should be able to visit:
-      | Path                        |
-      | /contact/hm-revenue-customs |
+      | Path                                      |
+      | /contact/hm-revenue-customs               |
+      | /contact/hm-revenue-customs/child-benefit |


### PR DESCRIPTION
These leaf pages will be served by a separate application to the index
pages for a while, so it's good to have a check for both.

Removing the "Given the application has booted" line because that's
redundant since we moved away from passenger.
