### PR TITLE
Remove 'Given the "foo" application has booted' steps

### DIFF
--- a/features/browse.feature
+++ b/features/browse.feature
@@ -3,7 +3,6 @@ Feature: Browse
   @high
   Scenario: check browse pages load
     Given I am testing through the full stack
-    And the "frontend" application has booted
     And I force a varnish cache miss
     Then I should be able to visit:
       | Path            |

--- a/features/businesssupportfinder.feature
+++ b/features/businesssupportfinder.feature
@@ -2,8 +2,7 @@ Feature: Business Support Finder
 
   @normal
   Scenario: check business support finder loads
-    Given the "businesssupportfinder" application has booted
-    And I am testing through the full stack
+    Given I am testing through the full stack
     And I force a varnish cache miss
     Then I should be able to visit:
       | Path                                                                                                                          |
@@ -13,8 +12,7 @@ Feature: Business Support Finder
 
   @low
   Scenario: Quickly loading the business support finder home page
-    Given the "businesssupportfinder" application has booted
-    And I am benchmarking
+    Given I am benchmarking
     And I am testing through the full stack
     When I visit "/business-finance-support-finder"
     Then the elapsed time should be less than 1 seconds

--- a/features/calendars.feature
+++ b/features/calendars.feature
@@ -2,8 +2,7 @@ Feature: Calendars
 
   @normal
   Scenario: check calendars loads
-    Given the "calendars" application has booted
-    And I am testing through the full stack
+    Given I am testing through the full stack
     And I force a varnish cache miss
     Then I should be able to visit:
       | Path                       |
@@ -12,8 +11,7 @@ Feature: Calendars
 
   @normal
   Scenario: check alternative formats are available
-    Given the "calendars" application has booted
-    And I am testing through the full stack
+    Given I am testing through the full stack
     Then I should be able to visit:
       | Path                            |
       | /when-do-the-clocks-change/united-kingdom.json |
@@ -21,6 +19,5 @@ Feature: Calendars
 
   @normal
   Scenario: check bank holidays JSON format is consistent
-    Given the "calendars" application has booted
-    And I am testing through the full stack
+    Given I am testing through the full stack
     Then I should see a consistent JSON format for the path "/bank-holidays.json"

--- a/features/content_api.feature
+++ b/features/content_api.feature
@@ -2,8 +2,7 @@ Feature: Content API
 
 @high
 Scenario: (Public) Content API availability
-  Given the "public-contentapi" application has booted
-  And I am testing through the full stack
+  Given I am testing through the full stack
   And I force a varnish cache miss
   When I visit "/api/tags.json"
   Then I should get a 200 status code

--- a/features/efg.feature
+++ b/features/efg.feature
@@ -6,22 +6,19 @@ Feature: EFG
   @notskyscapepreview
   @normal
   Scenario: Requires authenticated user to view lenders
-    Given the "EFG" application has booted
     When I try to access the list of lenders
     Then I should be on the EFG home page
 
   @notskyscapepreview
   @normal
   Scenario: Quickly loading the EFG home page
-    Given the "EFG" application has booted
-      And I am benchmarking
+    Given I am benchmarking
     When I visit the EFG home page
     Then the elapsed time should be less than 1 seconds
 
   @notskyscapepreview
   @normal
   Scenario: Can log in
-    Given the "EFG" application has booted
     When I try to login as a valid EFG user
     Then I should be on the EFG post-login page
 

--- a/features/fact_cave.feature
+++ b/features/fact_cave.feature
@@ -3,7 +3,6 @@ Feature: Fact Cave
   @local-network
   @normal
   Scenario: Internal Fact Cave availability
-    Given the "fact-cave" application has booted
     When I visit "/facts/vat-rate.json" on the "fact-cave" application
     Then I should get a 200 status code
     And I should see "description"
@@ -11,8 +10,7 @@ Feature: Fact Cave
 
   @normal
   Scenario: Public Fact Cave availability
-    Given the "fact-cave" application has booted
-    And I am testing through the full stack
+    Given I am testing through the full stack
     And I force a varnish cache miss
     When I visit "/api/facts/vat-rate.json"
     Then I should get a 200 status code

