### PR TITLE
Add test for CSV preview

### DIFF
--- a/features/csv.feature
+++ b/features/csv.feature
@@ -1,0 +1,9 @@
+Feature: CSV preview
+
+  @normal
+  Scenario: Accessing a CSV preview
+    Given I am testing through the full stack
+    And I force a varnish cache miss
+
+    When I visit "/government/uploads/system/uploads/attachment_data/file/214962/passport-impact-indicat.csv/preview"
+    Then JavaScript should run without any errors

--- a/features/step_definitions/csv_steps.rb
+++ b/features/step_definitions/csv_steps.rb
@@ -1,0 +1,5 @@
+Then /^JavaScript should run without any errors$/ do
+  # If the `report-a-problem-toggle-wrapper` element exists then JavaScript
+  # is running on the page and there are no SRI or similar errors
+  expect(page).to have_selector('.report-a-problem-toggle-wrapper')
+end


### PR DESCRIPTION
This commit adds a test for the whitehall CSV preview to ensure JavaScript is running without any errors on those pages.

Trello: https://trello.com/c/BoQt5GLG/195-add-smokey-test-for-csv-preview-incident-review-action