### PR TITLE
Add youtube.com to Poltergeist's blacklist of URLs

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -18,7 +18,10 @@ Capybara.app_host = ENV["GOVUK_WEBSITE_ROOT"]
 phantomjs_logger = File.open("log/phantomjs.log", "a")
 
 GOOGLE_ANALYTICS_URL = 'www.google-analytics.com'
-BLACKLISTED_URLS = [GOOGLE_ANALYTICS_URL]
+BLACKLISTED_URLS = [
+  GOOGLE_ANALYTICS_URL,
+  'www.youtube.com'
+]
 
 Capybara.register_driver :poltergeist do |app|
   options = {


### PR DESCRIPTION
This fixes the intermittent error we've been seeing in the "check
Transformation dashboard" scenario of the "Design Principles" feature;
as reported in issue #279.

I ran the problematic scenario 10 times before this fix and 10 times
after:

    $ bundle exec cucumber features/design_principles.feature:14

I saw 6 failures and 4 successes before the fix and 10 successes
afterwards so I'm fairly confident this will solve the intermittent
failures we've been seeing.

Blacklisting youtube.com doesn't appear to negatively affect any of the
other scenarios.