### PR TITLE
Disable timing check for the performance platform tests

### DIFF
--- a/features/performance_platform.feature
+++ b/features/performance_platform.feature
@@ -8,7 +8,6 @@ Feature: Performance Platform
     When I visit "/performance"
     Then I should get a 200 status code
     And I should see "Performance"
-    And the elapsed time should be less than 5 seconds
 
   @high
   Scenario: Performance Platform dashboards are available
@@ -18,4 +17,3 @@ Feature: Performance Platform
     When I visit "/performance/carers-allowance"
     Then I should get a 200 status code
     And I should see "Carer's Allowance"
-    And the elapsed time should be less than 5 seconds


### PR DESCRIPTION
The 'elapsed time' check has been failing regularly across all environments.
This is a known issue and doesn't require immediate action, so it shouldn't
trigger an error alert in nagios.

If the page takes way too long, the nginx timeout would kick in and the return
code wouldn't be 200 (which is asserted on, so that scenario will be detected).

/cc @tombooth