### PR TITLE
Expand JSON output to include Scenario Outline results

### DIFF
--- a/tests_json_output.sh
+++ b/tests_json_output.sh
@@ -26,6 +26,6 @@ fi
 
 rm -f ${TMP_FILE}
 /usr/local/bin/govuk_setenv default \
-    bundle exec cucumber --format json ${PROFILE:-} \
+    bundle exec cucumber --expand --format json ${PROFILE:-} \
         -t ~@disabled_in_icinga > ${TMP_FILE} || true
 mv ${TMP_FILE} ${CACHE_FILE}


### PR DESCRIPTION
In a recent Pull Request, we introduced the use of Cucumber’s
[`Scenario Outline`](https://github.com/cucumber/cucumber/wiki/Scenario-Outlines).

This change caused us failures in our monitoring, because the monitoring
expects all `step` items in the JSON to have an associated `result` key.

This is not the case in the default JSON formatting, as can be seen
[here](https://relishapp.com/cucumber/cucumber/docs/formatters/json-output-formatter#scenario-outline).

What we actually want is to expand the JSON formatting, so that each
of the `Scenario Outline` steps has a `result`, like [this](https://relishapp.com/cucumber/cucumber/docs/formatters/json-output-formatter#scenario-outline-expanded).

This change enables the `--expand` flag, which will report the results
for each step as demonstrated above.