### PR TITLE
Add a scenario to test logging into local links manager

### DIFF
--- a/features/mainstream_publishing_tools.feature
+++ b/features/mainstream_publishing_tools.feature
@@ -34,3 +34,12 @@ Feature: Mainstream Publishing Tools
     Then I should see "GOV.UK Travel Advice Publisher"
       And I should see "Sign out"
       And I should see "All countries"
+
+  @high
+  Scenario: Can log in to local-links-manager
+    When I go to the "local-links-manager" landing page
+      And I try to login as a user
+      And I go to the "local-links-manager" landing page
+    Then I should see "Local Links Manager"
+      And I should see "Sign out"
+      And I should see "Local Authorities"


### PR DESCRIPTION
This app exists to maintain a dataset which will soon be used to power a
mainstream format, so I've put it in the `mainstream_publishing_tools` feature.