### PR TITLE
[Do not merge yet] Update policy selector to fix broken step

### DIFF
--- a/features/step_definitions/whitehall_steps.rb
+++ b/features/step_definitions/whitehall_steps.rb
@@ -41,7 +41,7 @@ end
 def follow_link_to_first_policy_on_policies_page
   html = get_request("#{@host}/government/policies", cache_bust: @bypass_varnish)
   doc = Nokogiri::HTML(html)
-  link_to_policy = doc.at('.document-row a')
+  link_to_policy = doc.at('.document a')
   assert ! link_to_policy.nil?, "No policy links found"
   href = link_to_policy.attributes['href'].value
   get_request("#{@host}#{href}", cache_bust: @bypass_varnish)


### PR DESCRIPTION
The policies list is moving to `finder-frontend`, which has
slightly different class names. Update the selector to match
the policies as presented by `finder-frontend`

The movement of policies to `finder-frontend` has been done
on preview, but will happen on production when the new 
government is formed.

Until then this PR will actually introduce Smokey errors on
production. I'm not sure if we have have separate preview/
staging/production deploys for Smokey, if so this can be 
deployed to preview, but we'd want to hold off deploying
to prod until the government forms.

It might just be easier to leave this PR until that point, and
ack the preview errors. Thoughts from 2ndline, as they'll
be dealing with any alerts in the meantime?