### PR TITLE
Check that search results are not duplicated

### DIFF
--- a/features/search.feature
+++ b/features/search.feature
@@ -1,11 +1,28 @@
 Feature: Search
 
   @high
-  Scenario: check search results
+  Scenario: check search results for tax
     Given I am testing through the full stack
     And I force a varnish cache miss
     When I search for "tax"
     Then I should see some search results
+    And the search results should have different titles
+
+  @high
+  Scenario: check search results for passport
+    Given I am testing through the full stack
+    And I force a varnish cache miss
+    When I search for "passport"
+    Then I should see some search results
+    And the search results should have different titles
+
+  @high
+  Scenario: check search results for universal credit
+    Given I am testing through the full stack
+    And I force a varnish cache miss
+    When I search for "universal credit"
+    Then I should see some search results
+    And the search results should have different titles
 
   @normal
   Scenario: check organisation filtering

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -11,3 +11,9 @@ Then /^I should see organisations in the organisation filter$/ do
   organisation_options = page.all("#organisations-filter input")
   organisation_options.count.should >= 10
 end
+
+And /^the search results should have different titles$/ do
+  result_titles = page.all(".results-list li a").map(&:text)
+
+  expect(result_titles.uniq.count).to eq(result_titles.count)
+end


### PR DESCRIPTION
This only checks a couple of common search terms, but should catch some obvious bugs
affecting high volume content.

Note: This test currently fails due to a bug with search we are fixing. https://trello.com/c/jx2JMs9R/301-prevent-duplicate-search-results-for-smart-answers