### PR TITLE
Fix gov_uk.feature

### DIFF
--- a/features/gov_uk.feature
+++ b/features/gov_uk.feature
@@ -15,12 +15,16 @@ Feature: Core GOV.UK behaviour
 
   @normal
   Scenario: entirely upper case slugs redirect to lowercase
-    Given I visit "/GOVERNMENT/PUBLICATIONS" without following redirects
+    Given I am testing through the full stack
+    And I force a varnish cache miss
+    When I visit "/GOVERNMENT/PUBLICATIONS" without following redirects
     Then I should get a 301 status code
-    And I should get a location of "/government/publications"
+    And I should be at a location path of "/government/publications"
 
   @normal
   Scenario: partially upper case slugs do not redirect
+    Given I am testing through the full stack
+    And I force a varnish cache miss
     When I try to visit "/government/publicatIONS"
     Then I should get a 404 status code
 

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -145,6 +145,10 @@ Then /^I should see "(.*)"$/ do |content|
   end
 end
 
+Then /^I should be at a location path of "(.*)"$/ do |location_path|
+  @response['location'].should == "#{@host}#{location_path}"
+end
+
 When /^I click "(.*?)"$/ do |link_text|
   link_href = Nokogiri::HTML.parse(@response.body).at_xpath("//a[text()='#{link_text}']/@href")
   link_href.should_not == nil


### PR DESCRIPTION
The recent features added to test the 'downcase all caps urls' functionality added in https://github.com/alphagov/govuk-puppet/pull/4573 were broken. This commit updates adds some steps to ensure the correct host is added and that the location is correctly checked.