### PR TITLE
Fix publisher tests.

### DIFF
--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -167,6 +167,5 @@ Then /^I should see organisations in the unified organisation filter$/ do
 end
 
 Then /^I should see Publisher's publication index$/ do
-  page.should have_content("publications")
   page.should have_selector("#publication-list-container")
 end


### PR DESCRIPTION
The title was changed in https://github.com/alphagov/publisher/pull/294,
resulting in this test failing.  This removes the check for specific
words in the title, and leaves it checking for the publications list
itself using the HTML id.
