### PR TITLE
Revert email campaign click_link

### DIFF
--- a/features/step_definitions/email_campaign_steps.rb
+++ b/features/step_definitions/email_campaign_steps.rb
@@ -29,7 +29,7 @@ end
 
 When /^I follow the link to the campaign$/ do
   mechanize_with_referer do
-    click_link 'www.gov.uk/lloydsshares', match: :first
+    click_link 'www.gov.uk/lloydsshares'
   end
 end
 


### PR DESCRIPTION
This reverts 7140dc737d9a243bf289e9683800f842d1491af8 which was done in relation to a Capybara 2 upgrade which has now also been reverted.