### PR TITLE
Re-phrase draft tests for specialist-frontend

### DIFF
--- a/features/draft_environment.feature
+++ b/features/draft_environment.feature
@@ -19,14 +19,14 @@ Feature: Draft environment
     And the page should contain the draft watermark
 
   @draft
-  Scenario: visiting a specialist document served by specialist-frontend
+  Scenario: visiting a specialist document served by government-frontend
     When I try to login as a user
     And I attempt to visit a CMA case
     Then I should see "Competition and Markets Authority case"
     And the page should contain the draft watermark
 
   @draft
-  Scenario: visiting a manual served by specialist-frontend
+  Scenario: visiting a manual served by manuals-frontend
     When I try to login as a user
     And I attempt to visit a manual
     Then I should see "Content design"


### PR DESCRIPTION
* specialist documents are served by government-frontend
* manuals are served by manuals-fronted

The tests themselves don’t need to change.

Part of: https://trello.com/c/UM7aecOQ/194-final-stage-decomission-specialist-frontend-2