### PR TITLE
Bump the performance budget for dashboards

### DIFF
--- a/features/performance_platform.feature
+++ b/features/performance_platform.feature
@@ -18,4 +18,4 @@ Feature: Performance Platform
     When I visit "/performance/carers-allowance"
     Then I should get a 200 status code
     And I should see "Carer's Allowance"
-    And the elapsed time should be less than 2 seconds
+    And the elapsed time should be less than 3 seconds


### PR DESCRIPTION
This is rubbish. But we’re not investing in making this fast at the
moment. To make smokey still useful to us, and avoid unnecessary noise
to 2nd line, we’ll increase the budget for this page.

The CDN will be caching these still.
