### PR TITLE
Fix tariff search feature.

### DIFF
--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -96,6 +96,7 @@ Then /^I should be able to visit:$/ do |table|
 end
 
 Then /^I should be able to search the tariff and see matching results$/ do
+  page.driver.browser.agent.add_auth(@host, ENV['AUTH_USERNAME'], ENV['AUTH_PASSWORD'])
   %w(animal mineral vegetable).each do |query|
     visit("/trade-tariff/sections")
 


### PR DESCRIPTION
The URL requires basic auth which needs to be added manually since the
request doesn't go via the `get_request` method.