### PR TITLE
Update smokey to check topics dynamically

### DIFF
--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -169,3 +169,10 @@ end
 Then /^I should see Publisher's publication index$/ do
   page.should have_selector("#publication-list-container")
 end
+
+Then(/^I should be able to visit a (first|second) level topic at random$/) do |level|
+  topics = Nokogiri::HTML.parse(@response.body).css("nav.topics li a")
+  topic_path = topics.map { |t| t.attributes["href"].value }.sample(1).first
+  puts "Level: #{level}, Path: #{topic_path}, Topic Count: #{topics.count}"
+  should_visit(topic_path)
+end

--- a/features/topics.feature
+++ b/features/topics.feature
@@ -1,0 +1,10 @@
+Feature: Topics
+
+  Scenario: dynamically checking topic hierarchy
+    Given I am testing through the full stack
+    And I force a varnish cache miss
+    Then I should be able to visit:
+      | Path               |
+      | /topic             |
+    And I should be able to visit a first level topic at random
+    And I should be able to visit a second level topic at random


### PR DESCRIPTION
Add additional step to traverse topic hierarchy across both first and
second levels, to improve monitoring of /topic path.

Story: https://trello.com/c/Dj4P9D8N