--- a/features/frontend.feature
+++ b/features/frontend.feature
@@ -1,8 +1,7 @@
 Feature: Frontend
 
   Background:
-    Given the "frontend" application has booted
-    And I am testing through the full stack
+    Given I am testing through the full stack
     And I force a varnish cache miss
 
   @normal

--- a/features/licencefinder.feature
+++ b/features/licencefinder.feature
@@ -2,8 +2,7 @@ Feature: Licence Finder
 
   @normal
   Scenario: check licence finder loads
-    Given the "licencefinder" application has booted
-    And I am testing through the full stack
+    Given I am testing through the full stack
     And I force a varnish cache miss
     Then I should be able to visit:
       | Path                                                              |
@@ -16,16 +15,14 @@ Feature: Licence Finder
 
   @normal
   Scenario: check licence finder returns licences
-    Given the "licencefinder" application has booted
-    And I am testing through the full stack
+    Given I am testing through the full stack
     And I force a varnish cache miss
     When I visit "/licence-finder/licences?activities=149&location=wales&sectors=59"
     Then I should see "A premises licence is for carrying out 'licensable activities' at a particular venue"
 
   @low
   Scenario: Quickly loading the licence finder home page
-    Given the "licencefinder" application has booted
-    And I am benchmarking
+    Given I am benchmarking
     And I am testing through the full stack
     When I visit "/licence-finder"
     Then the elapsed time should be less than 1 seconds

--- a/features/mainstream_publishing_tools.feature
+++ b/features/mainstream_publishing_tools.feature
@@ -1,8 +1,6 @@
 Feature: Mainstream Publishing Tools
   @high
   Scenario: Can log in to publisher
-    Given the "signon" application has booted
-      And the "publisher" application has booted
     When I go to the "publisher" landing page
       And I try to login as a user
       And I go to the "publisher" landing page
@@ -12,8 +10,6 @@ Feature: Mainstream Publishing Tools
 
   @high
   Scenario: Can log in to panopticon
-    Given the "signon" application has booted
-      And the "panopticon" application has booted
     When I go to the "panopticon" landing page
       And I try to login as a user
       And I go to the "panopticon" landing page
@@ -23,8 +19,6 @@ Feature: Mainstream Publishing Tools
 
   @high
   Scenario: Can log in to imminence
-    Given the "signon" application has booted
-      And the "imminence" application has booted
     When I go to the "imminence" landing page
       And I try to login as a user
       And I go to the "imminence" landing page
@@ -33,8 +27,6 @@ Feature: Mainstream Publishing Tools
       And I should see "Services"
 
   Scenario: Can log in to travel-advice-publisher
-    Given the "signon" application has booted
-    And the "travel-advice-publisher" application has booted
     When I go to the "travel-advice-publisher" landing page
     And I try to login as a user
     And I go to the "travel-advice-publisher" landing page

--- a/features/mirror.feature
+++ b/features/mirror.feature
@@ -1,3 +1,4 @@
+@local-network
 Feature: Mirror
 
     @high

--- a/features/private_frontend.feature
+++ b/features/private_frontend.feature
@@ -1,8 +1,7 @@
 Feature: Private Frontend
 
   Background:
-    Given the "private-frontend" application has booted
-    And I am testing "private-frontend"
+    Given I am testing "private-frontend"
     And I am not an authenticated user
 
   @normal

--- a/features/router.feature
+++ b/features/router.feature
@@ -2,8 +2,7 @@ Feature: Router
 
   @high
   Scenario: check router loads homepage
-    Given the "frontend" application has booted
-    And I am testing through the full stack
+    Given I am testing through the full stack
     And I force a varnish cache miss
     Then I should be able to visit:
       | Path      |

--- a/features/search.feature
+++ b/features/search.feature
@@ -3,7 +3,6 @@ Feature: Search
   @high
   Scenario: check search loads
     Given I am testing through the full stack
-    And the "frontend" application has booted
     And I force a varnish cache miss
     Then I should be able to visit:
       | Path            |
@@ -12,14 +11,12 @@ Feature: Search
 
   Scenario: check search results on unified search
     Given I am testing through the full stack
