### PR TITLE
Remove transactions explorer smoke test

### DIFF
--- a/features/transactions_explorer.feature
+++ b/features/transactions_explorer.feature
@@ -1,8 +1,0 @@
-Feature: Transactions Explorer
-
-  Scenario: Transactions Explorer main page is available
-    Given I am testing through the full stack
-    And I force a varnish cache miss
-    When I visit "/performance/transactions-explorer/all-services/by-transactions-per-year/descending"
-    Then I should get a 200 status code
-    And I should see "Transactions Explorer"


### PR DESCRIPTION
The url tested by this smoke test redirects to /performance/services.

The transactions explorer appears to no longer be running.