### PR TITLE
Remove some mirror features

### DIFF
--- a/features/mirror.feature
+++ b/features/mirror.feature
@@ -3,18 +3,6 @@
 Feature: Mirror
 
     @high
-    Scenario: Check homepage is served by the load-balanced mirrors
-      Given mirror provider 1
-      Then I should get a 200 response from "/" on the mirrors
-      And I should see "Welcome to GOV.UK"
-
-    @high
-    Scenario: Check that search returns an error on the load-balanced mirrors
-      Given mirror provider 1
-      Then I should get a 503 response from "/search" on the mirrors
-      And I should see a technical difficulties message
-
-    @high
     Scenario: Check homepage is served by all the mirrors
       Given there are 2 mirrors in provider 1
       Then I should get a 200 response from "/" on the mirrors


### PR DESCRIPTION
This PR removes two features that are currently failing due to a know SSL issue on the mirrors. This is being worked on but in the meantime we want Smokey to be in a green state for the rest of the tests and to be alerted appropriately for failures in the rest of the suite.

This will be reverted once the other issue is fixed.

[Trello to revert](https://trello.com/c/nvWkhcLU/393-revert-smokey-mirror-test-removal)