### PR TITLE
Rename @notnagios Cucumber tag

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,7 @@ Cucumber::Rake::Task.new("test:wip",
 end
 
 Cucumber::Rake::Task.new(:remote, "Excludes nagios tests") do |t|
-  t.cucumber_opts = %w{--format pretty -t ~@pending -t ~@notnagios}
+  t.cucumber_opts = %w{--format pretty -t ~@pending -t ~@disabled_in_icinga}
 end
 
 task :default => "test:notlocalnetwork"

--- a/cron_json.sh
+++ b/cron_json.sh
@@ -23,5 +23,5 @@ TMP_FILE="${CACHE_FILE}.tmp"
 rm -f ${TMP_FILE}
 /usr/local/bin/govuk_setenv default \
     bundle exec cucumber --format json \
-        -t ~@pending -t ~@notnagios > ${TMP_FILE} || true
+        -t ~@pending -t ~@disabled_in_icinga > ${TMP_FILE} || true
 mv ${TMP_FILE} ${CACHE_FILE}

--- a/features/whitehall.feature
+++ b/features/whitehall.feature
@@ -31,7 +31,7 @@ Feature: Whitehall
     When I do a whitehall search for "Assessing radioactive waste disposal sites"
     Then I should see "Assessing radioactive waste disposal sites"
 
-  @notnagios
+  @disabled_in_icinga
   Scenario: Feeds should be available for documents
     Given I am testing through the full stack
     And I force a varnish cache miss


### PR DESCRIPTION
- We no longer use Nagios for monitoring
- Make the tag name more descriptive