### PR TITLE
Use an interactive shell when deploying

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -7,6 +7,6 @@ set -eu
 
 chmod 777 log
 rsync -av --delete --exclude='.git' --exclude 'log/*' "$(pwd)/" "deploy@${DEPLOY_TO}":/opt/smokey
-ssh deploy@${DEPLOY_TO} 'cd /opt/smokey && bundle install --path $HOME/.bundle/gems --deployment'
+ssh deploy@${DEPLOY_TO} 'bash -lc "cd /opt/smokey && bundle install --path $HOME/.bundle/gems --deployment"'
 
 logger -p INFO -t jenkins "DEPLOYMENT: ${JOB_NAME} ${BUILD_NUMBER} (${BUILD_URL})"


### PR DESCRIPTION
Using a non-interactive shell when executing `bundle` uses bundler which is installed as a system gem.

Newly provisioned machines do not have bundler installed as a system gem and need to use rbenv, which requires an interactive login shell to set up.