### PR TITLE
Remove quotes from the PROFILE parameter expansion

### DIFF
--- a/tests_json_output.sh
+++ b/tests_json_output.sh
@@ -26,6 +26,6 @@ fi
 
 rm -f ${TMP_FILE}
 /usr/local/bin/govuk_setenv default \
-    bundle exec cucumber --format json ${PROFILE:-""} \
+    bundle exec cucumber --format json ${PROFILE:-} \
         -t ~@pending -t ~@disabled_in_icinga > ${TMP_FILE} || true
 mv ${TMP_FILE} ${CACHE_FILE}


### PR DESCRIPTION
Including the quotes meant that cucumber received an argument of the empty
string, which caused it to crash. I don't quite understand why, but just
removing the quotes means that no argument is included, and cucumber executes
successfully.