### PR TITLE
Make Local Transaction test less brittle

### DIFF
--- a/features/frontend.feature
+++ b/features/frontend.feature
@@ -54,7 +54,7 @@ Feature: Frontend
     When I visit "/pay-council-tax"
     Then I should see "Pay your Council Tax"
     When I try to post to "/pay-council-tax" with "postcode=WC2B+6SE"
-    Then I should see "London Borough of Camden"
+    Then I should see "Camden"
 
   @normal
   Scenario: check find my nearest returns results


### PR DESCRIPTION
This test uses a specific name for London Borough of Camden / Camden Borough
Council to verify the test.  We get council names from a variety of sources
and we want to somewhat insulate the test from the fact that these names change
from time to time.  

We are in the middle of switching from Publisher to Local Links Manager as the data source for Local Transaction links, and the data in each is slightly different due to the original sources disagreeing.