### PR TITLE
Update Smokey tests for Design Principles

### DIFF
--- a/features/design_principles.feature
+++ b/features/design_principles.feature
@@ -11,19 +11,6 @@ Feature: Design Principles
     And I should see "Start with user needs"
 
   @normal
-  Scenario: check Service Manual
-    When I visit "/service-manual"
-    Then I should get a 200 status code
-    And I should see "Government Service Design Manual"
-
-  @normal
-  Scenario: check Service Manual search
-    When I visit "/service-manual/search?q=alpha"
-    Then I should get a 200 status code
-    And I should see "alpha"
-    And I should see some search results
-
-  @normal
   Scenario: check Transformation dashboard
     When I visit "/transformation"
     Then I should get a 200 status code

--- a/features/service_manual.feature
+++ b/features/service_manual.feature
@@ -4,6 +4,11 @@ Feature: Service Manual
     Given I am testing through the full stack
     And I force a varnish cache miss
 
+  Scenario: check Service Manual
+    When I visit "/service-manual"
+    Then I should see "Service Manual"
+    And I should get a 200 status code
+
   Scenario: Visiting a topic page
     When I visit "/service-manual/agile-delivery"
     Then I should see "Agile delivery"


### PR DESCRIPTION
`design-principles` is no longer involved in serving the service manual – it’s entirely served by `service-manual-frontend`. Move the service manual homepage test from the design principles feature to the service manual feature.

Additionally, the search for the service manual is now handled by the global `/search` in combination with `filter_manual` so this does not need to be tested separately.