### PR TITLE
Fix the smoke test for the new browse design

### DIFF
--- a/features/frontend.feature
+++ b/features/frontend.feature
@@ -63,8 +63,7 @@ Feature: Frontend
   Scenario: check browse page load, and links
     When I visit "/browse/driving"
     Then I should get a 200 status code
-    And I should see "Book your driving test or get a tax disc online"
     And I should see "Teaching people to drive"
-    When I click "Teaching people to drive"
+    When I click on the section "Teaching people to drive"
     Then I should get a 200 status code
     And I should see "Apply to become a driving instructor"

--- a/features/step_definitions/frontend_steps.rb
+++ b/features/step_definitions/frontend_steps.rb
@@ -1,3 +1,9 @@
+When /^I click on the section "(.*?)"$/ do |section_name|
+  link_href = Nokogiri::HTML.parse(@response.body).at_xpath("//h3[text()='#{section_name}']/../@href")
+  link_href.should_not == nil
+  step "I visit \"#{link_href.value}\""
+end
+
 Then /^I should see the services and information section on the homepage$/ do
   html = get_request "#{@host}/", cache_bust: @bypass_varnish
   doc = Nokogiri::HTML(html)


### PR DESCRIPTION
The new browse design includes the heading and description text inside the anchor tag, so the existing method doesn't find the section link.

I've fixed this by defining a custom method to click on a section, which looks first for the `<h3>`, and then fetches the href from its parent.
