### PR TITLE
Make travel advice publisher scenario high priority

### DIFF
--- a/features/mainstream_publishing_tools.feature
+++ b/features/mainstream_publishing_tools.feature
@@ -26,6 +26,7 @@ Feature: Mainstream Publishing Tools
       And I should see "Sign out"
       And I should see "All services"
 
+  @high
   Scenario: Can log in to travel-advice-publisher
     When I go to the "travel-advice-publisher" landing page
     And I try to login as a user

--- a/features/mainstream_publishing_tools.feature
+++ b/features/mainstream_publishing_tools.feature
@@ -29,8 +29,8 @@ Feature: Mainstream Publishing Tools
   @high
   Scenario: Can log in to travel-advice-publisher
     When I go to the "travel-advice-publisher" landing page
-    And I try to login as a user
-    And I go to the "travel-advice-publisher" landing page
+      And I try to login as a user
+      And I go to the "travel-advice-publisher" landing page
     Then I should see "GOV.UK Travel Advice Publisher"
-    And I should see "Sign out"
-    And I should see "All countries"
+      And I should see "Sign out"
+      And I should see "All countries"


### PR DESCRIPTION
Travel advice is one of the critical parts of GOV.UK and we should be treating tests for it at least as urgently as those for other publishing applications.

This will make this scenario be run as part of the [`Run mainstream_publishing_tools high priority tests` Icinga check](https://alert.publishing.service.gov.uk/cgi-bin/icinga/extinfo.cgi?type=2&host=monitoring-1.management.publishing.service.gov.uk&service=Run+mainstream_publishing_tools+high+priority+tests) - it isn't being run from Icinga at the moment, only from Jenkins after deploys.

Should this scenario actually be `@urgent` given the importance of travel advice? Would that make us more likely to notice quickly if it's broken?