### PR TITLE
Disable GA in smokey apart from A/B tests

### DIFF
--- a/features/ab_testing.feature
+++ b/features/ab_testing.feature
@@ -15,7 +15,7 @@ Feature: A/B Testing
     When multiple new users visit "/help/ab-testing"
     Then we have shown them all versions of the AB test
 
-  @low @notintegration @notstaging
+  @withanalitics @low @notintegration @notstaging
   Scenario: check that an A/B test works
     Given there is an AB test setup
     And I am testing through the full stack

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -15,11 +15,25 @@ else
 end
 
 Capybara.app_host = ENV["GOVUK_WEBSITE_ROOT"]
-Capybara.default_driver = :poltergeist
+phantomjs_logger = File.open("log/phantomjs.log", "a")
+ANALYTICS_URL = 'https://www.google-analytics.com'
 
 Capybara.register_driver :poltergeist do |app|
   # TODO: We should log the output from PhantomJS. This is currently disabled
   # because the log format is causing errors with Monitoring
   # https://github.com/alphagov/smokey/pull/237
-  Capybara::Poltergeist::Driver.new(app, phantomjs_logger: File.open("log/phantomjs.log", "a"))
+  Capybara::Poltergeist::Driver.new(app, phantomjs_logger: phantomjs_logger).tap do |driver|
+    driver.browser.url_blacklist = [ANALYTICS_URL]
+  end
+end
+
+Capybara.default_driver = :poltergeist
+
+Around('@withanalitics') do |scenario, block|
+  current_url_blacklist = page.driver.browser.url_blacklist
+  page.driver.browser.url_blacklist = current_url_blacklist - ANALYTICS_URL
+
+  block.call
+
+  page.driver.browser.url_blacklist = current_url_blacklist
 end


### PR DESCRIPTION
This commit disables calls to GA from all smokey tests apart from the
A/B test where we need to make sure we submit events to GA.

Trello: https://trello.com/c/7ArY5dG6/421-don-t-load-google-analytics-in-smoke-tests