### PR TITLE
Replace 'preview' references with 'integration'

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ or against a single `feature`:
 bundle exec cucumber features/frontend.feature
 ```
 
-The tests will run against the preview environment by default.  You can
+The tests will run against the integration environment by default.  You can
 override that by setting the `GOVUK_WEBSITE_ROOT` environment variable.
 
 You may also specify the domain of the draft website root using

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,9 @@
 require 'rubygems'
 require 'cucumber/rake/task'
 
-Cucumber::Rake::Task.new("test:preview",
-    "Run all tests that are valid in our preview environment") do |t|
-  t.cucumber_opts = %w{--format progress -t ~@pending -t ~@notpreview}
+Cucumber::Rake::Task.new("test:integration",
+    "Run all tests that are valid in our integration environment") do |t|
+  t.cucumber_opts = %w{--format progress -t ~@pending -t ~@notintegration}
 end
 
 Cucumber::Rake::Task.new("test:production",

--- a/features/efg.feature
+++ b/features/efg.feature
@@ -3,20 +3,20 @@ Feature: EFG
   Background:
     Given I am testing in an EFG context
 
-  @notpreview
+  @notintegration
   @normal
   Scenario: Requires authenticated user to view lenders
     When I try to access the list of lenders
     Then I should be on the EFG home page
 
-  @notpreview
+  @notintegration
   @normal
   Scenario: Quickly loading the EFG home page
     Given I am benchmarking
     When I visit the EFG home page
     Then the elapsed time should be less than 1 seconds
 
-  @notpreview
+  @notintegration
   @normal
   Scenario: Can log in
     When I try to login as a valid EFG user

--- a/features/support/base_urls.rb
+++ b/features/support/base_urls.rb
@@ -1,5 +1,5 @@
 def app_domain
-  ENV["GOVUK_APP_DOMAIN"] || "preview.alphagov.co.uk"
+  ENV["GOVUK_APP_DOMAIN"] || "integration.publishing.service.gov.uk"
 end
 
 def efg_base_url

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -4,11 +4,11 @@ require 'capybara/mechanize'
 require 'uri'
 require 'plek'
 
-ENV["GOVUK_WEBSITE_ROOT"] ||= "https://www.preview.alphagov.co.uk"
+ENV["GOVUK_WEBSITE_ROOT"] ||= "https://www-origin.integration.publishing.service.gov.uk"
 ENV["GOVUK_DRAFT_WEBSITE_ROOT"] ||= Plek.find('draft-origin')
 
 case ENV["GOVUK_WEBSITE_ROOT"]
-when "https://www.preview.alphagov.co.uk", "https://www-origin.staging.publishing.service.gov.uk"
+when "https://www-origin.integration.publishing.service.gov.uk", "https://www-origin.staging.publishing.service.gov.uk"
   ENV["EXPECTED_GOVUK_WEBSITE_ROOT"] = ENV["GOVUK_WEBSITE_ROOT"]
 else
   ENV["EXPECTED_GOVUK_WEBSITE_ROOT"] = 'https://www.gov.uk'

--- a/features/whitehall.feature
+++ b/features/whitehall.feature
@@ -8,7 +8,7 @@ Feature: Whitehall
     And I force a varnish cache miss
     Then I should see the departments and policies section on the homepage
 
-  @notpreview
+  @notintegration
   Scenario: There should be no authentication for Whitehall
     Given I am testing through the full stack
     And I force a varnish cache miss

--- a/manual_test/smokey.json
+++ b/manual_test/smokey.json
@@ -391,7 +391,7 @@
                 "description": "",
                 "tags": [
                     {
-                        "name": "@notpreview",
+                        "name": "@notintegration",
                         "line": 3
                     }
                 ],


### PR DESCRIPTION
The preview environment has been retired and replaced by the
integration environment in Dec 2015.

/cc @jamiecobbett 