### PR TITLE
Updating smart-answers feature

### DIFF
--- a/features/smartanswers.feature
+++ b/features/smartanswers.feature
@@ -7,6 +7,7 @@ Feature: Smart Answers
     Then I should be able to visit:
       | Path                                        |
       | /additional-commodity-code                  |
+      | /apply-tier-4-visa                          |
       | /calculate-employee-redundancy-pay          |
       | /calculate-married-couples-allowance        |
       | /calculate-your-maternity-pay               |


### PR DESCRIPTION
/become-a-driving-instructor is being changed to a simple-smart-answer so it needs to be replaced here.
