### PR TITLE
Update frontend features

### DIFF
--- a/features/frontend.feature
+++ b/features/frontend.feature
@@ -13,22 +13,22 @@ Feature: Frontend
   @normal
   Scenario: check quick answers load
     When I visit "/vat-rates"
-    Then I should see "VAT rates"
+    Then I should see the heading "VAT rates"
 
   @normal
   Scenario: check guides load
     When I visit "/getting-an-mot"
-    Then I should see "Getting an MOT"
+    Then I should see the heading "Getting an MOT"
 
   @normal
   Scenario: check transactions load
     When I visit "/apply-renew-passport"
-    Then I should see "UK passport"
+    Then I should see the heading "UK passport"
 
   @normal
   Scenario: check benefit schemes load
     When I visit "/pension-credit"
-    Then I should see "Pension Credit"
+    Then I should see the heading "Pension Credit"
 
   @normal
   Scenario: check homepage content type & charset
@@ -43,18 +43,18 @@ Feature: Frontend
   @normal
   Scenario: check licences load
     When I visit "/busking-licence"
-    Then I should see "Busking licence"
+    Then I should see the heading "Busking licence"
      And I should see an input field for entering my postcode
     When I try to post to "/busking-licence" with "postcode=E20+2ST"
     Then I should get a 200 status code
-     And I should see "Busking licence"
+     And I should see the heading "Busking licence"
 
   @normal
   Scenario: check local transactions load
     When I visit "/pay-council-tax"
-    Then I should see "Pay your Council Tax"
+    Then I should see the heading "Pay your Council Tax"
     When I try to post to "/pay-council-tax" with "postcode=WC2B+6SE"
-    Then I should see "London Borough of Camden"
+    Then I should see the matched local authority "London Borough of Camden"
 
   @normal
   Scenario: check find my nearest returns results
@@ -66,7 +66,7 @@ Feature: Frontend
   Scenario: check find my nearest (places) load
     When I visit "/ukonline-centre-internet-access-computer-training"
     Then I should get a 200 status code
-    And I should see "UK online centres"
+    And I should see the heading "UK online centres"
 
   @normal
   Scenario: check campaign pages load
@@ -80,4 +80,4 @@ Feature: Frontend
     And I should see "Teaching people to drive"
     When I click on the section "Teaching people to drive"
     Then I should get a 200 status code
-    And I should see "Apply to become a driving instructor"
+    And I should see the link to "Apply to become a driving instructor"

--- a/features/frontend.feature
+++ b/features/frontend.feature
@@ -44,7 +44,7 @@ Feature: Frontend
   Scenario: check licences load
     When I visit "/busking-licence"
     Then I should see "Busking licence"
-     And I should see "Enter a postcode"
+     And I should see an input field for entering my postcode
     When I try to post to "/busking-licence" with "postcode=E20+2ST"
     Then I should get a 200 status code
      And I should see "Busking licence"

--- a/features/step_definitions/frontend_steps.rb
+++ b/features/step_definitions/frontend_steps.rb
@@ -9,3 +9,7 @@ Then /^I should see the services and information section on the homepage$/ do
   doc = Nokogiri::HTML(html)
   assert doc.css('#services-and-information')
 end
+
+Then /^I should see an input field for entering my postcode$/ do
+  @response.body.should have_field('postcode')
+end

--- a/features/step_definitions/frontend_steps.rb
+++ b/features/step_definitions/frontend_steps.rb
@@ -13,3 +13,15 @@ end
 Then /^I should see an input field for entering my postcode$/ do
   @response.body.should have_field('postcode')
 end
+
+Then /^I should see the heading "(.*?)"$/ do |title|
+  @response.body.should have_css('h1', text: title)
+end
+
+Then /^I should see the matched local authority "(.*?)"$/ do |local_authority|
+  @response.body.should have_css('span.local-authority', text: local_authority)
+end
+
+Then /^I should see the link to "(.*?)"$/ do |link|
+  @response.body.should have_link(link)
+end


### PR DESCRIPTION
For https://trello.com/c/l7ViHu5u/247-improve-frontend-smokey-tests-1-day

This is an attempt to make tests for entering a postcode less brittle by moving away from searching for the string of the label "Enter a postcode" and towards searching for the input field by class. That enables us to change the label text in the `frontend` app without breaking the smokey tests.

Additionally this PR attempts to make the `frontend` tests more accurate by specifying HTML elements as well as text when searching for an element on a page.