### PR TITLE
Update the Travel Advice root page title

### DIFF
--- a/features/travel_advice.feature
+++ b/features/travel_advice.feature
@@ -15,7 +15,7 @@ Feature: Travel Advice
   Scenario: check a country page loads
     When I visit "/foreign-travel-advice/luxembourg"
     Then I should see "Luxembourg"
-    And I should see "Current travel advice"
+    And I should see "Summary"
 
   @normal
   Scenario: Feeds should be available for index and countries


### PR DESCRIPTION
The title of the root page has changed to Summary instead of
Current Travel Advice.