### PR TITLE
Add test for Smart Answers country pickers

### DIFF
--- a/features/smartanswers.feature
+++ b/features/smartanswers.feature
@@ -51,3 +51,22 @@ Feature: Smart Answers
     | /marriage-abroad/y/sweden/uk                        |
     | /marriage-abroad/y/sweden/uk/partner_other          |
     | /marriage-abroad/y/sweden/uk/partner_other/same_sex |
+
+  @normal
+  Scenario Outline: Viewing countries in a select element
+    Given I am testing through the full stack
+    And I force a varnish cache miss
+    When I request "<Path>"
+    Then I should see a populated country select
+
+    Examples:
+      | Path                                                       |
+      | /check-uk-visa/y                                           |
+      | /help-if-you-are-arrested-abroad/y                         |
+      | /marriage-abroad/y                                         |
+      | /register-a-birth/y                                        |
+      | /register-a-birth/y/afghanistan/father/yes/another_country |
+      | /register-a-death/y/overseas                               |
+      | /register-a-death/y/overseas/afghanistan/another_country   |
+      | /report-a-lost-or-stolen-passport/y/abroad                 |
+      | /uk-benefits-abroad/y/going_abroad/child_benefit           |

--- a/features/step_definitions/smartanswers_steps.rb
+++ b/features/step_definitions/smartanswers_steps.rb
@@ -1,0 +1,8 @@
+Then /^I should see a populated country select$/ do
+  countries = Nokogiri::HTML.parse(@response.body)
+    .css(".question select option")
+
+  # Check that we have a sensible-looking number of countries, with
+  # some flex for that number to change
+  expect(countries.count).to be > 200
+end


### PR DESCRIPTION
Following an incident where the country pickers were showing no (or very
few) countries on Smart Answers, this change adds tests to check that
the dropdowns are populated with a sensible-looking number of elements.

This test is needed, because Smart Answers relies on getting countries
from Whitehall, so we should test this integration.

The tests check for the number of countries being greater than 200,
which should provide a sense check without requiring constant updating
of the list of countries every time Whitehall or Smart Answers changes.