### PR TITLE
Add Smart Answers Worldwide API Tests

### DIFF
--- a/features/smartanswers.feature
+++ b/features/smartanswers.feature
@@ -70,3 +70,16 @@ Feature: Smart Answers
       | /register-a-death/y/overseas/afghanistan/another_country   |
       | /report-a-lost-or-stolen-passport/y/abroad                 |
       | /uk-benefits-abroad/y/going_abroad/child_benefit           |
+
+  Scenario Outline: Country names are correctly formatted
+    Given I am testing through the full stack
+    And I force a varnish cache miss
+    When I request "<Path>"
+    Then I should see "<Expected string>"
+
+    Examples:
+      | Path                                                                         | Expected string                                    |
+      | /marriage-abroad/y/netherlands/ceremony_country/partner_british/opposite_sex | local authorities in the Netherlands               |
+      | /marriage-abroad/y/cayman-islands/uk/partner_british/opposite_sex            | The Cayman Islands is a British overseas territory |
+      | /register-a-birth/y/cayman-islands                                           | regulations in the Cayman Islands                  |
+      | /register-a-death/y/overseas/cayman-islands                                  | regulations in the Cayman Islands                  |

--- a/features/smartanswers.feature
+++ b/features/smartanswers.feature
@@ -83,3 +83,22 @@ Feature: Smart Answers
       | /marriage-abroad/y/cayman-islands/uk/partner_british/opposite_sex            | The Cayman Islands is a British overseas territory |
       | /register-a-birth/y/cayman-islands                                           | regulations in the Cayman Islands                  |
       | /register-a-death/y/overseas/cayman-islands                                  | regulations in the Cayman Islands                  |
+
+  Scenario Outline: Country slugs are correctly validated
+    Given I am testing through the full stack
+    And I force a varnish cache miss
+    When I request "<Path>"
+    Then the slug should be <Valid>
+
+    Examples:
+      | Path                                                   | Valid   |
+      | /marriage-abroad/y/netherlands                         | valid   |
+      | /marriage-abroad/y/foo                                 | invalid |
+      | /register-a-birth/y/cayman-islands                     | valid   |
+      | /register-a-birth/y/foo                                | invalid |
+      | /register-a-death/y/overseas/cayman-islands            | valid   |
+      | /register-a-death/y/overseas/foo                       | invalid |
+      | /help-if-you-are-arrested-abroad/y/afghanistan         | valid   |
+      | /help-if-you-are-arrested-abroad/y/foo                 | invalid |
+      | /report-a-lost-or-stolen-passport/y/abroad/afghanistan | valid   |
+      | /report-a-lost-or-stolen-passport/y/abroad/foo         | invalid |

--- a/features/smartanswers.feature
+++ b/features/smartanswers.feature
@@ -102,3 +102,16 @@ Feature: Smart Answers
       | /help-if-you-are-arrested-abroad/y/foo                 | invalid |
       | /report-a-lost-or-stolen-passport/y/abroad/afghanistan | valid   |
       | /report-a-lost-or-stolen-passport/y/abroad/foo         | invalid |
+
+  Scenario Outline: Country FCOs can be looked up
+    Given I am testing through the full stack
+    And I force a varnish cache miss
+    When I request "<Path>"
+    Then I should see "<Expected string>"
+
+    Examples:
+      | Path                                                           | Expected string                 |
+      | /marriage-abroad/y/afghanistan/uk/partner_british/opposite_sex | Embassy of Afghanistan          |
+      | /register-a-birth/y/venezuela/mother/yes/same_country          | venezuela.consulate@fco.gov.uk  |
+      | /register-a-death/y/overseas/north-korea/same_country          | Pyongyang.enquiries@fco.gov.uk  |
+      | /report-a-lost-or-stolen-passport/y/abroad/afghanistan         | britishembassy.kabul@fco.gov.uk |

--- a/features/step_definitions/smartanswers_steps.rb
+++ b/features/step_definitions/smartanswers_steps.rb
@@ -6,3 +6,15 @@ Then /^I should see a populated country select$/ do
   # some flex for that number to change
   expect(countries.count).to be > 200
 end
+
+Then /^the slug should be (valid|invalid)$/ do |valid_or_invalid|
+  is_valid = valid_or_invalid == "valid"
+
+  error_message = "#current-error"
+
+  if is_valid
+    expect(@response.body).to_not have_css(error_message)
+  else
+    expect(@response.body).to have_css(error_message)
+  end
+end


### PR DESCRIPTION
Smart Answers relies on the Worldwide API for:

- Country dropdowns (tested in a [separate change](https://github.com/alphagov/smokey/pull/286))
- Display of country names
- Validation of country slugs
- FCO details

This change adds integration tests for the above, to test that Smart Answers is using the Worldwide API as expected.