### PR TITLE
Add search step to check for unique results

### DIFF
--- a/features/search.feature
+++ b/features/search.feature
@@ -6,7 +6,7 @@ Feature: Search
     And I force a varnish cache miss
     When I search for "tax"
     Then I should see some search results
-    And the search results should have different titles
+    And the search results should be unique
 
   @high
   Scenario: check search results for passport
@@ -14,7 +14,7 @@ Feature: Search
     And I force a varnish cache miss
     When I search for "passport"
     Then I should see some search results
-    And the search results should have different titles
+    And the search results should be unique
 
   @high
   Scenario: check search results for universal credit
@@ -22,7 +22,7 @@ Feature: Search
     And I force a varnish cache miss
     When I search for "universal credit"
     Then I should see some search results
-    And the search results should have different titles
+    And the search results should be unique
 
   @normal
   Scenario: check organisation filtering

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -12,8 +12,10 @@ Then /^I should see organisations in the organisation filter$/ do
   organisation_options.count.should >= 10
 end
 
-And /^the search results should have different titles$/ do
-  result_titles = page.all(".results-list li a").map(&:text)
-
-  expect(result_titles.uniq.count).to eq(result_titles.count)
+And /^the search results should be unique$/ do
+  results = []
+  page.all(".results-list li a").each_with_index do |item, idx|
+    results << item.text + page.all(".results-list li p")[idx].text
+  end
+  expect(results.uniq.count).to eq(results.count)
 end


### PR DESCRIPTION
Previously some of our search tests had a "the search results should have
different titles" step which intends to check that no duplicate results are
displayed in search.  However, it is possible for two different pieces of
content to have the same title, so this step is a bit flaky.  To resolve this
issue we replace this step with "the search results should be unique", which
checks the combined search result title and description for uniqueness to
determine whether duplicate search results are appearing.