### PR TITLE
Bypass SSL certificate verification for mirror requests

### DIFF
--- a/features/step_definitions/mirror_steps.rb
+++ b/features/step_definitions/mirror_steps.rb
@@ -20,7 +20,11 @@ end
 Then /^I should get a (\d+) response from "(.*)" on the mirrors$/ do |status, path|
   @responses = []
   @hosts.each do |mirror_host|
-    response = try_get_request("#{mirror_host}#{path}", host_header: "www-origin.mirror.production.govuk.service.gov.uk")
+    response = try_get_request(
+      "#{mirror_host}#{path}",
+      host_header: "www-origin.mirror.production.govuk.service.gov.uk",
+      verify_ssl: false,
+    )
     response.code.should == status.to_i
     @responses << response
   end

--- a/features/support/http_requests.rb
+++ b/features/support/http_requests.rb
@@ -57,6 +57,7 @@ end
 def do_http_request(url, method = :get, options = {}, &block)
   defaults = {
     :auth => true,
+    :verify_ssl => true,
   }
   options = defaults.merge(options)
 
@@ -93,7 +94,8 @@ def do_http_request(url, method = :get, options = {}, &block)
     password: password,
     headers: headers,
     timeout: 10,
-    payload: options[:payload]
+    payload: options[:payload],
+    verify_ssl: options[:verify_ssl],
   ).execute &block
 rescue RestClient::Unauthorized => e
   raise "Unable to fetch '#{url}' due to '#{e.message}'. Maybe you need to set AUTH_USERNAME and AUTH_PASSWORD?"


### PR DESCRIPTION
SSL certificates for the mirrors are offloaded to Fastly. The change from rest-client 1.6.7 to 1.8.0 changed the default from bypassing SSL certificate verification to peer validation.