### PR TITLE
[#104329818] Add monitoring for GOVUK_WEBSITE_ROOT

### DIFF
--- a/features/gov_uk.feature
+++ b/features/gov_uk.feature
@@ -5,3 +5,10 @@ Feature: Core GOV.UK behaviour
     When I visit "https://www.gov.uk/browse/benefits/" without following redirects
     Then I should get a 301 status code
     And I should get a location of "/browse/benefits"
+
+  @normal
+  Scenario: Crown logo links to GOV.UK homepage
+    Given I am testing through the full stack
+    And I force a varnish cache miss
+    When I visit "/"
+    Then the logo should link to the homepage

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -151,6 +151,11 @@ When /^I try to post to "(.*)" with "(.*)"$/ do |path, payload|
   @response = post_request "#{@host}#{path}", :payload => "#{payload}"
 end
 
+Then /^the logo should link to the homepage$/ do
+  logo = Nokogiri::HTML.parse(@response.body).at_css('#logo')
+  logo.attributes['href'].value.should == ENV['EXPECTED_GOVUK_WEBSITE_ROOT']
+end
+
 Then /^I should see some search results$/ do
   result_links = Nokogiri::HTML.parse(@response.body).css(".results-list li a")
   result_links.count.should >= 1

--- a/features/step_definitions/travel_advice_steps.rb
+++ b/features/step_definitions/travel_advice_steps.rb
@@ -1,0 +1,4 @@
+Then /^the XML ID is formed from the correct URL$/ do
+  first_entry_id = Nokogiri::XML.parse(@response.body).at_xpath('/xmlns:feed/xmlns:entry[1]/xmlns:id')
+  first_entry_id.text.should start_with("#{ENV['EXPECTED_GOVUK_WEBSITE_ROOT']}/foreign-travel-advice/ireland")
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -7,5 +7,12 @@ require 'plek'
 ENV["GOVUK_WEBSITE_ROOT"] ||= "https://www.preview.alphagov.co.uk"
 ENV["GOVUK_DRAFT_WEBSITE_ROOT"] ||= Plek.find('draft-origin')
 
+case ENV["GOVUK_WEBSITE_ROOT"]
+when "https://www.preview.alphagov.co.uk", "https://www-origin.staging.publishing.service.gov.uk"
+  ENV["EXPECTED_GOVUK_WEBSITE_ROOT"] = ENV["GOVUK_WEBSITE_ROOT"]
+else
+  ENV["EXPECTED_GOVUK_WEBSITE_ROOT"] = 'https://www.gov.uk'
+end
+
 Capybara.default_driver = :mechanize
 Capybara.app_host = ENV["GOVUK_WEBSITE_ROOT"]

--- a/features/travel_advice.feature
+++ b/features/travel_advice.feature
@@ -23,3 +23,8 @@ Feature: Travel Advice
       | Path                                   |
       | /foreign-travel-advice.atom            |
       | /foreign-travel-advice/luxembourg.atom |
+
+  @normal
+  Scenario: Country feed should contain correct website root
+    When I visit "/foreign-travel-advice/ireland.atom"
+    Then the XML ID is formed from the correct URL


### PR DESCRIPTION
We had an incident recently where we accidentally changed the content of travel advice feeds which caused GovDelivery to send email alerts when there were no actual updates.

This commit tests that the GOVUK_WEBSITE_ROOT environment variable is configured correctly on our machines. In preview and staging the expected value is always equal to the actual value. This test is only valuable in production where it makes sure that the website root is set to `https://www.gov.uk`.

I've also had to add a new step definition to include the value of the environment variable which I'm not particularly happy about but it's the best I've come up with so far.

---

I'm not particularly happy with any of this code which is probably an indication that it's the wrong approach to be taking. If anyone has any better ideas for monitoring that the website root is set correctly in production I would really like to hear them.