### PR TITLE
Upgrade cucumber to 1.2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem "plek", "1.11.0"
 gem "rake", "0.9.2.2"
 gem "rspec", "2.11.0"
 gem "minitest", "5.8.4"
-gem "cucumber", "1.2.1"
+gem "cucumber", "1.2.5"
 gem "capybara", "1.1.2"
 gem "capybara-mechanize", "0.3.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,11 +14,11 @@ GEM
       mechanize (~> 2.3)
     childprocess (0.5.9)
       ffi (~> 1.0, >= 1.0.11)
-    cucumber (1.2.1)
+    cucumber (1.2.5)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.3)
-      gherkin (~> 2.11.0)
-      json (>= 1.4.6)
+      gherkin (~> 2.11.7)
+      multi_json (~> 1.3)
     diff-lcs (1.1.3)
     domain_name (0.5.20160310)
       unf (>= 0.0.5, < 1.0.0)
@@ -27,7 +27,6 @@ GEM
       multi_json (~> 1.3)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
-    json (1.8.3)
     mechanize (2.7.3)
       domain_name (~> 0.5, >= 0.5.1)
       http-cookie (~> 1.0)
@@ -39,7 +38,7 @@ GEM
       webrobots (>= 0.0.9, < 0.2)
     mime-types (2.99.1)
     minitest (5.8.4)
-    multi_json (1.12.0)
+    multi_json (1.12.1)
     net-http-digest_auth (1.4)
     net-http-persistent (2.9.4)
     nokogiri (1.5.5)
@@ -78,7 +77,7 @@ PLATFORMS
 DEPENDENCIES
   capybara (= 1.1.2)
   capybara-mechanize (= 0.3.0)
-  cucumber (= 1.2.1)
+  cucumber (= 1.2.5)
   minitest (= 5.8.4)
   nokogiri (= 1.5.5)
   plek (= 1.11.0)
@@ -87,4 +86,4 @@ DEPENDENCIES
   rspec (= 2.11.0)
 
 BUNDLED WITH
-   1.11.2
+   1.12.5


### PR DESCRIPTION
This removes these deprecation warnings:

```
[DEPRECATION] "eval" is deprecated. Please use "evaluate" instead
```

https://github.com/cucumber/cucumber-ruby/blob/master/History.md#125