### PR TITLE
Fix intermittent test failures with auth

### DIFF
--- a/features/private_frontend.feature
+++ b/features/private_frontend.feature
@@ -1,10 +1,7 @@
 Feature: Private Frontend
 
-  Background:
-    Given I am testing "private-frontend"
-    And I am not an authenticated user
-
   @normal
   Scenario: check private frontend requires auth
-    When I try to visit "/"
+    Given I am testing "private-frontend"
+    When I visit "/" without authentication
     Then I should get a 401 status code

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -16,10 +16,6 @@ Given /^I force a varnish cache miss$/ do
   @bypass_varnish = true
 end
 
-Given /^I am not an authenticated user$/ do
-  @authenticated = false
-end
-
 Given /^I am an authenticated API client$/ do
   @authenticated_as_client = true
 end
@@ -40,6 +36,10 @@ end
 
 When /^I visit "(.*)"$/ do |path_or_url|
   visit_path path_or_url
+end
+
+When /^I visit "(.*)" without authentication$/ do |path_or_url|
+  visit_without_auth path_or_url
 end
 
 When /^I try to visit "(.*)"$/ do |path_or_url|

--- a/features/support/visiting_pages.rb
+++ b/features/support/visiting_pages.rb
@@ -14,3 +14,13 @@ def visit_path(path)
 
   page.driver.error_messages.should == []
 end
+
+def visit_without_auth(path)
+  if path.match(%r[\?])
+    visit "#{path}&cachebust=#{rand.to_s}"
+  else
+    visit "#{path}?cachebust=#{rand.to_s}"
+  end
+
+  page.driver.error_messages.should == []
+end

--- a/features/whitehall.feature
+++ b/features/whitehall.feature
@@ -12,7 +12,6 @@ Feature: Whitehall
   Scenario: There should be no authentication for Whitehall
     Given I am testing through the full stack
     And I force a varnish cache miss
-    And I am not an authenticated user
     Then I should be able to view policies
     And I should be able to view announcements
     And I should be able to view publications


### PR DESCRIPTION
Our `visit_path` step sets up basic auth by default now, which means we get false positives for visiting authenticated pages.

This removes the misleading step and makes sure we test correctly.

https://trello.com/c/WIunrfiT