### PR TITLE
Remove Content API tests

### DIFF
--- a/features/content_api.feature
+++ b/features/content_api.feature
@@ -1,9 +1,0 @@
-Feature: Content API
-
-@high
-Scenario: (Public) Content API availability
-  Given I am testing through the full stack
-  And I force a varnish cache miss
-  When I request "/api/vehicle-tax.json"
-  Then I should get a 200 status code
-  And I should see "Tax your vehicle"

--- a/features/support/base_urls.rb
+++ b/features/support/base_urls.rb
@@ -19,7 +19,6 @@ def application_base_url(app_name)
   when 'licensing' then "https://licensify.#{app_domain}/apply-for-a-licence"
   when 'local-links-manager' then "https://local-links-manager.#{app_domain}"
   when 'manuals-publisher' then "https://manuals-publisher.#{app_domain}"
-  when 'public-contentapi' then "https://www.#{app_domain}/api/tags.json" # this should be changed to a Content API 'homepage' when we have one
   when 'publisher' then "https://publisher.#{app_domain}/admin"
   when 'signon' then "https://signon.#{app_domain}/"
   when 'smartanswers' then "https://smartanswers.#{app_domain}/calculate-your-maternity-pay"


### PR DESCRIPTION
We no longer support the Content API and officially there is no other
app using it.

Trello: https://trello.com/c/Uo9tfmSE/139-investigate-who-is-using-travel-advice-endpoints-on-content-api-in-production