### PR TITLE
Draft smokey features

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,16 @@ Cucumber::Rake::Task.new("test:preview",
   t.cucumber_opts = %w{--format progress -t ~@pending -t ~@notpreview}
 end
 
+Cucumber::Rake::Task.new("test:draft",
+    "Run all tests that are valid in our draft environment") do |t|
+  t.cucumber_opts = %w{--format progress -t ~@pending -t @draft}
+end
+
+Cucumber::Rake::Task.new("test:preview_draft",
+    "Run all tests that are valid in our preview draft environment") do |t|
+  t.cucumber_opts = %w{--format progress -t @draft -t ~@pending -t ~@notpreview}
+end
+
 Cucumber::Rake::Task.new("test:skyscapenetwork",
     "Run all tests that are valid in our production environment") do |t|
   t.cucumber_opts = %w{--format progress -t ~@pending}

--- a/features/contacts.feature
+++ b/features/contacts.feature
@@ -1,5 +1,6 @@
 Feature: Contacts
 
+  @draft
   @normal
   Scenario: check contacts app can be reached
     Given I am testing through the full stack

--- a/features/government_frontend.feature
+++ b/features/government_frontend.feature
@@ -4,6 +4,7 @@ Feature: Government Frontend
     Given I am testing through the full stack
     And I force a varnish cache miss
 
+  @draft
   Scenario:
     When I visit "/government/case-studies/epic-cic"
     Then I should see "Case study"


### PR DESCRIPTION
This adds a rake task for running smokey features for the draft stacks: 

```
$ bundle exec rake test:preview_draft
```

and

```
$ bundle exec rake test:draft
```

Features that apply to the draft stack should be marked with the `@draft` tag.

It's worth noting that we do not currently have any features for either static or manuals-frontend.