### PR TITLE
Add Cucumber scenario for manuals-publisher

### DIFF
--- a/features/mainstream_publishing_tools.feature
+++ b/features/mainstream_publishing_tools.feature
@@ -34,3 +34,13 @@ Feature: Mainstream Publishing Tools
     Then I should see "Local Links Manager"
       And I should see "Sign out"
       And I should see "Local Authorities"
+
+  @high
+  Scenario: Can log in to manuals-publisher
+    When I go to the "manuals-publisher" landing page
+      And I try to login as a user
+      And I go to the "manuals-publisher" landing page
+    Then I should see "Manuals Publisher"
+      And I should see "Sign out"
+      And I should see "Your manuals"
+      And I should see "New manual"

--- a/features/support/base_urls.rb
+++ b/features/support/base_urls.rb
@@ -18,6 +18,7 @@ def application_base_url(app_name)
   when 'licencefinder' then "https://licencefinder.#{app_domain}/licence-finder"
   when 'licensing' then "https://licensify.#{app_domain}/apply-for-a-licence"
   when 'local-links-manager' then "https://local-links-manager.#{app_domain}"
+  when 'manuals-publisher' then "https://manuals-publisher.#{app_domain}"
   when 'public-contentapi' then "https://www.#{app_domain}/api/tags.json" # this should be changed to a Content API 'homepage' when we have one
   when 'publisher' then "https://publisher.#{app_domain}/admin"
   when 'signon' then "https://signon.#{app_domain}/"


### PR DESCRIPTION
This follows the pattern of the other publishing tests.

One of the motivations for adding a Smoke test was to catch the sort of timeout
problem we saw recently where the /manuals index page was taking too
long to load. Unfortunately, I don't think this test would've caught
that problem because the test signon user doesn't have any manuals to
load! Irrespective, I still think it's useful to have this sort of test
to ensure we get an early warning if we've really broken something.

The test signon user has the manuals-publisher permission. You can run
this test locally by using the signon credentials stored in the Smokey
job configuration in the integration Jenkins instance.

I've set the scenario as `@high` priority which means (if I understand [the
README][1] correctly) that it'll generate a pager alert if it fails. This
is the same priority as the other scenarios in this feature although
it's not obvious to me that it's definitely the right thing to do.

[1]:
https://github.com/alphagov/smokey/blob/master/README.md#prioritising-scenarios