### PR TITLE
Don't run mirrorer tests on AWS

### DIFF
--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -2,3 +2,4 @@
 integration: -t ~@pending -t ~@notintegration
 staging: -t ~@pending -t ~@notstaging
 production: -t ~@pending -t ~@notproduction
+aws: -t ~@pending -t ~@notaws

--- a/features/mirror.feature
+++ b/features/mirror.feature
@@ -1,3 +1,4 @@
+@notaws
 @local-network
 Feature: Mirror
 


### PR DESCRIPTION
- We don't have a VPN set up from AWS to the mirror boxes, so these
  Smokey tests are failing. Avoid this noise in our AWS environment by
  disabling these tests in that case.