### PR TITLE
Allow setting of CUSTOM_DESTINATION_URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ You can use the following environment variables to configure the tests:
   * Default: Blank
   * Password of a user with a Signon account in the environment the tests are being run in.
 
+### Spoof target domain
+
+Set the `SPOOF_TARGET_DOMAIN` environment variable to run tests against a alternative URL, while
+maintaining the `Host` header as set by the `GOVUK_WEBSITE_ROOT` environment variable.
+
+This may be useful when you wish to test against the FQDN of a site where the DNS does not yet
+resolve to the correct IP.
+
+An alternative method would be to update `/etc/hosts` on the client running the tests.
+
 ### Debugging the tests
 
 Set the `POLTERGEIST_DEBUG` environment variable to see Poltergeist debug output when running the tests:

--- a/features/support/http_requests.rb
+++ b/features/support/http_requests.rb
@@ -67,6 +67,12 @@ def do_http_request(url, method = :get, options = {}, &block)
   }
 
   started_at = Time.now
+
+  spoof_target_domain = ENV['SPOOF_TARGET_DOMAIN']
+  if spoof_target_domain
+    options[:host_header] = URI(url).host
+    url = URI(url).scheme + "://" + spoof_target_domain
+  end
   url = options[:cache_bust] ? cache_bust(url) : url
   if options[:auth]
     user     = ENV['AUTH_USERNAME']

--- a/features/support/http_requests.rb
+++ b/features/support/http_requests.rb
@@ -72,6 +72,8 @@ def do_http_request(url, method = :get, options = {}, &block)
   if spoof_target_domain
     options[:host_header] = URI(url).host
     url = URI(url).scheme + "://" + spoof_target_domain
+    # FIXME: this is set only in the interests of the migration period
+    options[:verify_ssl] = false
   end
   url = options[:cache_bust] ? cache_bust(url) : url
   if options[:auth]


### PR DESCRIPTION
For the migration to AWS, we need to test the service domain works correctly before we do the switchover. To achieve this, we want to use Smokey as an indicator that stuff works like we expect.

Add an environment variable called `CUSTOM_DESTINATION_URI` that allows setting a custom domain. For our use, it will be something using the top level "integration.govuk.digital" domain, while setting the `GOVUK_WEBSITE_ROOT` and `EXPECTED_GOVUK_WEBSITE_ROOT` to the `integration.publishing.service.gov.uk`.

The code will update the destination, while ensuring the Host header is set as appropriate.