### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,67 @@
-Smoke tests that verify the applications that run GOV.UK are working as expected.
+# GOV.UK Smoke Tests
 
-## Running the tests
+Automated tests that describe high level user journeys which touch multiple
+applications within the GOV.UK stack.
 
-The tests will run against the preview environment by default.  You can 
+These are used to verify releases and also to provide Nagios alerts for major
+features.
+
+## Technical documentation
+
+The smoke tests are based on [Cucumber](http://cukes.info/). We use feature
+files to describe single applications (eg
+[`whitehall`](https://github.com/alphagov/whitehall),
+[`frontend`](https://github.com/alphagov/frontend)).
+
+### Running the tests
+
+Run the suite with:
+
+```
+bundle exec rake
+```
+
+or against a single `feature`:
+
+```
+bundle exec cucumber features/frontend.feature
+```
+
+The tests will run against the preview environment by default.  You can
 override that by setting the `GOVUK_WEBSITE_ROOT` environment variable.
 
-You'll need to configure the http auth credentials by setting the 
+You'll need to configure the http auth credentials by setting the
 `AUTH_USERNAME` and `AUTH_PASSWORD` environment variables.
 
     GOVUK_WEBSITE_ROOT=https://hostname AUTH_USERNAME=username AUTH_PASSWORD=password bundle exec rake
 
-## Adding new tests
+### Adding new tests
 
 Tests that are supposed to be run by icinga also have to be added to the file
 `modules/monitoring/manifests/checks/smokey.pp` in our Puppet repository. For
 example, the test [frontend.feature](/features/frontend.feature)
 is added to icinga like this:
 
-    icinga::check_feature {
-      'check_frontend':          feature => 'frontend';
-      #other feature tests
-    }
+```puppet
+icinga::check_feature {
+  'check_frontend':          feature => 'frontend';
+  #other feature tests
+}
+```
 
-## Prioritising scenarios
+### Prioritising scenarios
+
+Because we integrate Nagios with the output from these tests, we provide a set
+of tags which match with how important we consider a scenario to be. `@high` and
+above will trigger pager alerts.
 
 Each scenario can and should be prioritised by using the `@urgent`, `@high`,
 `@normal` or `@low` cucumber tags. For example, the frontend scenario "check
 guides load" can be prioritised like this:
 
-    @low
-    Scenario: check guides load
-      When I visit "/getting-an-mot/overview"
-      Then I should see "Getting an MOT"
+```cucumber
+@low
+Scenario: check guides load
+  When I visit "/getting-an-mot/overview"
+  Then I should see "Getting an MOT"
+```


### PR DESCRIPTION
This improves the README inline with the [GOV.UK README guidance](https://github.com/alphagov/styleguides/blob/a56ac875b9031eb82bffa9e20b9f19b60aaf4377/use-of-READMEs.md).
Primarily it adds:
- A better intro
- Explicit instructions about how it's Cucumber, and how to run it
- Syntax highlighting
- A description of Nagios integration
