### PR TITLE
Update postcode form step to check for input element

### DIFF
--- a/features/frontend.feature
+++ b/features/frontend.feature
@@ -44,7 +44,7 @@ Feature: Frontend
   Scenario: check licences load
     When I visit "/busking-licence"
     Then I should see "Busking licence"
-     And I should see "Enter a postcode"
+     And I should see an input field for postcode
     When I try to post to "/busking-licence" with "postcode=E20+2ST"
     Then I should get a 200 status code
      And I should see "Busking licence"

--- a/features/step_definitions/frontend_steps.rb
+++ b/features/step_definitions/frontend_steps.rb
@@ -9,3 +9,7 @@ Then /^I should see the services and information section on the homepage$/ do
   doc = Nokogiri::HTML(html)
   assert doc.css('#services-and-information')
 end
+
+Then /^I should see an input field for postcode$/ do
+  @response.body.should have_field('postcode')
+end


### PR DESCRIPTION
For https://trello.com/c/l7ViHu5u/247-improve-frontend-smokey-tests-1-day

This is an attempt to make tests for entering a postcode less brittle by moving away from searching for the string of the label "Enter a postcode" and towards searching for the input field by class. That enables us to change the label text in the frontend app without breaking the smokey tests.

See discussion in https://github.com/alphagov/smokey/pull/169