-    And the "frontend" application has booted
     And I force a varnish cache miss
     When I search for "tax" using unified search
     Then I should see some GOV.UK results
 
   Scenario: check organisation filtering on unified search
     Given I am testing through the full stack
-    And the "frontend" application has booted
     And I force a varnish cache miss
     When I search for "policy" using unified search
     Then I should see organisations in the unified organisation filter

--- a/features/signon.feature
+++ b/features/signon.feature
@@ -1,7 +1,6 @@
 Feature: Sign-on-o-tron
   @high
   Scenario: Can log in
-    Given the "signon" application has booted
     When I try to login as a user
     Then I should see "Welcome to GOV.UK"
 

--- a/features/smartanswers.feature
+++ b/features/smartanswers.feature
@@ -2,8 +2,7 @@ Feature: Smart Answers
 
   @normal
   Scenario: check smart answers load
-    Given the "smartanswers" application has booted
-    And I am testing through the full stack
+    Given I am testing through the full stack
     And I force a varnish cache miss
     Then I should be able to visit:
       | Path                                        |
@@ -18,8 +17,7 @@ Feature: Smart Answers
 
     @normal
     Scenario: step through a smart answer
-      Given the "smartanswers" application has booted
-      And I am testing through the full stack
+      Given I am testing through the full stack
       And I force a varnish cache miss
       Then I should be able to visit:
       | Path                                              |

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -1,8 +1,3 @@
-Given /^the "(.*)" application has booted$/ do |app_name|
-  url = application_base_url(app_name)
-  head_request(url)
-end
-
 Given /^I am testing "(.*)"/ do |host|
   if host.include? "://"
     @host = host

--- a/features/tariff.feature
+++ b/features/tariff.feature
@@ -2,9 +2,7 @@ Feature: Trade Tariff
 
   @normal
   Scenario: Visiting trade tariff
-    Given the "tariff-backend" application has booted
-      And the "tariff-frontend" application has booted
-      And I am testing through the full stack
+    Given I am testing through the full stack
       And I force a varnish cache miss
     Then I should be able to visit:
       | Path                                  |
@@ -16,9 +14,7 @@ Feature: Trade Tariff
 
   @normal
   Scenario: Displaying Grouped headings
-    Given the "tariff-backend" application has booted
-      And the "tariff-frontend" application has booted
-      And I am testing through the full stack
+    Given I am testing through the full stack
       And I force a varnish cache miss
     When I visit "/trade-tariff/headings/6309"
     # Grouped commodity code should be displayed
@@ -26,9 +22,7 @@ Feature: Trade Tariff
 
   @normal
   Scenario: Searching trade tariff
-    Given the "tariff-backend" application has booted
-      And the "tariff-frontend" application has booted
-      And I am testing through the full stack
+    Given I am testing through the full stack
       And I force a varnish cache miss
     Then I should be able to visit and see:
       | Path                             | See                           |

--- a/features/transition.feature
+++ b/features/transition.feature
@@ -2,8 +2,6 @@ Feature: Transition management tools
 
   @high
   Scenario: Can log in to transition app
-    Given the "signon" application has booted
-      And the "transition" application has booted
     When I go to the "transition" landing page
       And I try to login as a user
       And I go to the "transition" landing page
@@ -12,7 +10,6 @@ Feature: Transition management tools
 
   @high
   Scenario: Can get the host list from API to configure CDN
-    Given the "transition" application has booted
     When I visit "/hosts.json" on the "transition" application
     Then I should get a 200 status code
      And I should see "www.direct.gov.uk"

--- a/features/travel_advice.feature
+++ b/features/travel_advice.feature
@@ -1,8 +1,7 @@
 Feature: Travel Advice
 
   Background:
-    Given the "frontend" application has booted
-    And I am testing through the full stack
+    Given I am testing through the full stack
     And I force a varnish cache miss
 
   @normal

--- a/features/whitehall.feature
+++ b/features/whitehall.feature
@@ -4,15 +4,13 @@ Feature: Whitehall
 
   @normal
   Scenario: Government publishing section on GOV.UK homepage
-    Given the "frontend" application has booted
-    And I am testing through the full stack
+    Given I am testing through the full stack
     And I force a varnish cache miss
     Then I should see the departments and policies section on the homepage
 
   @notpreview
   Scenario: There should be no authentication for Whitehall
