### PR TITLE
Update smokey to work with draft stack

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,27 +3,27 @@ require 'cucumber/rake/task'
 
 Cucumber::Rake::Task.new("test:preview",
     "Run all tests that are valid in our preview environment") do |t|
-  t.cucumber_opts = %w{--format progress -t ~@pending -t ~@notpreview}
+  t.cucumber_opts = %w{--format progress -t ~@pending -t ~@notpreview -t ~@draft-only}
 end
 
 Cucumber::Rake::Task.new("test:draft",
     "Run all tests that are valid in our draft environment") do |t|
-  t.cucumber_opts = %w{--format progress -t ~@pending -t @draft}
+  t.cucumber_opts = %w{--format progress -t ~@pending -t @draft-only}
 end
 
 Cucumber::Rake::Task.new("test:preview_draft",
     "Run all tests that are valid in our preview draft environment") do |t|
-  t.cucumber_opts = %w{--format progress -t @draft -t ~@pending -t ~@notpreview}
+  t.cucumber_opts = %w{-t @draft-only -t ~@pending -t ~@notpreview}
 end
 
 Cucumber::Rake::Task.new("test:skyscapenetwork",
     "Run all tests that are valid in our production environment") do |t|
-  t.cucumber_opts = %w{--format progress -t ~@pending}
+  t.cucumber_opts = %w{--format progress -t ~@pending -t ~@draft-only}
 end
 
 Cucumber::Rake::Task.new("test:notlocalnetwork",
     "Run all tests that do not make use of the local network") do |t|
-  t.cucumber_opts = %w{--format pretty -t ~@pending -t ~@local-network}
+  t.cucumber_opts = %w{--format pretty -t ~@pending -t ~@local-network -t ~@draft-only}
 end
 
 Cucumber::Rake::Task.new("test:wip",
@@ -32,7 +32,7 @@ Cucumber::Rake::Task.new("test:wip",
 end
 
 Cucumber::Rake::Task.new(:remote, "Excludes nagios tests") do |t|
-  t.cucumber_opts = %w{--format pretty -t ~@pending -t ~@disabled_in_icinga}
+  t.cucumber_opts = %w{--format pretty -t ~@pending -t ~@disabled_in_icinga -t ~@draft-only}
 end
 
 task :default => "test:notlocalnetwork"

--- a/features/contacts.feature
+++ b/features/contacts.feature
@@ -7,7 +7,6 @@ Feature: Contacts
     When I visit "/government/organisations/hm-revenue-customs/contact"
     Then I should see "HM Revenue &amp; Customs Contacts"
 
-  @draft
   @normal
   Scenario: viewing a contact
     Given I am testing through the full stack

--- a/features/draft_environment.feature
+++ b/features/draft_environment.feature
@@ -1,0 +1,23 @@
+Feature: Draft environment
+  The draft environment is used to preview content before it is put live on
+  GOV.UK. Accessing the draft environment requires a valid signon session.
+  Access to the draft stack should be denied without a valid signon session.
+
+  @draft-only
+  Scenario: visiting a draft page requires a signon session
+    When I attempt to go to a case study
+    Then I should be prompted to log in
+    When I log in using valid credentials
+    Then I should be on the case study page
+
+  @draft-only
+  Scenario: visiting a page served by government-frontend
+    Given I have a valid signon session
+    When I attempt to visit "government/case-studies/epic-cic"
+    Then I should see "Case study"
+
+  @draft-only
+  Scenario: visiting a page served by contacts-frontend
+    Given I have a valid signon session
+    When I attempt to visit "government/organisations/hm-revenue-customs/contact/child-benefit"
+    Then I should see "Child Benefit"

--- a/features/government_frontend.feature
+++ b/features/government_frontend.feature
@@ -4,7 +4,6 @@ Feature: Government Frontend
     Given I am testing through the full stack
     And I force a varnish cache miss
 
-  @draft
   Scenario:
     When I visit "/government/case-studies/epic-cic"
     Then I should see "Case study"

--- a/features/step_definitions/draft_environment_steps.rb
+++ b/features/step_definitions/draft_environment_steps.rb
@@ -1,0 +1,22 @@
+When /^I attempt to go to a case study$/ do
+  visit "government/case-studies/epic-cic"
+end
+
+When /^I attempt to visit "(.*?)"$/ do |path|
+  visit path
+end
+
+Then /^I should be prompted to log in$/ do
+  page.should have_content('Sign in')
+end
+
+When /^I log in using valid credentials$/ do
+  fill_in "Email", :with => ENV["SIGNON_EMAIL"]
+  fill_in "Passphrase", :with => ENV["SIGNON_PASSWORD"]
+  click_button "Sign in"
+end
+
+Then /^I should be on the case study page$/ do
+  page.current_path.should eq("/government/case-studies/epic-cic")
+  page.should have_content('Case study')
+end

--- a/features/step_definitions/signon_steps.rb
+++ b/features/step_definitions/signon_steps.rb
@@ -1,3 +1,11 @@
+
+Given /^I have a valid signon session$/ do
+  visit signon_base_url
+  fill_in "Email", :with => ENV["SIGNON_EMAIL"]
+  fill_in "Passphrase", :with => ENV["SIGNON_PASSWORD"]
+  click_button "Sign in"
+end
+
 When /^I try to login as a user$/ do
   assert ENV["SIGNON_EMAIL"] && ENV["SIGNON_PASSWORD"], "Please ensure that the signon user credentials are available in the environment"
 
@@ -7,4 +15,3 @@ When /^I try to login as a user$/ do
   fill_in "Passphrase", :with => ENV["SIGNON_PASSWORD"]
   click_button "Sign in"
 end
-


### PR DESCRIPTION
This adjusts the organisation of the smokey features such that there are
specific ones that are only run on the draft stack.

Ideally, there wouldn't be entirely separate scenarios for testing the draft
stack, but unfortunately the existing scenarios that call the "When I visit X"
step are not compatible with user sessions as under the hood they make the
requests using RestClient and not the capybara driver. Without rewriting all the
existing scenarios to use the proper driver, it would be too mucky to make these
scenarios work on both draft and non-draft stacks.