### PR TITLE
Only test that department short URLs redirect

### DIFF
--- a/features/whitehall.feature
+++ b/features/whitehall.feature
@@ -58,9 +58,9 @@ Feature: Whitehall
       | /government/world                |
 
   @normal
-  Scenario: Department short URLs work correctly
+  Scenario: Department short URLs redirect correctly
     Given I am testing through the full stack
-    Then I should be able to visit:
+    Then I should get a 301 response when I try to visit:
       | Path                      |
       | /ago                      |
       | /airports-commission      |


### PR DESCRIPTION
The destination pages sometimes time out and cause false positives - what we care about here is that the URLs redirect.

Pinning these to the destination will probably also cause false positives if any of the slugs change.