### PR TITLE
Update smartanswers test to step through a different answer

### DIFF
--- a/features/smartanswers.feature
+++ b/features/smartanswers.feature
@@ -14,14 +14,15 @@ Feature: Smart Answers
       | /overseas-passports                         |
       | /pay-leave-for-parents                      |
       | /register-a-death                           |
+      | /vat-payment-deadlines                      |
 
-    @normal
-    Scenario: step through a smart answer
-      Given I am testing through the full stack
-      And I force a varnish cache miss
-      Then I should be able to visit:
-      | Path                                              |
-      | /student-finance-calculator                       |
-      | /student-finance-calculator/y                     |
-      | /student-finance-calculator/y/2013-2014           |
-      | /student-finance-calculator/y/2013-2014/full-time |
+  @normal
+  Scenario: step through a smart answer
+    Given I am testing through the full stack
+    And I force a varnish cache miss
+    Then I should be able to visit:
+    | Path                                        |
+    | /vat-payment-deadlines                      |
+    | /vat-payment-deadlines/y                    |
+    | /vat-payment-deadlines/y/2000-01-31         |
+    | /vat-payment-deadlines/y/2000-01-31/cheque  |


### PR DESCRIPTION
As can be checked on preview by visiting `/student-finance-calculator/y/2013-2014/full-time`, the answer kept redirecting to the first question, because the dates in the URL are no longer valid as answers. Therefore the test was not testing the flow as intended.

This picks another answer to test against that is less likely to change the possible answers.