### PR TITLE
[DO NOT MERGE] Add test for query parameters on the mirrors

### DIFF
--- a/features/mirror.feature
+++ b/features/mirror.feature
@@ -13,6 +13,12 @@ Feature: Mirror
       Then I should get a 503 response from "/search" on the mirrors
       And I should see "Sorry, we are experiencing technical difficulties"
 
+    @normal
+    Scenario: Check that requests with query parameters return an error
+      Given there are 2 mirror providers
+      Then I should get a 503 response from "/search?q=government" on the mirrors
+      And I should see "Sorry, we are experiencing technical difficulties"
+
     @high
     Scenario: Check homepage is served by all the mirrors
       Given there are 2 mirrors and 2 providers


### PR DESCRIPTION
We're unable to serve dynamic content from the static mirrors so we force every request with a query string to return a 503 error.