### PR TITLE
Rename content API to content store

### DIFF
--- a/features/publicapi.feature
+++ b/features/publicapi.feature
@@ -10,7 +10,7 @@ Feature: Public API
       And JSON is returned
 
     @normal
-    Scenario: Check the content API returns data
+    Scenario: Check the content store returns data
       Given I force a varnish cache miss
       When I request "/api/content/help"
       Then I should get a 200 status code


### PR DESCRIPTION
The content API no longer exists and the test is actually testing the content store.