### PR TITLE
Visit a different endpoint for content-api

### DIFF
--- a/features/content_api.feature
+++ b/features/content_api.feature
@@ -4,6 +4,6 @@ Feature: Content API
 Scenario: (Public) Content API availability
   Given I am testing through the full stack
   And I force a varnish cache miss
-  When I visit "/api/tags.json"
+  When I visit "/api/vehicle-tax.json"
   Then I should get a 200 status code
-  And I should see "Business Link"
+  And I should see "Tax your vehicle"


### PR DESCRIPTION
/api/tags.json is scheduled for retirement. This changes the smokey test to test for a different endpoint instead. /vehicle-tax seems a stable page since it's linked from the homepage.

https://trello.com/c/jvuqHiS7