### PR TITLE
Add assets test

### DIFF
--- a/features/assets.feature
+++ b/features/assets.feature
@@ -1,0 +1,7 @@
+Feature: Assets
+
+  @high
+  Scenario: Assets are being served
+    Given I am testing "assets"
+    When I visit "/__canary__"
+    Then I should get a 200 status code

--- a/features/support/base_urls.rb
+++ b/features/support/base_urls.rb
@@ -13,6 +13,7 @@ end
 def application_base_url(app_name)
   case app_name
   when 'asset-manager' then "https://asset-manager.#{app_domain}/"
+  when 'assets' then "https://assets-origin.#{app_domain}/"
   when 'bouncer' then "https://bouncer.#{app_domain}/"
   when 'calendars' then "https://calendars.#{app_domain}/bank-holidays"
   when 'contacts' then "https://www.#{app_domain}/contact/hm-revenue-customs"


### PR DESCRIPTION
We don't have any end-to-end monitoring that checks whether the internal hostname for assets is functioning as we expect.

The canary is the only route I can think of which will remain stable on the assets hostname.