### PR TITLE
Update smokey to check browse and topics dynamically

### DIFF
--- a/features/browse.feature
+++ b/features/browse.feature
@@ -7,4 +7,4 @@ Feature: Browse
     Then I should be able to visit:
       | Path            |
       | /browse         |
-      | /browse/driving |
+    And I should be able to navigate the browse pages

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -169,3 +169,40 @@ end
 Then /^I should see Publisher's publication index$/ do
   page.should have_selector("#publication-list-container")
 end
+
+Then /^I should be able to navigate the topic hierarchy$/ do
+  topics = Nokogiri::HTML.parse(@response.body).css("nav.topics li a")
+  random_path_selection(anchor_tags: topics).each do |path|
+    log_traversal_info(path, level: 1, links: topics)
+    should_visit(path)
+    subtopics = Nokogiri::HTML.parse(@response.body).css("nav.topics li a")
+    random_path_selection(anchor_tags: subtopics).each do |path|
+      log_traversal_info(path, level: 2, links: subtopics)
+      should_visit(path)
+    end
+  end
+end
+
+Then /^I should be able to navigate the browse pages$/ do
+  categories = Nokogiri::HTML.parse(@response.body).css(".browse-panes ul li a")
+  random_path_selection(anchor_tags: categories).each do |path|
+    log_traversal_info(path, level: 1, links: categories)
+    should_visit(path)
+    subcategories = Nokogiri::HTML.parse(@response.body).css(".pane-inner ul li a")
+    random_path_selection(anchor_tags: subcategories).each do |path|
+      log_traversal_info(path, level: 2, links: subcategories)
+      should_visit(path)
+    end
+  end
+end
+
+def random_path_selection(opts={})
+  size = opts[:size] || 3
+  anchor_tags = opts[:anchor_tags] || []
+  anchor_tags.map { |anchor| anchor.attributes["href"].value }.sample(size)
+end
+
+def log_traversal_info(path, opts={})
+  puts "Level: #{opts.fetch(:level)} | Available links: #{opts.fetch(:links).count} | Visited path: #{path}"
+end
+

--- a/features/topics.feature
+++ b/features/topics.feature
@@ -1,0 +1,9 @@
+Feature: Topics
+
+  Scenario: dynamically checking topic hierarchy
+    Given I am testing through the full stack
+    And I force a varnish cache miss
+    Then I should be able to visit:
+      | Path               |
+      | /topic             |
+    And I should be able to navigate the topic hierarchy


### PR DESCRIPTION
Add additional step to traverse browse categories across both first and
second levels, to improve monitoring of /browse path.

Stories: https://trello.com/c/VqFDnMot and https://trello.com/c/Dj4P9D8N