### PR TITLE
Switch epic-cic to libraries-unlimited

### DIFF
--- a/features/draft_environment.feature
+++ b/features/draft_environment.feature
@@ -14,7 +14,7 @@ Feature: Draft environment
   @draft
   Scenario: visiting a page served by government-frontend
     When I try to login as a user
-    When I attempt to visit "government/case-studies/epic-cic"
+    When I attempt to visit "government/case-studies/libraries-unlimited"
     Then I should see "Case study"
     And the page should contain the draft watermark
 

--- a/features/government_frontend.feature
+++ b/features/government_frontend.feature
@@ -5,5 +5,5 @@ Feature: Government Frontend
     And I force a varnish cache miss
 
   Scenario:
-    When I visit "/government/case-studies/epic-cic"
+    When I visit "/government/case-studies/libraries-unlimited"
     Then I should see "Case study"


### PR DESCRIPTION
As the epic-cic page contains JavaScript from YouTube which errors
when tested through Smokey. The libraries-unlimited page is a case
study which does not have this JavaScript present.