### PR TITLE
Ensure @host is present when calling the performance feature

### DIFF
--- a/features/performance_platform.feature
+++ b/features/performance_platform.feature
@@ -2,10 +2,12 @@ Feature: Performance Platform
 
   @high
   Scenario: Can visit the Performance Platform homepage
+    Given I am testing through the full stack
     When I visit "/performance"
     Then I should see "Performance"
     And I should see "Find performance data of government services"
 
   Scenario: Can visit a Performance Platform dashboard
+    Given I am testing through the full stack
     When I visit "/performance/register-to-vote"
     Then I should see "Voter registration"


### PR DESCRIPTION
'Given I am testing through the full stack' sets the `@host` variable
to the GOVUK_WEBSITE_ROOT environment variable