### PR TITLE
Make performance platform tests less brittle.

### DIFF
--- a/features/performance_platform.feature
+++ b/features/performance_platform.feature
@@ -8,7 +8,7 @@ Feature: Performance Platform
     When I visit "/performance"
     Then I should get a 200 status code
     And I should see "Performance"
-    And the elapsed time should be less than 2 seconds
+    And the elapsed time should be less than 5 seconds
 
   @high
   Scenario: Performance Platform dashboards are available
@@ -18,4 +18,4 @@ Feature: Performance Platform
     When I visit "/performance/carers-allowance"
     Then I should get a 200 status code
     And I should see "Carer's Allowance"
-    And the elapsed time should be less than 3 seconds
+    And the elapsed time should be less than 5 seconds


### PR DESCRIPTION
Tests have been frequently timing out, so increase the value for now, as discussed with @mattrco.