### PR TITLE
Rewrite scenario outline as scenario

### DIFF
--- a/features/smartanswers.feature
+++ b/features/smartanswers.feature
@@ -1,21 +1,19 @@
 Feature: Smart Answers
 
   @normal
-  Scenario Outline: Check selected smart answer start pages
+  Scenario: Check selected smart answer start pages
     Given I am testing through the full stack
     And I force a varnish cache miss
-    When I visit "<smart_answer_start_page>"
-    Then I should get a 200 status code
-
-    Examples:
-      | smart_answer_start_page                     |
-      | /additional-commodity-code                  |
-      | /calculate-employee-redundancy-pay          |
-      | /calculate-married-couples-allowance        |
-      | /marriage-abroad                            |
-      | /pay-leave-for-parents                      |
-      | /register-a-death                           |
-      | /vat-payment-deadlines                      |
+    Then I should be able to visit:
+    | Path                                        |
+    | /additional-commodity-code                  |
+    | /calculate-employee-redundancy-pay          |
+    | /calculate-married-couples-allowance        |
+    | /marriage-abroad                            |
+    | /pay-leave-for-parents                      |
+    | /register-a-death                           |
+    | /vat-payment-deadlines                      |
+    And I should get a 200 status code
 
   @normal
   Scenario: step through a smart answer


### PR DESCRIPTION
Due to the @normal priority, this is one of the things that the
nagios_check_cache.py script checks, except, when this was changed to
an outline, the results don't appear to be included. This means that
the script breaks.

To fix this, change it back to an scenario. There is another example
of a scenario outline, but because it lacks a priority, it doesn't
break the script.