### PR TITLE
Remove private-frontend tests

### DIFF
--- a/features/private_frontend.feature
+++ b/features/private_frontend.feature
@@ -1,8 +1,0 @@
-Feature: Private Frontend
-
-  @normal
-  Scenario: check private frontend requires auth
-    Given I am testing "private-frontend"
-    And I am not an authenticated user
-    When I try to request "/"
-    Then I should get a 401 status code

--- a/features/support/base_urls.rb
+++ b/features/support/base_urls.rb
@@ -14,7 +14,6 @@ def application_base_url(app_name)
   when 'calendars' then "https://calendars.#{app_domain}/bank-holidays"
   when 'contacts' then "https://www.#{app_domain}/contact/hm-revenue-customs"
   when 'frontend' then "https://frontend.#{app_domain}/"
-  when 'private-frontend' then "https://private-frontend.#{app_domain}/"
   when 'imminence' then "https://imminence.#{app_domain}/"
   when 'licencefinder' then "https://licencefinder.#{app_domain}/licence-finder"
   when 'licensing' then "https://licensify.#{app_domain}/apply-for-a-licence"


### PR DESCRIPTION
Private-frontend is being turned off, so we remove private-frontend tests from `smokey`.

[Trello](https://trello.com/c/JYT9roQm/709-turn-off-private-frontend)