### PR TITLE
Make mechanize use the RATE_LIMIT_TOKEN if set.

### DIFF
--- a/features/support/mechanize.rb
+++ b/features/support/mechanize.rb
@@ -1,0 +1,8 @@
+Before do
+  page.driver.browser.agent.pre_connect_hooks << proc { |agent, request|
+    rate_limit_token = ENV['RATE_LIMIT_TOKEN']
+    if rate_limit_token
+      request["Rate-Limit-Token"] = rate_limit_token
+    end
+  }
+end


### PR DESCRIPTION
There are 2 ways of making http requests in smokey. One using
rest-client directly, and one using capybara with the mechanize driver.
The RATE_LIMIT_TOKEN had only been implemented for the rest-client
methods.

This adds the same for capyabra with mechanize.