### PR TITLE
Make finder tests aware of the policy finder A/B test

### DIFF
--- a/features/finder_frontend.feature
+++ b/features/finder_frontend.feature
@@ -4,6 +4,7 @@ Feature: Finder Frontend
   Background:
     Given I am testing through the full stack
     And I force a varnish cache miss
+    And I am in the "A" group for "PolicyFinderTest" AB testing
 
   @normal
   Scenario: check people page loads


### PR DESCRIPTION
I wrote the test assuming the user agent is assigned to the A bucket.

Trello: https://trello.com/c/oTkICgvO/291-stop-blank-people-appearing-in-policy-finder