### PR TITLE
Fix broken A/B test

### DIFF
--- a/features/step_definitions/ab_testing_steps.rb
+++ b/features/step_definitions/ab_testing_steps.rb
@@ -1,4 +1,4 @@
-GOOGLE_ANALYTICS_PAGE_VIEW_URL_MATCHER = %r{google-analytics.com/r/collect\?.*t=pageview}
+GOOGLE_ANALYTICS_PAGE_VIEW_URL_MATCHER = %r{google-analytics.com/collect\?.*t=pageview}
 
 Given(/^there is an AB test setup$/) do
   # Empty step.


### PR DESCRIPTION
This test was failing because the regexp didn't match the URL of the
request that's actually made to Google Analytics.

This failure only became apparent after merging PR #281. Prior to
merging this PR, this test wasn't running at all: It was failing in the
`Around('@withanalytics')` block when trying to set
`page.driver.browser.url_blacklist = []` as `page` is nil.

You can observe the problem by checking out the commit prior to PR #281
(`git checkout f069ccdf167483a34025a9313a7e42b48fe0ed76~`) and running
the test:

    $ GOVUK_WEBSITE_ROOT=https://www.gov.uk \
    bundle exec cucumber \
    --format pretty features/ab_testing.feature:19

    @withanalytics @low @notintegration @notstaging
    Scenario: check that an A/B test works # features/ab_testing.feature:19
    undefined local variable or method `page' for nil:NilClass (NameError)

    0 scenarios
    0 steps
    0m0.004s