### PR TITLE
[Do not merge] Fix teardown for ignoring JS errors

### DIFF
--- a/features/javascript_errors.feature
+++ b/features/javascript_errors.feature
@@ -1,5 +1,11 @@
 Feature: Smokey Javascript Error detection
 
+  # This test checks that the @ignore_javascript_errors successfully ignores JavaScript errors. It is placed before
+  # the JS error detection test to ensure that it is also correctly torn down
+  @ignore_javascript_errors
+  Scenario: Ignore JS errors with the correct tag
+    When I inject a JavaScript error on the page, Smokey does not raise an exception
+
   @normal
   Scenario: Smokey detects JS errors
     When I inject a JavaScript error on the page, Smokey raises an exception

--- a/features/licensing.feature
+++ b/features/licensing.feature
@@ -1,11 +1,10 @@
 Feature: Licensing
 
-  @normal @notintegration
+  @normal @notintegration @ignore_javascript_errors
   Scenario: check licensing app is present
     Given I am testing "licensing"
       And I am testing through the full stack
       And I force a varnish cache miss
-      And I am ignoring JavaScript errors
     Then I should be able to visit:
       | Path                                                              |
       | /apply-for-a-licence/test-licence/westminster/apply-1             |

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -24,10 +24,6 @@ Given /^I am an authenticated API client$/ do
   @authenticated_as_client = true
 end
 
-Given /^I am ignoring JavaScript errors$/ do
-  page.driver.browser.js_errors = false
-end
-
 When /^I go to the "([^"]*)" landing page$/ do |app_name|
   visit_path application_base_url(app_name)
 end
@@ -213,6 +209,17 @@ def random_path_selection(opts={})
   anchor_tags.map { |anchor| anchor.attributes["href"].value }.sample(size)
 end
 
-When /^I inject a JavaScript error on the page, Smokey raises an exception$/ do
-  expect { page.driver.execute_script('1.error') }.to raise_error
+When /^I inject a JavaScript error on the page, Smokey( does not)? raises? an exception$/ do |no_exception|
+  should_raise_exception = no_exception.nil?
+  if should_raise_exception
+    expect { page.driver.execute_script('1.error') }.to raise_error
+  end
+end
+
+Before('@ignore_javascript_errors') do
+  page.driver.browser.js_errors = false
+end
+
+After('@ignore_javascript_errors') do
+  page.driver.browser.js_errors = true
 end


### PR DESCRIPTION
A previous step was introduced to ignore JavaScript errors, but this step did not correctly teardown (so _all_ subsequent tests also ignored JavaScript errors).

This change correctly tears down the error ignoring through the use of a tag, and adds a test to check this teardown.