### PR TITLE
Revert "Switch epic-cic to libraries-unlimited"

### DIFF
--- a/features/draft_environment.feature
+++ b/features/draft_environment.feature
@@ -14,7 +14,7 @@ Feature: Draft environment
   @draft
   Scenario: visiting a page served by government-frontend
     When I try to login as a user
-    When I attempt to visit "government/case-studies/libraries-unlimited"
+    When I attempt to visit "government/case-studies/epic-cic"
     Then I should see "Case study"
     And the page should contain the draft watermark
 

--- a/features/government_frontend.feature
+++ b/features/government_frontend.feature
@@ -5,5 +5,5 @@ Feature: Government Frontend
     And I force a varnish cache miss
 
   Scenario:
-    When I visit "/government/case-studies/libraries-unlimited"
+    When I visit "/government/case-studies/epic-cic"
     Then I should see "Case study"


### PR DESCRIPTION
Reverts alphagov/smokey#277

We can switch back to using a case study that includes a video thanks to #280.