### PR TITLE
Stop benchmarking in smoke tests

### DIFF
--- a/features/bouncer.feature
+++ b/features/bouncer.feature
@@ -3,8 +3,6 @@ Feature: Bouncer
   @high
   Scenario: Bouncer application is up
     Given I am testing "bouncer"
-    And I am benchmarking
     When I request "http://www.attorneygeneral.gov.uk" from Bouncer directly
     Then I should get a 301 status code
     And I should get a "Location" header of "https://www.gov.uk/government/organisations/attorney-generals-office"
-    And the elapsed time should be less than 2 seconds

--- a/features/businesssupportfinder.feature
+++ b/features/businesssupportfinder.feature
@@ -9,10 +9,3 @@ Feature: Business Support Finder
       | /business-finance-support-finder                                                                                              |
       | /business-finance-support-finder/search                                                                                       |
       | /business-finance-support-finder/search?support_types%5B%5D=finance&support_types%5B%5D=equity&support_types%5B%5D=grant&support_types%5B%5D=loan&support_types%5B%5D=expertise-and-advice&support_types%5B%5D=recognition-award&support_types_submitted=true&location=england&size=between-501-and-1000&sector=travel-and-leisure&stage=grow-and-sustain&commit=#filtered-results                          |
-
-  @low
-  Scenario: Quickly loading the business support finder home page
-    Given I am benchmarking
-    And I am testing through the full stack
-    When I visit "/business-finance-support-finder"
-    Then the elapsed time should be less than 1 seconds

--- a/features/licencefinder.feature
+++ b/features/licencefinder.feature
@@ -19,10 +19,3 @@ Feature: Licence Finder
     And I force a varnish cache miss
     When I visit "/licence-finder/licences?activities=149&location=wales&sectors=59"
     Then I should see "A premises licence is for carrying out 'licensable activities' at a particular venue"
-
-  @low
-  Scenario: Quickly loading the licence finder home page
-    Given I am benchmarking
-    And I am testing through the full stack
-    When I visit "/licence-finder"
-    Then the elapsed time should be less than 1 seconds

--- a/features/licensing.feature
+++ b/features/licensing.feature
@@ -12,15 +12,6 @@ Feature: Licensing
       | /apply-for-a-licence/forms/bury/test-licence/9999-7-1,0-1         |
 
   @normal @notintegration
-  Scenario: Loading a pdf in a reasonable amount of time
-    Given I am testing "licensing"
-      And I am benchmarking
-      And I am testing through the full stack
-      And I force a varnish cache miss
-    When I request "/apply-for-a-licence/forms/bury/test-licence/9999-7-1,0-1"
-    Then the elapsed time should be less than 10 seconds
-
-  @normal @notintegration
   Scenario: Signing in to licensify-admin
      When I try to login as a user
       And I login to Licensify

--- a/features/step_definitions/benchmark_steps.rb
+++ b/features/step_definitions/benchmark_steps.rb
@@ -1,7 +1,0 @@
-Given /^I am benchmarking$/ do
-  @scenario_start_time = Time.now
-end
-
-Then /^the elapsed time should be less than (\d+) seconds?$/ do |time|
-  (@scenario_start_time - Time.now).should > time.to_i * -1
-end

--- a/features/whitehall.feature
+++ b/features/whitehall.feature
@@ -93,23 +93,6 @@ Feature: Whitehall
       | /treasury                 |
       | /wales-office             |
 
-  @local-network
-  @low
-  Scenario: Whitehall frontend website should be fast
-    Given I am benchmarking
-    And I am testing through the full stack
-    And I force a varnish cache miss
-    When I visit "/government/how-government-works" on the "whitehall-frontend" application
-    Then the elapsed time should be less than 2 seconds
-
-  @normal
-  Scenario: Whitehall offers a world location API
-    Given I am benchmarking
-    And I am testing through the full stack
-    And I force a varnish cache miss
-    When I visit "/api/world-locations" on the "whitehall-admin" application
-    Then the elapsed time should be less than 2 seconds
-
   @normal
   Scenario: Whitehall assets are served
     Given I am testing through the full stack
@@ -120,7 +103,5 @@ Feature: Whitehall
   Scenario: National statistics release calendar is served
     Given I am testing through the full stack
     And I force a varnish cache miss
-    And I am benchmarking
     When I visit "/government/statistics/announcements"
     Then I should get a 200 status code
-    And the elapsed time should be less than 2 seconds


### PR DESCRIPTION
This is controversial - I'm totally fine with this not being merged. 

I believe we should not benchmark pages in smokey.

Firstly, because the tests are brittle and often fail. This erodes confidence in the tests, which leads people to ignore them. When something real breaks, we might not know. Perhaps intermittently failing tests are worse than no tests.

Secondly, smokey is not a good tool to verify the performance of an application. Slowdowns can have many causes. When smokey thinks something is too slow, we learn nothing about the cause.

Lastly, developers can't reasonably act on these alerts. We've seen dozens of smokey fails over the last months, since we started broadcasting failures on Slack. Nothing has happened to fix the underlying cause, probably because there's not actually a real problem here.