### PR TITLE
Fix smokey test for Panopticon

### DIFF
--- a/features/mainstream_publishing_tools.feature
+++ b/features/mainstream_publishing_tools.feature
@@ -14,7 +14,7 @@ Feature: Mainstream Publishing Tools
       And I try to login as a user
       And I go to the "panopticon" landing page
     Then I should see "GOV.UK Panopticon"
-      And I should see "Signed in"
+      And I should see "Sign out"
       And I should see "artefacts"
 
   @high


### PR DESCRIPTION
The change to make Panopticon use govuk_admin_template means that the words "Signed in" no longer appear on the page. Changing this to "sign out", as per the Publisher cuke above.
