### PR TITLE
Activate smokey checks for draft environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ bundle exec cucumber features/frontend.feature
 The tests will run against the preview environment by default.  You can
 override that by setting the `GOVUK_WEBSITE_ROOT` environment variable.
 
+You may also specify the domain of the draft website root using
+`GOVUK_DRAFT_WEBSITE_ROOT`. By default this will be derived from
+`GOVUK_WEBSITE_ROOT` by replacing the first element of the hostname with
+`draft-origin` (so `https://www.preview.alphagov.co.uk` becomes `https
+://draft-origin.preview.alphagov.co.uk`).
+
 You'll need to configure the http auth credentials by setting the
 `AUTH_USERNAME` and `AUTH_PASSWORD` environment variables.
 

--- a/Rakefile
+++ b/Rakefile
@@ -3,27 +3,17 @@ require 'cucumber/rake/task'
 
 Cucumber::Rake::Task.new("test:preview",
     "Run all tests that are valid in our preview environment") do |t|
-  t.cucumber_opts = %w{--format progress -t ~@pending -t ~@notpreview -t ~@draft-only}
-end
-
-Cucumber::Rake::Task.new("test:draft",
-    "Run all tests that are valid in our draft environment") do |t|
-  t.cucumber_opts = %w{--format progress -t ~@pending -t @draft-only}
-end
-
-Cucumber::Rake::Task.new("test:preview_draft",
-    "Run all tests that are valid in our preview draft environment") do |t|
-  t.cucumber_opts = %w{-t @draft-only -t ~@pending -t ~@notpreview}
+  t.cucumber_opts = %w{--format progress -t ~@pending -t ~@notpreview}
 end
 
 Cucumber::Rake::Task.new("test:production",
     "Run all tests that are valid in our production environment") do |t|
-  t.cucumber_opts = %w{--format progress -t ~@pending -t ~@draft-only}
+  t.cucumber_opts = %w{--format progress -t ~@pending}
 end
 
 Cucumber::Rake::Task.new("test:notlocalnetwork",
     "Run all tests that do not make use of the local network") do |t|
-  t.cucumber_opts = %w{--format pretty -t ~@pending -t ~@local-network -t ~@draft-only}
+  t.cucumber_opts = %w{--format pretty -t ~@pending -t ~@local-network}
 end
 
 Cucumber::Rake::Task.new("test:wip",
@@ -32,7 +22,7 @@ Cucumber::Rake::Task.new("test:wip",
 end
 
 Cucumber::Rake::Task.new(:remote, "Excludes nagios tests") do |t|
-  t.cucumber_opts = %w{--format pretty -t ~@pending -t ~@disabled_in_icinga -t ~@draft-only}
+  t.cucumber_opts = %w{--format pretty -t ~@pending -t ~@disabled_in_icinga}
 end
 
 task :default => "test:notlocalnetwork"

--- a/features/draft_environment.feature
+++ b/features/draft_environment.feature
@@ -3,20 +3,22 @@ Feature: Draft environment
   GOV.UK. Accessing the draft environment requires a valid signon session.
   Access to the draft stack should be denied without a valid signon session.
 
-  @draft-only
+  @draft
   Scenario: visiting a draft page requires a signon session
     When I attempt to go to a case study
     Then I should be prompted to log in
     When I log in using valid credentials
     Then I should be on the case study page
+    And the page should contain the draft watermark
 
-  @draft-only
+  @draft
   Scenario: visiting a page served by government-frontend
     When I try to login as a user
     When I attempt to visit "government/case-studies/epic-cic"
     Then I should see "Case study"
+    And the page should contain the draft watermark
 
-  @draft-only
+  @draft
   Scenario: visiting a page served by contacts-frontend
     When I try to login as a user
     When I attempt to visit "government/organisations/hm-revenue-customs/contact/child-benefit"

--- a/features/step_definitions/draft_environment_steps.rb
+++ b/features/step_definitions/draft_environment_steps.rb
@@ -20,3 +20,7 @@ Then /^I should be on the case study page$/ do
   page.current_path.should eq("/government/case-studies/epic-cic")
   page.should have_content('Case study')
 end
+
+Then /^the page should contain the draft watermark$/ do
+  page.should have_css('body.draft')
+end

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -7,7 +7,7 @@ Given /^I am testing "(.*)"/ do |host|
 end
 
 Given /^I am testing through the full stack$/ do
-  @host = base_url
+  @host = ENV["GOVUK_WEBSITE_ROOT"]
   @bypass_varnish = false
   @authenticated = true
 end

--- a/features/support/capybara_mechanize_request_tracing.rb
+++ b/features/support/capybara_mechanize_request_tracing.rb
@@ -1,0 +1,17 @@
+require 'logger'
+
+def activate_capybara_mechanize_request_tracing!(logger = Logger.new(STDOUT))
+  Capybara::Mechanize::Browser.instance_eval do
+    old_process_remote_request = instance_method(:process_remote_request)
+
+    define_method(:process_remote_request) do |method, url, attributes, headers|
+      logger.info "#{method.upcase} #{url}"
+      old_process_remote_request.bind(self).(method, url, attributes, headers)
+    end
+  end
+end
+
+# Uncomment this line if you want to see log output for every HTTP request
+# made through mechanize:
+#
+# activate_capybara_mechanize_request_tracing!

--- a/features/support/draft.rb
+++ b/features/support/draft.rb
@@ -1,0 +1,9 @@
+Around('@draft') do |scenario, block|
+  old_app_host = Capybara.app_host
+  begin
+    Capybara.app_host = ENV.fetch('GOVUK_DRAFT_WEBSITE_ROOT')
+    block.call
+  ensure
+    Capybara.app_host = old_app_host
+  end
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,10 +1,16 @@
 require 'nokogiri'
 require 'capybara/cucumber'
 require 'capybara/mechanize'
+require 'uri'
 
-def base_url
-  ENV["GOVUK_WEBSITE_ROOT"] || "https://www.preview.alphagov.co.uk"
+def guess_draft_url_from_live(live_url)
+  url = URI.parse(live_url)
+  host = (["draft-origin"] + url.host.split(".")[1..-1]).join(".")
+  "#{url.scheme}://#{host}"
 end
 
+ENV["GOVUK_WEBSITE_ROOT"] ||= "https://www.preview.alphagov.co.uk"
+ENV["GOVUK_DRAFT_WEBSITE_ROOT"] ||= guess_draft_url_from_live(ENV["GOVUK_WEBSITE_ROOT"])
+
 Capybara.default_driver = :mechanize
-Capybara.app_host = base_url
+Capybara.app_host = ENV["GOVUK_WEBSITE_ROOT"]


### PR DESCRIPTION
the draft steps had been set up in such a way that there was an assumption
that smokey would be invoked with `GOVUK_WEBSITE_ROOT` set to point to
the draft environment.

Given that we've moved away from having a full duplicate stack for the
draft environment, we will now only run smoke tests in one place.

This change allows steps tagged with `@draft` to be directed towards the
draft environment urls.

I also added an extra step to some of the draft scenarios to check that
the watermark shows on the page (which is triggered by the `draft` css
class on the document body).

https://trello.com/c/crylF01S/304-make-draft-smoke-tests-run-as-part-of-normal-run