-    Given the "whitehall" application has booted
-    And I am testing through the full stack
+    Given I am testing through the full stack
     And I force a varnish cache miss
     And I am not an authenticated user
     Then I should be able to view policies
@@ -28,16 +26,14 @@ Feature: Whitehall
 
   @normal
   Scenario: Searching for an existing consultation on whitehall via elastic search
-    Given the "whitehall" application has booted
-    And I am testing through the full stack
+    Given I am testing through the full stack
     And I force a varnish cache miss
     When I do a whitehall search for "Assessing radioactive waste disposal sites"
     Then I should see "Assessing radioactive waste disposal sites"
 
   @notnagios
   Scenario: Feeds should be available for documents
-    Given the "whitehall" application has booted
-    And I am testing through the full stack
+    Given I am testing through the full stack
     And I force a varnish cache miss
     Then I should be able to visit:
       | Path                           |
@@ -46,8 +42,7 @@ Feature: Whitehall
 
   @normal
   Scenario: Visiting whitehall
-    Given the "whitehall" application has booted
-    And I am testing through the full stack
+    Given I am testing through the full stack
     And I force a varnish cache miss
     Then I should be able to view policies
     And I should be able to view announcements
@@ -103,8 +98,7 @@ Feature: Whitehall
   @local-network
   @high
   Scenario: Whitehall frontend can connect to the database
-    Given the "whitehall" application has booted
-    And I am testing through the full stack
+    Given I am testing through the full stack
     And I force a varnish cache miss
     When I visit "/healthcheck" on the "whitehall-frontend" application
     Then I should get a 200 status code
@@ -112,8 +106,7 @@ Feature: Whitehall
   @local-network
   @normal
   Scenario: Whitehall admin can connect to the database
-    Given the "whitehall" application has booted
-    And I am testing through the full stack
+    Given I am testing through the full stack
     And I force a varnish cache miss
     When I visit "/healthcheck" on the "whitehall-admin" application
     Then I should get a 200 status code
@@ -121,8 +114,7 @@ Feature: Whitehall
   @local-network
   @normal
   Scenario: Whitehall frontend database should be fast
-    Given the "whitehall" application has booted
-    And I am benchmarking
+    Given I am benchmarking
     And I am testing through the full stack
     And I force a varnish cache miss
     When I visit "/healthcheck" on the "whitehall-frontend" application
@@ -131,8 +123,7 @@ Feature: Whitehall
   @local-network
   @low
   Scenario: Whitehall frontend website should be fast
-    Given the "whitehall" application has booted
-    And I am benchmarking
+    Given I am benchmarking
     And I am testing through the full stack
     And I force a varnish cache miss
     When I visit "/government/how-government-works" on the "whitehall-frontend" application
@@ -141,8 +132,7 @@ Feature: Whitehall
   @local-network
   @low
   Scenario: Whitehall admin database should be fast
-    Given the "whitehall" application has booted
-    And I am benchmarking
+    Given I am benchmarking
     And I am testing through the full stack
     And I force a varnish cache miss
     When I visit "/healthcheck" on the "whitehall-admin" application
@@ -150,8 +140,7 @@ Feature: Whitehall
 
   @normal
   Scenario: Whitehall offers a world location API
-    Given the "whitehall" application has booted
-    And I am benchmarking
+    Given I am benchmarking
     And I am testing through the full stack
     And I force a varnish cache miss
     When I visit "/api/world-locations" on the "whitehall-admin" application
@@ -159,7 +148,6 @@ Feature: Whitehall
 
   @normal
   Scenario: Whitehall assets are served
-    Given the "whitehall" application has booted
-    And I am testing through the full stack
+    Given I am testing through the full stack
     When I visit "/government/uploads/system/uploads/attachment_data/file/32409/11-944-higher-education-students-at-heart-of-system.pdf"
     Then I should get a 200 status code


### PR DESCRIPTION
These are a holdover from when we were running on passenger, and the
application workers were started on demand.  Now that we're using
Unicorn everywhere, the workers are running all the time.

This used to just send a HEAD request to the base URL for the app which
would cause passenger to spin up a worker if one wasn't already running.
