### PR TITLE
[#50426159] Replace XFF/TCI with Rate-Limit-Token

### DIFF
--- a/features/support/http_requests.rb
+++ b/features/support/http_requests.rb
@@ -60,12 +60,9 @@ def do_http_request(url, method = :get, options = {}, &block)
   }
   options = defaults.merge(options)
 
-  ip_last_octet = rand(256)
   headers = {
     'User-Agent' => 'Smokey Test / Ruby',
     'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-    'X-Forwarded-For' => "10.0.0.#{ip_last_octet}",
-    'True-Client-Ip' => "10.0.0.#{ip_last_octet}",
   }
 
   started_at = Time.now
@@ -80,6 +77,10 @@ def do_http_request(url, method = :get, options = {}, &block)
   end
   if options[:host_header]
     headers["Host"] = options[:host_header]
+  end
+  rate_limit_token = ENV['RATE_LIMIT_TOKEN']
+  if rate_limit_token
+    headers["Rate-Limit-Token"] = rate_limit_token
   end
 
   RestClient::Request.new(


### PR DESCRIPTION
Replace the X-Forwarded-For and True-Client-IP headers, which are used to
workaround rate limiting, with a Rate-Limit-Token header.

This optional token is passed in from a RATE_LIMIT_TOKEN environment
variable and will be unique to this application/environment. It will allow
us to:
- preserve the correct IP in our logs
- point Smokey at the CDN instead of origin

I've added this to the following Jenkins jobs:
- Preview_Smokey
- Staging_Smokey
- Production_Smokey

And it's added to the Icinga checks in:
- https://github.gds/gds/puppet/commit/a47d8bc4c364407c8673001039dab9ab3fe05066
- https://github.gds/gds/deployment/commit/30f5ce5f86478faae2a1a87bebfa613bb36203c2
