### PR TITLE
Add tests for the public API

### DIFF
--- a/features/publicapi.feature
+++ b/features/publicapi.feature
@@ -1,0 +1,38 @@
+Feature: Public API
+
+    Background:
+      Given I am testing through the full stack
+
+    @normal
+    Scenario: Check the search API returns data
+      When I request "/api/search.json"
+      Then I should get a 200 status code
+      And JSON is returned
+
+    @normal
+    Scenario: Check the content API returns data
+      Given I force a varnish cache miss
+      When I request "/api/content/help"
+      Then I should get a 200 status code
+      And JSON is returned
+
+    @normal
+    Scenario: Check the whitehall governments API returns data
+      Given I force a varnish cache miss
+      When I request "/api/governments"
+      Then I should get a 200 status code
+      And JSON is returned
+
+    @normal
+    Scenario: Check the whitehall organisations API returns data
+      Given I force a varnish cache miss
+      When I request "/api/organisations"
+      Then I should get a 200 status code
+      And JSON is returned
+
+    @normal
+    Scenario: Check the whitehall world locations API returns data
+      Given I force a varnish cache miss
+      When I request "/api/world-locations"
+      Then I should get a 200 status code
+      And JSON is returned

--- a/features/step_definitions/calendar_steps.rb
+++ b/features/step_definitions/calendar_steps.rb
@@ -1,5 +1,0 @@
-require 'json'
-
-Then /^JSON is returned$/ do
-  JSON.parse(@response.body).class.should == Hash
-end

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 Given /^I am testing "(.*)"/ do |host|
   if host.include? "://"
     @host = host
@@ -189,6 +191,10 @@ Then /^I should be able to navigate the browse pages$/ do
       visit_path path
     end
   end
+end
+
+Then /^JSON is returned$/ do
+  JSON.parse(@response.body).class.should == Hash
 end
 
 def random_path_selection(opts={})


### PR DESCRIPTION
This commit adds some tests to ensure the public API is available and returning JSON. It tests the search API, content API and the various whitehall APIs. It does not test whether the data returned by the APIs is correct.

It also moves the step definition for testing for JSON responses to a more generic file since it is now used in mutiple tests.