### PR TITLE
Revert "Add test for related link overrides for A/B test"

### DIFF
--- a/features/ab_testing.feature
+++ b/features/ab_testing.feature
@@ -25,39 +25,3 @@ Feature: A/B Testing
     And I can see the bucket I am assigned to
     And the bucket is reported to Google Analytics
     And I stay on the same bucket when I keep visiting "/help/ab-testing"
-
-  Scenario Outline: show old related links for selected mainstream pages
-    Given I am testing through the full stack
-    And I am in the "B" group for "EducationNavigation" AB testing
-    When I visit "<mainstream_page>"
-    Then I am in the "B" variant of the education navigation test
-    And I can see the taxonomy beta tag
-    And I can see the taxonomy breadcrumbs
-    And I can see the old related links sidebar
-
-    Examples:
-      | mainstream_page                        |
-      | /nhs-bursaries                         |
-      | /student-finance-register-login        |
-      | /apply-online-for-student-finance      |
-      | /extra-money-pay-university            |
-      | /career-development-loans              |
-      | /travel-grants-students-england        |
-      | /parents-learning-allowance            |
-      | /social-work-bursaries                 |
-      | /adult-dependants-grant                |
-      | /disabled-students-allowances-dsas     |
-      | /apply-for-student-finance             |
-      | /childcare-grant                       |
-      | /postgraduate-loan                     |
-      | /repaying-your-student-loan            |
-      | /student-finance                       |
-      | /care-to-learn                         |
-      | /advanced-learner-loan                 |
-      | /dance-drama-awards                    |
-      | /teacher-training-funding              |
-      | /student-finance-for-existing-students |
-      | /funding-for-postgraduate-study        |
-      | /contact-student-finance-england       |
-      | /student-finance-forms                 |
-      | /student-finance-calculator            |

--- a/features/step_definitions/ab_testing_steps.rb
+++ b/features/step_definitions/ab_testing_steps.rb
@@ -70,38 +70,6 @@ Then(/^I stay on the same bucket when I keep visiting "(.*?)"$/) do |path|
   end
 end
 
-Then(/^I can see the old related links sidebar$/) do
-  refute(
-    page.has_selector?('.govuk-taxonomy-sidebar'),
-    "We should not be seeing the taxonomy sidebar for this page"
-  )
-
-  assert(
-    page.has_selector?('.govuk-related-items'),
-    "We should see the related links sidebar for this page"
-  )
-end
-
-Then(/^I can see the taxonomy beta tag$/) do
-  assert(
-    page.has_selector?(
-      '.govuk-beta-label',
-      text: /this is a test version of the layout of this page/i
-    ),
-    "There should be a beta tag on the page."
-  )
-end
-
-Then(/^I can see the taxonomy breadcrumbs$/) do
-  assert(
-    page.has_selector?(
-      '.govuk-breadcrumbs',
-      text: /education, training and skills/i
-    ),
-    "There should be a taxonomy breadcrumb on the page."
-  )
-end
-
 def ab_bucket page
   Nokogiri::HTML.parse(page).css(".ab-example-group").text.strip
 end


### PR DESCRIPTION
This reverts commit 87875255da41bc5b7eccd2a441dc01cba000e331.

Trello: https://trello.com/c/WrLDSJYm/26-deploy-new-curated-related-links-for-student-loans-content

Related PRs:
- [x] https://github.com/alphagov/government-frontend/pull/409
- [x] https://github.com/alphagov/frontend/pull/1266