### PR TITLE
Fix step definition for search results

### DIFF
--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -152,7 +152,7 @@ When /^I try to post to "(.*)" with "(.*)"$/ do |path, payload|
 end
 
 Then /^I should see some search results$/ do
-  result_links = Nokogiri::HTML.parse(@response.body).css("ol.results-list li a")
+  result_links = Nokogiri::HTML.parse(@response.body).css(".results-list li a")
   result_links.count.should >= 1
 end
 


### PR DESCRIPTION
The container for search results changed from a `ul` to an `ol` in alphagov/frontend#661. 

This updates the step definition for the search feature so that the search results list can continue to be found.
