### PR TITLE
Frontend tests: checks for content type

### DIFF
--- a/features/frontend.feature
+++ b/features/frontend.feature
@@ -43,7 +43,7 @@ Feature: Frontend
   Scenario: check local transactions load
     When I visit "/pay-council-tax"
     Then I should see "Pay your Council Tax"
-    When I try to post to "/pay-council-tax" with "postcode=WC2B+6SE" 
+    When I try to post to "/pay-council-tax" with "postcode=WC2B+6SE"
     Then I should see "London Borough of Camden"
 
   @normal

--- a/features/frontend.feature
+++ b/features/frontend.feature
@@ -31,6 +31,16 @@ Feature: Frontend
     Then I should see "Pension Credit"
 
   @normal
+  Scenario: check homepage content type & charset
+    When I visit "/"
+    Then I should get a Content-Type header of "text/html; charset=utf-8"
+
+  @normal
+  Scenario: check 404 page content type & charset
+    When I visit a non-existent page
+    Then I should get a Content-Type header of "text/html; charset=utf-8"
+
+  @normal
   Scenario: check licences load
     When I visit "/busking-licence"
     Then I should see "Busking licence"

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -59,6 +59,10 @@ When /^I visit "(.*)" (\d+) times$/ do |path, count|
   }
 end
 
+When /^I visit a non-existent page$/ do
+  @response = get_request("#{@host}/404", default_request_options.merge(return_response_on_error: true))
+end
+
 When /^I search for "(.*)" using tabbed search$/ do |term|
   @response = get_request("#{@host}/search?q=#{term}&ui=old", default_request_options)
 end
@@ -107,6 +111,10 @@ end
 
 Then /^I should get a (\d+) status code$/ do |status|
   @response.code.to_i.should == status.to_i
+end
+
+Then /^I should get a Content-Type header of "(.*)"$/ do |content_type|
+  @response.headers[:content_type].should == content_type
 end
 
 Then /^I should get a location of "(.*)"$/ do |location|

--- a/features/support/http_requests.rb
+++ b/features/support/http_requests.rb
@@ -95,12 +95,16 @@ def do_http_request(url, method = :get, options = {}, &block)
 rescue RestClient::Unauthorized => e
   raise "Unable to fetch '#{url}' due to '#{e.message}'. Maybe you need to set AUTH_USERNAME and AUTH_PASSWORD?"
 rescue RestClient::Exception => e
-  finished_at = Time.now
-  message = ["Unable to fetch '#{url}'"]
-  message += ["  Exception: '#{e}'"]
-  message += ["  Response headers: #{e.response.headers.inspect if e.response}"]
-  message += ["  Response time in seconds: #{finished_at - started_at}"]
-  raise message.join("\n")
+  if options[:return_response_on_error]
+    e.response
+  else
+    finished_at = Time.now
+    message = ["Unable to fetch '#{url}'"]
+    message += ["  Exception: '#{e}'"]
+    message += ["  Response headers: #{e.response.headers.inspect if e.response}"]
+    message += ["  Response time in seconds: #{finished_at - started_at}"]
+    raise message.join("\n")
+  end
 end
 
 def single_http_request(url)


### PR DESCRIPTION
This change involves adding another config option to the test helpers to prevent an exception being raised.

This adds coverage for https://github.com/alphagov/govuk-puppet/pull/3816 .

/cc @alexmuller @mattbostock 