### PR TITLE
[WIP] Add tests for Worldwide Taxonomy pages

### DIFF
--- a/features/collections_worldwide_taxonomy.feature
+++ b/features/collections_worldwide_taxonomy.feature
@@ -1,0 +1,21 @@
+Feature: Collections for Worldwide Taxonomy
+
+  Scenario: Using the accordion page
+    When I visit "/world/brazil"
+
+    Then I should be able to see the following accordion sections:
+      | Living abroad                              |
+      | Tax, benefits, pensions and working abroad |
+      | Coming to the UK                           |
+      | Travelling to Brazil                       |
+      | Trade and invest in the UK                 |
+      | Diplomacy and development                  |
+      | British Embassy or High Commission         |
+
+    And I cannot see any of the accordion content
+
+    When I toggle the first accordion section
+    Then I can see the accordion content for only the first item
+
+    When I toggle the first accordion section
+    Then I cannot see the accordion content for only the first item

--- a/features/step_definitions/collections_steps.rb
+++ b/features/step_definitions/collections_steps.rb
@@ -49,3 +49,12 @@ Then(/^I stay on bucket "(A|B)" of the education navigation test when I keep vis
     )
   end
 end
+
+Then(/^I should be able to see the following ordered accordion sections:$/) do |table|
+  section_titles = find('.js-subsection-title-link')
+  assert_equal(section_titles.count, table.hashes.length)
+
+  table.hashes.each_with_index do |row, index|
+    assert_equal(row, section_titles[index].val())
+  end
+end


### PR DESCRIPTION
For https://trello.com/c/ZTMqkw1Q/199-create-smokey-tests-for-the-taxonomy-navigation-pages

Test for presence and order of sibling taxons