### PR TITLE
Update error message assertion in mirror feature

### DIFF
--- a/features/mirror.feature
+++ b/features/mirror.feature
@@ -11,7 +11,7 @@ Feature: Mirror
     Scenario: Check that search returns an error on the load-balanced mirrors
       Given there are 2 mirror providers
       Then I should get a 503 response from "/search" on the mirrors
-      And I should see "Sorry, we are experiencing technical difficulties"
+      And I should see a technical difficulties message
 
     @high
     Scenario: Check homepage is served by all the mirrors
@@ -29,10 +29,10 @@ Feature: Mirror
     Scenario: Check a non-existent page returns a service-unavailable error from all the mirrors
       Given there are 2 mirrors and 2 providers
       Then I should get a 503 response from "/jasdu3jjasd" on the mirrors
-      And I should see "Sorry, we are experiencing technical difficulties"
+      And I should see a technical difficulties message
 
     @high
     Scenario: Check that search returns an error on all the mirrors
       Given there are 2 mirrors and 2 providers
       Then I should get a 503 response from "/search" on the mirrors
-      And I should see "Sorry, we are experiencing technical difficulties"
+      And I should see a technical difficulties message

--- a/features/step_definitions/mirror_steps.rb
+++ b/features/step_definitions/mirror_steps.rb
@@ -25,3 +25,9 @@ Then /^I should get a (\d+) response from "(.*)" on the mirrors$/ do |status, pa
     @responses << response
   end
 end
+
+Then /^I should see a technical difficulties message$/ do
+  @responses.each do |response|
+    expect(response.body).to include("Sorry, we're experiencing technical difficulties")
+  end
+end


### PR DESCRIPTION
Why?

From 2ea193e in static, we contract "we are" to "we're" on the 503
page.

How?

- Update the error string we check for in the mirror scenarios.
- Refactor into a single step definition, rather than repeating the
  string multiple times in the feature file.