### PR TITLE
Add migrated finders to be tested

### DIFF
--- a/features/finder_frontend.feature
+++ b/features/finder_frontend.feature
@@ -1,0 +1,24 @@
+Feature: Finder Frontend
+  This are pages that have been migrated to a finder instead of index pages.
+
+  Background:
+    Given I am testing through the full stack
+    And I force a varnish cache miss
+
+  @normal
+  Scenario: check people page loads
+    When I visit "/government/people"
+    Then I should see "All ministers and senior officials on GOV.UK"
+    And I should see an input field to search
+
+  @normal
+  Scenario: check world organisations loads
+    When I visit "/government/world/organisations"
+    Then I should see "Worldwide organisations"
+    And I should see an input field to search
+
+  @normal
+  Scenario: check world organisations loads
+    When I visit "/government/groups"
+    Then I should see "Groups"
+    And I should see an input field to search

--- a/features/step_definitions/finder_frontend_steps.rb
+++ b/features/step_definitions/finder_frontend_steps.rb
@@ -1,0 +1,3 @@
+Then /^I should see an input field to search$/ do
+  @response.body.should have_field('keywords')
+end


### PR DESCRIPTION
Trello: https://trello.com/c/4J5oJ6CU/275-migrate-whitehall-index-pages-to-finders

Finding Things team has migrated some index pages to finders, this
commit makes sure those pages are tested through smokey.

- People finder
- World Organisations finder
- Groups finder

This commit depends on two PR's to be merged on Whitehall repository:

- https://github.com/alphagov/whitehall/pull/2831
- https://github.com/alphagov/whitehall/pull/2832