### PR TITLE
Add signon cookie tests

### DIFF
--- a/features/signon.feature
+++ b/features/signon.feature
@@ -4,3 +4,8 @@ Feature: Sign-on-o-tron
     When I try to login as a user
     Then I should see "Welcome to GOV.UK"
 
+  @low
+  Scenario: Signon cookies are marked as secure and HttpOnly
+    When I go to the "signon" landing page
+    Then I should receive a "_signonotron2_session" cookie which is "secure"
+     And I should receive a "_signonotron2_session" cookie which is "HttpOnly"

--- a/features/step_definitions/cookie_steps.rb
+++ b/features/step_definitions/cookie_steps.rb
@@ -1,0 +1,7 @@
+Then /^I should receive a "([a-z0-9_]+)" cookie which is "([a-zA-Z]+)"$/ do |cookie_name, cookie_property|
+  header = page.response_headers['set-cookie']
+  assert header.start_with?(cookie_name), "No cookie called #{cookie_name} is being set"
+
+  property_matches = header.match /; #{cookie_property}(;|$)/
+  assert !property_matches.nil?, "The cookie #{cookie_name} does not have property #{cookie_property}"
+end


### PR DESCRIPTION
These cookies need to be secure because they contain authentication
information. We set the HttpOnly flag because there's no reason for
client-side script to access the cookie.

My intention with the regular expression is to match the following:

- A delimiter in the Set-Cookie header (semicolon)
- Then a space
- Then the name of the property we want to find
- Then either another delimiter (semicolon) or the end of the header