### PR TITLE
Change trailing slash test to use a relative path

### DIFF
--- a/features/gov_uk.feature
+++ b/features/gov_uk.feature
@@ -4,4 +4,4 @@ Feature: Core GOV.UK behaviour
   Scenario: Paths with a trailing slash are redirected
     When I visit "https://www.gov.uk/browse/benefits/" without following redirects
     Then I should get a 301 status code
-    And I should get a location of "https://www.gov.uk/browse/benefits"
+    And I should get a location of "/browse/benefits"


### PR DESCRIPTION
The 301 response that we send when we strip the trailing slash contains a relative location rather than the absolute URL.

Thanks/sorry @jennyd @dsingleton.