### PR TITLE
Remove trailing slash from Limelight check

### DIFF
--- a/features/limelight.feature
+++ b/features/limelight.feature
@@ -7,7 +7,7 @@ Feature: Limelight
         And I force a varnish cache miss
       Then I should be able to visit:
         | Path                                        |
-        | /performance/licensing/                     |
+        | /performance/licensing                      |
         | /performance/licensing/licences             |
         | /performance/licensing/licences/childminder |
         | /performance/licensing/authorities          |


### PR DESCRIPTION
We don't use trailing slashes on GOV.UK.
