### PR TITLE
Simplify URL blacklisting configuration

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -20,7 +20,10 @@ phantomjs_logger = File.open("log/phantomjs.log", "a")
 BLACKLISTED_URLS = ['www.google-analytics.com']
 
 Capybara.register_driver :poltergeist do |app|
-  Capybara::Poltergeist::Driver.new(app, phantomjs_logger: phantomjs_logger)
+  options = {
+    phantomjs_logger: phantomjs_logger
+  }
+  Capybara::Poltergeist::Driver.new(app, options)
 end
 
 Capybara.default_driver = :poltergeist

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -21,6 +21,7 @@ BLACKLISTED_URLS = ['www.google-analytics.com']
 
 Capybara.register_driver :poltergeist do |app|
   options = {
+    debug: ENV['POLTERGEIST_DEBUG'] || false,
     phantomjs_logger: phantomjs_logger
   }
   Capybara::Poltergeist::Driver.new(app, options)

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -44,10 +44,6 @@ After('~@withanalytics') do
   end
 end
 
-Around('@withanalytics') do |scenario, block|
+Before('@withanalytics') do |scenario, block|
   page.driver.browser.url_blacklist = []
-
-  block.call
-
-  page.driver.browser.url_blacklist = BLACKLISTED_URLS
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -34,16 +34,6 @@ Before do
   page.driver.add_headers('User-Agent' => 'Smokey')
 end
 
-After('~@withanalytics') do
-  uris = page.driver.network_traffic.map(&:url)
-  urls = uris.select { |uri| ['http', 'https'].include?(URI.parse(uri).scheme) }
-  hosts = urls.map { |url| URI.parse(url).host }.uniq.sort
-
-  if (BLACKLISTED_URLS - hosts).empty?
-    raise "We should not contact Google Analytics. Please use @withanalytics if you need to."
-  end
-end
-
 Before('@withanalytics') do |scenario, block|
   page.driver.browser.url_blacklist = []
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -29,9 +29,12 @@ end
 
 Capybara.default_driver = :poltergeist
 
+Before do
+  page.driver.add_headers('User-Agent' => 'Smokey')
+end
+
 Before('~@withanalytics') do
   page.driver.browser.url_blacklist = BLACKLISTED_URLS
-  page.driver.add_headers('User-Agent' => 'Smokey')
 end
 
 After('~@withanalytics') do

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -17,7 +17,8 @@ end
 Capybara.app_host = ENV["GOVUK_WEBSITE_ROOT"]
 phantomjs_logger = File.open("log/phantomjs.log", "a")
 
-BLACKLISTED_URLS = ['www.google-analytics.com']
+GOOGLE_ANALYTICS_URL = 'www.google-analytics.com'
+BLACKLISTED_URLS = [GOOGLE_ANALYTICS_URL]
 
 Capybara.register_driver :poltergeist do |app|
   options = {
@@ -35,5 +36,5 @@ Before do
 end
 
 Before('@withanalytics') do |scenario, block|
-  page.driver.browser.url_blacklist = []
+  page.driver.browser.url_blacklist = BLACKLISTED_URLS - [GOOGLE_ANALYTICS_URL]
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -22,7 +22,8 @@ BLACKLISTED_URLS = ['www.google-analytics.com']
 Capybara.register_driver :poltergeist do |app|
   options = {
     debug: ENV['POLTERGEIST_DEBUG'] || false,
-    phantomjs_logger: phantomjs_logger
+    phantomjs_logger: phantomjs_logger,
+    url_blacklist: BLACKLISTED_URLS
   }
   Capybara::Poltergeist::Driver.new(app, options)
 end
@@ -31,10 +32,6 @@ Capybara.default_driver = :poltergeist
 
 Before do
   page.driver.add_headers('User-Agent' => 'Smokey')
-end
-
-Before('~@withanalytics') do
-  page.driver.browser.url_blacklist = BLACKLISTED_URLS
 end
 
 After('~@withanalytics') do


### PR DESCRIPTION
This is a precursor to PR #280.

I want to add 'www.youtube.com' to the URL blacklist but doing so made it apparent that the current implementation was quite closely tied to blacklisting 'www.google-analytics.com'. I think/hope this change makes the intention of the URL blacklisting a bit clearer.

This builds upon both PR #245 and PR #260.
