### PR TITLE
Fix licensify hostname

### DIFF
--- a/features/step_definitions/licensing.rb
+++ b/features/step_definitions/licensing.rb
@@ -1,4 +1,4 @@
 When /^I login to Licensify$/ do
-  visit 'https://licensify-admin.production.alphagov.co.uk/login'
+  visit "https://licensify-admin.#{ENV['GOVUK_APP_DOMAIN']}/login"
   click_button 'Login'
 end


### PR DESCRIPTION
Use GOVUK_APP_DOMAIN because it's more portable than hardcoding a hostname.