### PR TITLE
Special case for production draft url

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
+gem "plek"
 gem "rake"
 gem "rspec"
 gem "cucumber"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,7 @@ GEM
     net-http-persistent (2.7)
     nokogiri (1.5.5)
     ntlm-http (0.1.1)
+    plek (1.11.0)
     rack (1.4.1)
     rack-test (0.6.2)
       rack (>= 1.0)
@@ -78,6 +79,10 @@ DEPENDENCIES
   capybara-mechanize
   cucumber
   nokogiri
+  plek
   rake
   rest-client
   rspec
+
+BUNDLED WITH
+   1.10.4

--- a/README.md
+++ b/README.md
@@ -31,10 +31,8 @@ The tests will run against the preview environment by default.  You can
 override that by setting the `GOVUK_WEBSITE_ROOT` environment variable.
 
 You may also specify the domain of the draft website root using
-`GOVUK_DRAFT_WEBSITE_ROOT`. By default this will be derived from
-`GOVUK_WEBSITE_ROOT` by replacing the first element of the hostname with
-`draft-origin` (so `https://www.preview.alphagov.co.uk` becomes `https
-://draft-origin.preview.alphagov.co.uk`).
+`GOVUK_DRAFT_WEBSITE_ROOT`. By default this will use the url for `draft-
+origin` returned by [`plek`](http://github.com/alphagov/plek).
 
 You'll need to configure the http auth credentials by setting the
 `AUTH_USERNAME` and `AUTH_PASSWORD` environment variables.

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -2,15 +2,10 @@ require 'nokogiri'
 require 'capybara/cucumber'
 require 'capybara/mechanize'
 require 'uri'
-
-def guess_draft_url_from_live(live_url)
-  url = URI.parse(live_url)
-  host = (["draft-origin"] + url.host.split(".")[1..-1]).join(".")
-  "#{url.scheme}://#{host}"
-end
+require 'plek'
 
 ENV["GOVUK_WEBSITE_ROOT"] ||= "https://www.preview.alphagov.co.uk"
-ENV["GOVUK_DRAFT_WEBSITE_ROOT"] ||= guess_draft_url_from_live(ENV["GOVUK_WEBSITE_ROOT"])
+ENV["GOVUK_DRAFT_WEBSITE_ROOT"] ||= Plek.find('draft-origin')
 
 Capybara.default_driver = :mechanize
 Capybara.app_host = ENV["GOVUK_WEBSITE_ROOT"]


### PR DESCRIPTION
smokey incorrectly guesses the draft url in production.