### PR TITLE
Don't run benchmarking tests after deploy

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,19 +4,19 @@ require 'cucumber/rake/task'
 Cucumber::Rake::Task.new("test:integration",
     "Run all tests that are valid in our integration environment") do |t|
   t.profile = "integration"
-  t.cucumber_opts = %w{--format progress}
+  t.cucumber_opts = %w{--format progress -t ~@benchmarking}
 end
 
 Cucumber::Rake::Task.new("test:staging",
                          "Run all tests that are valid in our staging environment") do |t|
   t.profile = "staging"
-  t.cucumber_opts = %w{--format progress}
+  t.cucumber_opts = %w{--format progress -t ~@benchmarking}
 end
 
 Cucumber::Rake::Task.new("test:production",
     "Run all tests that are valid in our production environment") do |t|
   t.profile = "production"
-  t.cucumber_opts = %w{--format progress}
+  t.cucumber_opts = %w{--format progress -t ~@benchmarking}
 end
 
 Cucumber::Rake::Task.new("test:notlocalnetwork",

--- a/features/bouncer.feature
+++ b/features/bouncer.feature
@@ -1,6 +1,7 @@
 Feature: Bouncer
 
   @high
+  @benchmarking
   Scenario: Bouncer application is up
     Given I am testing "bouncer"
     And I am benchmarking

--- a/features/businesssupportfinder.feature
+++ b/features/businesssupportfinder.feature
@@ -11,6 +11,7 @@ Feature: Business Support Finder
       | /business-finance-support-finder/search?support_types%5B%5D=finance&support_types%5B%5D=equity&support_types%5B%5D=grant&support_types%5B%5D=loan&support_types%5B%5D=expertise-and-advice&support_types%5B%5D=recognition-award&support_types_submitted=true&location=england&size=between-501-and-1000&sector=travel-and-leisure&stage=grow-and-sustain&commit=#filtered-results                          |
 
   @low
+  @benchmarking
   Scenario: Quickly loading the business support finder home page
     Given I am benchmarking
     And I am testing through the full stack

--- a/features/licencefinder.feature
+++ b/features/licencefinder.feature
@@ -21,6 +21,7 @@ Feature: Licence Finder
     Then I should see "A premises licence is for carrying out 'licensable activities' at a particular venue"
 
   @low
+  @benchmarking
   Scenario: Quickly loading the licence finder home page
     Given I am benchmarking
     And I am testing through the full stack

--- a/features/licensing.feature
+++ b/features/licensing.feature
@@ -11,7 +11,7 @@ Feature: Licensing
       | /apply-for-a-licence/test-licence/westminster/apply-1/form        |
       | /apply-for-a-licence/forms/bury/test-licence/9999-7-1,0-1         |
 
-  @normal @notintegration
+  @normal @notintegration @benchmarking
   Scenario: Loading a pdf in a reasonable amount of time
     Given I am testing "licensing"
       And I am benchmarking

--- a/features/whitehall.feature
+++ b/features/whitehall.feature
@@ -95,6 +95,7 @@ Feature: Whitehall
 
   @local-network
   @low
+  @benchmarking
   Scenario: Whitehall frontend website should be fast
     Given I am benchmarking
     And I am testing through the full stack
@@ -103,6 +104,7 @@ Feature: Whitehall
     Then the elapsed time should be less than 2 seconds
 
   @normal
+  @benchmarking
   Scenario: Whitehall offers a world location API
     Given I am benchmarking
     And I am testing through the full stack
@@ -117,6 +119,7 @@ Feature: Whitehall
     Then I should get a 200 status code
 
   @normal
+  @benchmarking
   Scenario: National statistics release calendar is served
     Given I am testing through the full stack
     And I force a varnish cache miss


### PR DESCRIPTION
The bechmarking tests often fail on jenkins because they're a bit flaky. In https://github.com/alphagov/smokey/pull/241 it was proposed to remove them altogether.

Because there's no other way of getting alerted for consistently poor performing pages, we agreed that the monitoring process (which runs smokey in a loop) will keep benchmarking. Jenkins will skip the tests, so that the after-deploy smoke tests don't fail as much.

@boffbowsh 