### PR TITLE
Update licensify-admin Smokey search term

### DIFF
--- a/features/licensing.feature
+++ b/features/licensing.feature
@@ -24,4 +24,4 @@ Feature: Licensing
   Scenario: Signing in to licensify-admin
      When I try to login as a user
       And I login to Licensify
-     Then I should see "Tacit?"
+     Then I should see "There are no applications available for processing"


### PR DESCRIPTION
Smokey tests started to fail for licensify-admin for reasons not quite yet determined. Upon testing manually, the assigned user is able to login but is not presented with any applications. This appears to be
correct behaviour, but the search term that is specified is not present. This commit updates it to a specific term when that user logs in.

/cc @alexmuller who added the test in f5e48da4 to ensure that what we're seeing _is_ the correct behaviour.