### PR TITLE
Run A/B tests for sidebar overrides in all envs

### DIFF
--- a/features/ab_testing.feature
+++ b/features/ab_testing.feature
@@ -26,7 +26,6 @@ Feature: A/B Testing
     And the bucket is reported to Google Analytics
     And I stay on the same bucket when I keep visiting "/help/ab-testing"
 
-  @notintegration @notstaging
   Scenario Outline: show old related links for selected mainstream pages
     Given I am testing through the full stack
     And I am in the "B" group for "EducationNavigation" AB testing


### PR DESCRIPTION
We can run this test in all environments because it sets HTTP headers
besides setting the cookies, which means the A/B test works.

This will make sure we catch issues early on regarding the overrides on
related links.

This was related to an issue when migrating pages from smart-answers.

Relevant links:
- https://github.com/alphagov/frontend/pull/1261
- https://github.com/alphagov/smart-answers/pull/3134

Tested on:
- Integration: https://deploy.integration.publishing.service.gov.uk/job/Smokey/18193/console
- Staging: https://deploy.staging.publishing.service.gov.uk/job/Smokey/6367/console