### PR TITLE
Add test for related link overrides for A/B test

### DIFF
--- a/features/ab_testing.feature
+++ b/features/ab_testing.feature
@@ -25,3 +25,40 @@ Feature: A/B Testing
     And I can see the bucket I am assigned to
     And the bucket is reported to Google Analytics
     And I stay on the same bucket when I keep visiting "/help/ab-testing"
+
+  @notintegration @notstaging
+  Scenario Outline: show old related links for selected mainstream pages
+    Given I am testing through the full stack
+    And I am in the "B" group for "EducationNavigation" AB testing
+    When I visit "<mainstream_page>"
+    Then I am in the "B" variant of the education navigation test
+    And I can see the taxonomy beta tag
+    And I can see the taxonomy breadcrumbs
+    And I can see the old related links sidebar
+
+    Examples:
+      | mainstream_page                        |
+      | /nhs-bursaries                         |
+      | /student-finance-register-login        |
+      | /apply-online-for-student-finance      |
+      | /extra-money-pay-university            |
+      | /career-development-loans              |
+      | /travel-grants-students-england        |
+      | /parents-learning-allowance            |
+      | /social-work-bursaries                 |
+      | /adult-dependants-grant                |
+      | /disabled-students-allowances-dsas     |
+      | /apply-for-student-finance             |
+      | /childcare-grant                       |
+      | /postgraduate-loan                     |
+      | /repaying-your-student-loan            |
+      | /student-finance                       |
+      | /care-to-learn                         |
+      | /advanced-learner-loan                 |
+      | /dance-drama-awards                    |
+      | /teacher-training-funding              |
+      | /student-finance-for-existing-students |
+      | /funding-for-postgraduate-study        |
+      | /contact-student-finance-england       |
+      | /student-finance-forms                 |
+      | /student-finance-calculator            |

--- a/features/step_definitions/ab_testing_steps.rb
+++ b/features/step_definitions/ab_testing_steps.rb
@@ -70,6 +70,38 @@ Then(/^I stay on the same bucket when I keep visiting "(.*?)"$/) do |path|
   end
 end
 
+Then(/^I can see the old related links sidebar$/) do
+  refute(
+    page.has_selector?('.govuk-taxonomy-sidebar'),
+    "We should not be seeing the taxonomy sidebar for this page"
+  )
+
+  assert(
+    page.has_selector?('.govuk-related-items'),
+    "We should see the related links sidebar for this page"
+  )
+end
+
+Then(/^I can see the taxonomy beta tag$/) do
+  assert(
+    page.has_selector?(
+      '.govuk-beta-label',
+      text: /this is a test version of the layout of this page/i
+    ),
+    "There should be a beta tag on the page."
+  )
+end
+
+Then(/^I can see the taxonomy breadcrumbs$/) do
+  assert(
+    page.has_selector?(
+      '.govuk-breadcrumbs',
+      text: /education, training and skills/i
+    ),
+    "There should be a taxonomy breadcrumb on the page."
+  )
+end
+
 def ab_bucket page
   Nokogiri::HTML.parse(page).css(".ab-example-group").text.strip
 end


### PR DESCRIPTION
We have a bunch of overrides for related links on the new
Education Navigation A/B test in place across different apps. This is
hard to test in the apps as we mock requests/responses, and we've seen
it breaking when we moved the rendering app of some of those pages.

This test should be deleted once we have a solution for related links in
the new navigation.

Trello: https://trello.com/c/U6JKZN6s/115-make-sure-we-override-the-related-links-on-some-mainstream-content-that-was-recently-moved-to-government-frontend

cc/ @fofr 