### PR TITLE
Change search term for Smokey licensing test

### DIFF
--- a/features/licencefinder.feature
+++ b/features/licencefinder.feature
@@ -18,7 +18,7 @@ Feature: Licence Finder
     Given I am testing through the full stack
     And I force a varnish cache miss
     When I visit "/licence-finder/licences?activities=149&location=wales&sectors=59"
-    Then I should see "A premises licence is for carrying out 'licensable activities' at a particular venue"
+    Then I should see "Sign Out"
 
   @low
   Scenario: Quickly loading the licence finder home page


### PR DESCRIPTION
Someone added a test license so the search term changed again. Changed the search term to "Sign Out" which is present if one is logged in, but _shouldn't_ change if test licenses are added (and/or if there is a difference between Staging and Production).