### PR TITLE
Remove check for /transport FURL

### DIFF
--- a/features/whitehall.feature
+++ b/features/whitehall.feature
@@ -91,7 +91,6 @@ Feature: Whitehall
       | /pins                     |
       | /planning-inspectorate    |
       | /scotland-office          |
-      | /transport                |
       | /treasury                 |
       | /wales-office             |
 


### PR DESCRIPTION
We're soon going to be changing `/transport` to become a topic page, rather than a friendly URL (FURL). Therefore, we should stop checking the URL as part of the Whitehall feature.

The main FURL for the Department for Transport is `/dft`, and we're already checking that as part of this test.
