### PR TITLE
Disable analytics before each scenario

### DIFF
--- a/features/ab_testing.feature
+++ b/features/ab_testing.feature
@@ -15,7 +15,7 @@ Feature: A/B Testing
     When multiple new users visit "/help/ab-testing"
     Then we have shown them all versions of the AB test
 
-  @withanalitics @low @notintegration @notstaging
+  @withanalytics @low @notintegration @notstaging
   Scenario: check that an A/B test works
     Given there is an AB test setup
     And I am testing through the full stack


### PR DESCRIPTION
This has the exception of 1 test case where we need to send an analytics
event, but it should disable Google Analytics across all other tests.

I've also added a User-Agent to poltergeist so that we can recognise
those requests, should we need to.

Finally, we will raise an error if the Google Analytics host is somehow
in the list of hosts from the driver's network traffic list. We don't
want for this to happen and there is a cucumber tag to enable it, in
case someone needs it (e.g. used for one A/B test).

This should fix issue #256

cc/ @tijmenb and @fofr 