### PR TITLE
Fix Local Links Manager failures

### DIFF
--- a/features/mainstream_publishing_tools.feature
+++ b/features/mainstream_publishing_tools.feature
@@ -33,7 +33,7 @@ Feature: Mainstream Publishing Tools
       And I go to the "local-links-manager" landing page
     Then I should see "Local Links Manager"
       And I should see "Sign out"
-      And I should see "Local Authorities"
+      And I should see "Councils"
 
   @high
   Scenario: Can log in to manuals-publisher


### PR DESCRIPTION
- Since we changed the style of the homepage to be broken links
  instead of a list of LAs, this has been failing. Interestingly,
  I think this has only been failing in Integration, yet in the
  version of LLM we have in Production I can only see lowercase
  "local authorities" which does not fit with what the test is
  asking for (capitalised). Hmm.