### PR TITLE
Fix ampersand in contacts feature

### DIFF
--- a/features/contacts.feature
+++ b/features/contacts.feature
@@ -5,7 +5,7 @@ Feature: Contacts
     Given I am testing through the full stack
     And I force a varnish cache miss
     When I visit "/government/organisations/hm-revenue-customs/contact"
-    Then I should see "HM Revenue & Customs Contacts"
+    Then I should see "HM Revenue &amp; Customs Contacts"
 
   @draft
   @normal


### PR DESCRIPTION
The check just looks through the page body to find the given text. Because the ampersand is encoded in the HTML, the string "Revenue & Customs" doesn't exist.