### PR TITLE
Use scenario outline for checking search

### DIFF
--- a/features/search.feature
+++ b/features/search.feature
@@ -1,28 +1,26 @@
 Feature: Search
 
   @high
-  Scenario: check search results for tax
+  Scenario Outline: check search results
     Given I am testing through the full stack
     And I force a varnish cache miss
-    When I search for "tax"
+    When I search for "<query>"
     Then I should see some search results
     And the search results should have different titles
 
-  @high
-  Scenario: check search results for passport
-    Given I am testing through the full stack
-    And I force a varnish cache miss
-    When I search for "passport"
-    Then I should see some search results
-    And the search results should have different titles
+    Examples:
+      | query                           |
+      | universal credit                |
+      | personal tax account            |
+      | apprenticeships                 |
+      | contact                         |
+      | car tax                         |
+      | passport                        |
+      | claim your state pension online |
+      | SORN                            |
+      | SA100                           |
+      | change of address               |
 
-  @high
-  Scenario: check search results for universal credit
-    Given I am testing through the full stack
-    And I force a varnish cache miss
-    When I search for "universal credit"
-    Then I should see some search results
-    And the search results should have different titles
 
   @normal
   Scenario: check organisation filtering


### PR DESCRIPTION
Use a range of common queries with varying query types
(acronyms, single words, multi word)