### PR TITLE
Test that we place users in B variant on new nav

### DIFF
--- a/features/collections.feature
+++ b/features/collections.feature
@@ -18,7 +18,6 @@ Feature: Collections
     Then I am in the "A" variant of the education navigation test
     And I stay on bucket "A" of the education navigation test when I keep visiting "/education-maintenance-allowance-ema"
 
-  @notstaging @notproduction
   Scenario: Using the accordion page
     Given I am in the "B" group for "EducationNavigation" AB testing
     When I visit "/education/special-educational-needs-and-disability-send-and-high-needs"

--- a/features/collections.feature
+++ b/features/collections.feature
@@ -1,5 +1,23 @@
 Feature: Collections
 
+  @notintegration @notstaging
+  Scenario: Automatic opt-in to the B variant from navigation pages without any
+    previous variant
+    Given I do not have any AB testing cookies set
+    And I am testing through the full stack
+    When I visit "/education"
+    Then I am in the "B" variant of the education navigation test
+    And I stay on bucket "B" of the education navigation test when I keep visiting "/education"
+
+  @notintegration @notstaging
+  Scenario: Don't automatically opt-in to B variant on content pages
+    that start with "education"
+    Given I am testing through the full stack
+    And I am in the "A" group for "EducationNavigation" AB testing
+    When I visit "/education-maintenance-allowance-ema"
+    Then I am in the "A" variant of the education navigation test
+    And I stay on bucket "A" of the education navigation test when I keep visiting "/education-maintenance-allowance-ema"
+
   @notstaging @notproduction
   Scenario: Using the accordion page
     Given I am in the "B" group for "EducationNavigation" AB testing

--- a/features/step_definitions/ab_testing_steps.rb
+++ b/features/step_definitions/ab_testing_steps.rb
@@ -8,8 +8,11 @@ Given(/^there is an AB test setup$/) do
 end
 
 Given(/^I do not have any AB testing cookies set$/) do
-  # Empty step.
-  # By default, no cookies are set.
+  assert_equal(
+    {},
+    page.driver.cookies,
+    "There should be no cookies set"
+  )
 end
 
 Given(/^I am in the "(A|B)" group for "(.*)" AB testing$/) do |test_group, ab_test|

--- a/features/step_definitions/collections_steps.rb
+++ b/features/step_definitions/collections_steps.rb
@@ -21,3 +21,31 @@ Then(/^I can(not)? see the accordion content for only the first item$/) do |cann
     end
   end
 end
+
+Then(/^I am in the "(.*?)" variant of the education navigation test$/) do |variant|
+  ab_cookie = page.driver.cookies["ABTest-EducationNavigation"]
+
+  assert_equal(
+    variant,
+    ab_cookie.value,
+    "We have been assigned to the incorrect variant"
+  )
+
+  assert(
+    ab_cookie.expires,
+    "Expected the cookie to have an expiry date"
+  )
+end
+
+Then(/^I stay on bucket "(A|B)" of the education navigation test when I keep visiting "(.*?)"$/) do |variant, path|
+  20.times do
+    response = visit path
+    education_ab_cookie = page.driver.cookies['ABTest-EducationNavigation']
+
+    assert_equal(
+      variant,
+      education_ab_cookie.value,
+      "The ABTest-EducationNavigation cookie value doesn't match"
+    )
+  end
+end


### PR DESCRIPTION
Regardless of a user having a cookie or not, when they go to the new
education pages in collections, they should be assigned to the B
variant.

These tests will verify that the VCL configuration is working as
expected.

This depends on https://github.com/alphagov/govuk-cdn-config/pull/35
being live.