### PR TITLE
Remove check for enter postcode instruction

### DIFF
--- a/features/frontend.feature
+++ b/features/frontend.feature
@@ -44,7 +44,6 @@ Feature: Frontend
   Scenario: check licences load
     When I visit "/busking-licence"
     Then I should see "Busking licence"
-     And I should see "Enter a postcode"
     When I try to post to "/busking-licence" with "postcode=E20+2ST"
     Then I should get a 200 status code
      And I should see "Busking licence"


### PR DESCRIPTION
For https://trello.com/c/l7ViHu5u/247-improve-frontend-smokey-tests-1-day

This assertion is not required as the next assertion tests that the postcode form is present, and removing it allows us to change the "Enter a postcode" instruction text in the `frontend` app without having to update smokey tests.

The change is motivated to make the test less brittle. Initially we attempted to test with css selectors, but this was testing implementation which the individual apps should already do. See https://github.com/alphagov/smokey/pull/168