### PR TITLE
Add tests for specialist publisher formats on draft

### DIFF
--- a/features/draft_environment.feature
+++ b/features/draft_environment.feature
@@ -19,6 +19,21 @@ Feature: Draft environment
     And the page should contain the draft watermark
 
   @draft
+  Scenario: visiting a specialist document served by specialist-frontend
+    When I try to login as a user
+    And I attempt to visit a CMA case
+    Then I should see "Competition and Markets Authority case"
+    And the page should contain the draft watermark
+
+  @draft
+  Scenario: visiting a manual served by specialist-frontend
+    When I try to login as a user
+    And I attempt to visit a manual
+    Then I should see "Content design"
+    And I should see "Search this manual"
+    And the page should contain the draft watermark
+
+  @draft
   Scenario: visiting a page served by contacts-frontend
     When I try to login as a user
     When I attempt to visit "government/organisations/hm-revenue-customs/contact/child-benefit"

--- a/features/step_definitions/draft_environment_steps.rb
+++ b/features/step_definitions/draft_environment_steps.rb
@@ -6,6 +6,14 @@ When /^I attempt to visit "(.*?)"$/ do |path|
   visit path
 end
 
+When /^I attempt to visit a CMA case$/ do
+  visit "cma-cases/japan-tobacco-international-e-lites"
+end
+
+When /^I attempt to visit a manual$/ do
+  visit "guidance/content-design"
+end
+
 Then /^I should be prompted to log in$/ do
   page.should have_content('Sign in')
 end


### PR DESCRIPTION
These check that the specialist publisher format documents can be loaded
in the draft environment.

The URLs chosen are arbitrary ones which hopefully should be in
existence.