### PR TITLE
Fix the Trade Tariff search

### DIFF
--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -97,11 +97,13 @@ end
 
 Then /^I should be able to search the tariff and see matching results$/ do
   %w(animal mineral vegetable).each do |query|
-    expected_url = "/trade-tariff/search?t=#{query}"
-    expected_search_results_text = %r(Search results for (?:‘|')#{query}(?:’|'))
+    visit("/trade-tariff/sections")
 
-    should_visit(expected_url)
-    should_see(expected_search_results_text)
+    fill_in("search_t", with: query)
+    click_button("Search")
+
+    expected_search_results_text = %r(Search results for (?:‘|')#{query}(?:’|'))
+    expect(page.body).to have_content(expected_search_results_text)
   end
 end
 


### PR DESCRIPTION
It has changed from using a GET request to a POST request

We're not sure if this is supposed to be the case and this may need reverting if/when Trade Tariff is changed back to using GET.