### PR TITLE
Update check for mainstream publisher sign in

### DIFF
--- a/features/mainstream_publishing_tools.feature
+++ b/features/mainstream_publishing_tools.feature
@@ -7,7 +7,7 @@ Feature: Mainstream Publishing Tools
       And I try to login as a user
       And I go to the "publisher" landing page
     Then I should see "GOV.UK Publisher"
-      And I should see "Signed in"
+      And I should see "Sign out"
       And I should see Publisher's publication index
 
   @high


### PR DESCRIPTION
- "Signed in" is now "Sign out"
- This PR breaks the existing test:
  https://github.com/alphagov/publisher/pull/210
