### PR TITLE
Assign priorities to draft environment checks

### DIFF
--- a/features/draft_environment.feature
+++ b/features/draft_environment.feature
@@ -3,7 +3,7 @@ Feature: Draft environment
   GOV.UK. Accessing the draft environment requires a valid signon session.
   Access to the draft stack should be denied without a valid signon session.
 
-  @draft
+  @draft @high
   Scenario: visiting a draft page requires a signon session
     When I attempt to go to a case study
     Then I should be prompted to log in
@@ -11,14 +11,14 @@ Feature: Draft environment
     Then I should be on the case study page
     And the page should contain the draft watermark
 
-  @draft
+  @draft @high
   Scenario: visiting a page served by government-frontend
     When I try to login as a user
     When I attempt to visit "government/case-studies/epic-cic"
     Then I should see "Case study"
     And the page should contain the draft watermark
 
-  @draft
+  @draft @normal
   Scenario: visiting a page served by contacts-frontend
     When I try to login as a user
     When I attempt to visit "government/organisations/hm-revenue-customs/contact/child-benefit"

--- a/features/draft_environment.feature
+++ b/features/draft_environment.feature
@@ -11,14 +11,14 @@ Feature: Draft environment
     Then I should be on the case study page
     And the page should contain the draft watermark
 
-  @draft @high
+  @draft
   Scenario: visiting a page served by government-frontend
     When I try to login as a user
     When I attempt to visit "government/case-studies/epic-cic"
     Then I should see "Case study"
     And the page should contain the draft watermark
 
-  @draft @normal
+  @draft
   Scenario: visiting a page served by contacts-frontend
     When I try to login as a user
     When I attempt to visit "government/organisations/hm-revenue-customs/contact/child-benefit"


### PR DESCRIPTION
in order to have the smokey checks verified through nagios (and thus
trigger monitoring alerts), they need to be assigned priorities.