### PR TITLE
Fix place postcode request test

### DIFF
--- a/features/frontend.feature
+++ b/features/frontend.feature
@@ -58,7 +58,7 @@ Feature: Frontend
 
   @normal
   Scenario: check find my nearest returns results
-    When I try to post to "/ukonline-centre-internet-access-computer-training.json" with "postcode=WC2B+6NH"
+    When I try to submit to "/ukonline-centre-internet-access-computer-training.json" with "postcode=WC2B+6NH"
     Then I should get a 200 status code
     And I should see "Holborn Library"
 

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -165,6 +165,10 @@ When /^I try to post to "(.*)" with "(.*)"$/ do |path, payload|
   @response = post_request "#{@host}#{path}", :payload => "#{payload}"
 end
 
+When /^I try to submit to "(.*)" with "(.*)"$/ do |path, payload|
+  @response = get_request "#{@host}#{path}", :payload => "#{payload}"
+end
+
 Then /^the logo should link to the homepage$/ do
   logo = Nokogiri::HTML.parse(@response.body).at_css('#logo')
   logo.attributes['href'].value.should == ENV['EXPECTED_GOVUK_WEBSITE_ROOT']


### PR DESCRIPTION
Frontend now uses a GET request when the user searches for a postcode (not a POST request anymore). This commit makes the smokey tests pass again.