### PR TITLE
Add checks for the load-balanced mirrors

### DIFF
--- a/features/mirror.feature
+++ b/features/mirror.feature
@@ -2,6 +2,16 @@
 Feature: Mirror
 
     @high
+    Scenario: Check homepage is served by the load-balanced mirrors
+      Given there are 2 mirror providers
+      Then I should get a 200 response from "/" on the mirrors
+
+    @high
+    Scenario: Check that search returns an error on the load-balanced mirrors
+      Given there are 2 mirror providers
+      Then I should get a 503 response from "/search" on the mirrors
+
+    @high
     Scenario: Check homepage is served by all the mirrors
       Given there are 2 mirrors and 2 providers
       Then I should get a 200 response from "/" on the mirrors

--- a/features/step_definitions/mirror_steps.rb
+++ b/features/step_definitions/mirror_steps.rb
@@ -1,3 +1,11 @@
+Given /^there are (\d) mirror providers/ do |providers|
+  @hosts = Array.new()
+  provider_max = providers.to_i - 1
+  for p in 0..provider_max do
+    @hosts.push("https://www-origin.mirror.provider#{p}.production.govuk.service.gov.uk")
+  end
+end
+
 Given /^there are (\d) mirrors and (\d) providers/ do |mirrors,providers|
   @hosts = Array.new()
   mirror_max = mirrors.to_i - 1


### PR DESCRIPTION
We have checks for each of the mirrors for each provider, but we had no checks that ensured the load balancer (vShield Edge) before the mirrors was functioning.

These checks are the result of a load balancer failing to pass traffic to either of its mirrors.

This load balancer failure has been temporarily circumvented by modifying DNS so that `www-origin.mirror.provider1.production.govuk.service.gov.uk` resolves to `mirror0.mirror.provider1.production.govuk.service.gov.uk`.
