### PR TITLE
Allow EFG to be slower

### DIFF
--- a/features/efg.feature
+++ b/features/efg.feature
@@ -14,11 +14,10 @@ Feature: EFG
   Scenario: Quickly loading the EFG home page
     Given I am benchmarking
     When I visit the EFG home page
-    Then the elapsed time should be less than 1 seconds
+    Then the elapsed time should be less than 10 seconds
 
   @notintegration
   @normal
   Scenario: Can log in
     When I try to login as a valid EFG user
     Then I should be on the EFG post-login page
-


### PR DESCRIPTION
Smokey has been failing regularly on this test. We've never noticed before, but now we do since we've started posting the smokey failures in slack.

This bumps the threshold for "slow" requests to EFG to 10 seconds. I think we should possibly get rid of all benchmarking in smokey, but this is a start.

Example:

https://deploy.publishing.service.gov.uk/job/Smokey/4157/console