### PR TITLE
Remove duplicate tag in runner script.

### DIFF
--- a/tests_json_output.sh
+++ b/tests_json_output.sh
@@ -27,5 +27,5 @@ fi
 rm -f ${TMP_FILE}
 /usr/local/bin/govuk_setenv default \
     bundle exec cucumber --format json ${PROFILE:-} \
-        -t ~@pending -t ~@disabled_in_icinga > ${TMP_FILE} || true
+        -t ~@disabled_in_icinga > ${TMP_FILE} || true
 mv ${TMP_FILE} ${CACHE_FILE}


### PR DESCRIPTION
The `@pending` tag is specified in the yaml configuration and also in
the command-line options that are passed from tests_json_output.sh. It
seems that specifying a tag twice causes Cucumber to skip all tests.
Removing the duplicate fixes the problem.