### PR TITLE
Empty out the RestClient log after each run

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -2,6 +2,10 @@
 
 set -x
 
+# Clean up untracked files. This is mainly to remove `smokey-rest-client.log`,
+# otherwise it builds up between jobs.
+git clean -fdx
+
 if [ -z $MYTASK ]; then
   MYTASK="test:skyscapenetwork"
 fi


### PR DESCRIPTION
Without this, the log file builds up forever, with details of every HTTP request Smokey has ever made. Since we'll be capturing log output for anything interesting anyway, this isn't useful to us.