### PR TITLE
Add AWS domains to environment helper

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -7,8 +7,19 @@ require 'plek'
 ENV["GOVUK_WEBSITE_ROOT"] ||= "https://www-origin.integration.publishing.service.gov.uk"
 ENV["GOVUK_DRAFT_WEBSITE_ROOT"] ||= Plek.find('draft-origin')
 
+non_production_website_roots = [
+  "https://www-origin.integration.publishing.service.gov.uk",
+  "https://www-origin.staging.publishing.service.gov.uk",
+  "https://www-origin.integration.govuk.digital",
+  "https://www-origin.blue.integration.govuk.digital",
+  "https://www-origin.green.integration.govuk.digital",
+  "https://www-origin.staging.govuk.digital",
+  "https://www-origin.blue.staging.govuk.digital",
+  "https://www-origin.green.staging.govuk.digital",
+]
+
 case ENV["GOVUK_WEBSITE_ROOT"]
-when "https://www-origin.integration.publishing.service.gov.uk", "https://www-origin.staging.publishing.service.gov.uk"
+when *non_production_website_roots
   ENV["EXPECTED_GOVUK_WEBSITE_ROOT"] = ENV["GOVUK_WEBSITE_ROOT"]
 else
   ENV["EXPECTED_GOVUK_WEBSITE_ROOT"] = 'https://www.gov.uk'


### PR DESCRIPTION
This adds a bunch of domains that I am hoping will be future proofing against smokey tests in the future. For now, it's only https://www-origin.blue.integration.govuk.digital that really affects us, but I didn't see any harm in adding the others.

Adds them into an array and uses a splat to iterate over them.