### PR TITLE
Check what facets look like in finder pages

### DIFF
--- a/features/finder_frontend.feature
+++ b/features/finder_frontend.feature
@@ -1,5 +1,5 @@
 Feature: Finder Frontend
-  This are pages that have been migrated to a finder instead of index pages.
+  These are pages that let you search within a bunch of similar looking documents
 
   Background:
     Given I am testing through the full stack
@@ -10,6 +10,23 @@ Feature: Finder Frontend
     When I visit "/government/people"
     Then I should see "All ministers and senior officials on GOV.UK"
     And I should see an input field to search
+
+  @normal
+  Scenario: check policy page loads
+    When I visit "/government/policies"
+    Then I should see "Policy content"
+    And I should see an input field to search
+    And I should see an open facet titled "Organisation" with non-blank values
+
+  @normal
+  Scenario: check policy alpha loads
+    When I visit "/government/policies/all"
+    Then I should see "Policy content"
+    And I should see an input field to search
+    And I should see an open facet titled "Document type" with non-blank values
+    And I should see a closed facet titled "Organisation" with non-blank values
+    And I should see a closed facet titled "Policy" with non-blank values
+    And I should see a closed facet titled "People" with non-blank values
 
   @normal
   Scenario: check world organisations loads

--- a/features/step_definitions/finder_frontend_steps.rb
+++ b/features/step_definitions/finder_frontend_steps.rb
@@ -1,3 +1,22 @@
 Then /^I should see an input field to search$/ do
   page.body.should have_field('keywords')
 end
+
+And /^I should see an? (open|closed) facet titled "(.*?)" with non-blank values$/ do |open_closed, title|
+  facet = page.find('.govuk-option-select') { |elem| elem.find('.js-container-head').has_text?(title)}
+
+  if open_closed == "open"
+    expect(facet[:class].split(" ")).not_to include("js-closed")
+  else
+    expect(facet[:class].split(" ")).to include("js-closed")
+
+    # Facet options don't exist when you're not looking at them :(
+    facet.find('button').click
+  end
+
+  labels = facet.all('.options-container label').map(&:text)
+  blank_labels = labels.select { |label| label.strip.empty? }
+
+  expect(labels).not_to be_empty
+  expect(blank_labels).to be_empty
+end


### PR DESCRIPTION
This tests for issues like this:
https://docs.publishing.service.gov.uk/manual/incorrect-content-in-search-or-navigation.html#there-are-blank-options-on-finder-pages

The root cause in this case is rummager holding inconsistent data.  It knows
pages are tagged to people/organisations/topics but sometimes it's missing the
thing being tagged to.

In this case finder frontend just renders the thing with a blank title.

We could handle this better in finder frontend, but I think if the labels are ever
blank it should fail smokey, as this means the finder is not working properly.

Trello: https://trello.com/c/oTkICgvO/291-stop-blank-people-appearing-in-policy-finder