### PR TITLE
Remove Backdrop raw queries test

### DIFF
--- a/features/backdrop.feature
+++ b/features/backdrop.feature
@@ -8,11 +8,3 @@ Feature: Backdrop
       | Path                                                 |
       | /performance/licensing/api/application?group_by=foo  |
       | /performance/licensing/api/journey?group_by=foo      |
-
-  @normal
-  Scenario: Raw queries are allowed on some buckets
-    Given I am testing "backdrop"
-      And I am testing through the full stack
-    Then I should get a 200 response when I try to visit:
-      | Path                               |
-      | /performance/licensing/api/journey |


### PR DESCRIPTION
Given that Smokey times out when running this test
And I need to make sure Smokey tests run successfully
And there is no need to run this test because @robyoung says there are plenty of functional tests for this feature
Then we should remove this test as it is only intermittently successful
