### PR TITLE
Add downcase feature

### DIFF
--- a/features/gov_uk.feature
+++ b/features/gov_uk.feature
@@ -12,3 +12,16 @@ Feature: Core GOV.UK behaviour
     And I force a varnish cache miss
     When I visit "/"
     Then the logo should link to the homepage
+
+  @normal
+  Scenario: entirely upper case slugs redirect to lowercase
+    Given I visit "/GOVERNMENT/PUBLICATIONS" without following redirects
+    Then I should get a 301 status code
+    And I should get a location of "/government/publications"
+
+  @normal
+  Scenario: partially upper case slugs do not redirect
+    When I try to visit "/government/publicatIONS"
+    Then I should get a 404 status code
+
+


### PR DESCRIPTION
Functionality has been added to the router LB that downcases URLs that are entirely in capitals. This PR adds checks that:

* Entirely upper case urls are 301 redirected to their lowercase equivalent
* Partially upper case urls are ignored

Part of [Trello](https://trello.com/c/CDpTRF1e/408-404s-caused-by-capitalisation-medium)