### PR TITLE
Remove healthcheck-based tests from Whitehall

### DIFF
--- a/features/whitehall.feature
+++ b/features/whitehall.feature
@@ -96,31 +96,6 @@ Feature: Whitehall
       | /wales-office             |
 
   @local-network
-  @high
-  Scenario: Whitehall frontend can connect to the database
-    Given I am testing through the full stack
-    And I force a varnish cache miss
-    When I visit "/healthcheck" on the "whitehall-frontend" application
-    Then I should get a 200 status code
-
-  @local-network
-  @normal
-  Scenario: Whitehall admin can connect to the database
-    Given I am testing through the full stack
-    And I force a varnish cache miss
-    When I visit "/healthcheck" on the "whitehall-admin" application
-    Then I should get a 200 status code
-
-  @local-network
-  @normal
-  Scenario: Whitehall frontend database should be fast
-    Given I am benchmarking
-    And I am testing through the full stack
-    And I force a varnish cache miss
-    When I visit "/healthcheck" on the "whitehall-frontend" application
-    Then the elapsed time should be less than 1 second
-
-  @local-network
   @low
   Scenario: Whitehall frontend website should be fast
     Given I am benchmarking
@@ -128,15 +103,6 @@ Feature: Whitehall
     And I force a varnish cache miss
     When I visit "/government/how-government-works" on the "whitehall-frontend" application
     Then the elapsed time should be less than 2 seconds
-
-  @local-network
-  @low
-  Scenario: Whitehall admin database should be fast
-    Given I am benchmarking
-    And I am testing through the full stack
-    And I force a varnish cache miss
-    When I visit "/healthcheck" on the "whitehall-admin" application
-    Then the elapsed time should be less than 1 second
 
   @normal
   Scenario: Whitehall offers a world location API


### PR DESCRIPTION
Since the healthcheck is no longer available through nginx, we have
Nagios checks in place to monitor the healthcheck, and we have plenty of
checks that request paths within the app anyway, there's no need to keep
these.
