### PR TITLE
Only test performance platform in production

### DIFF
--- a/features/performance_platform.feature
+++ b/features/performance_platform.feature
@@ -1,12 +1,13 @@
 Feature: Performance Platform
 
-  @high
+  @high @notintegration @notstaging
   Scenario: Can visit the Performance Platform homepage
     Given I am testing through the full stack
     When I visit "/performance"
     Then I should see "Performance"
     And I should see "Find performance data of government services"
 
+  @notintegration @notstaging
   Scenario: Can visit a Performance Platform dashboard
     Given I am testing through the full stack
     When I visit "/performance/register-to-vote"


### PR DESCRIPTION
Spotlight should no longer be running in integration or staging, and so
only production tests are useful.