### PR TITLE
Add test for assets content type

### DIFF
--- a/features/assets.feature
+++ b/features/assets.feature
@@ -5,3 +5,15 @@ Feature: Assets
     Given I am testing "assets"
     When I request "/__canary__"
     Then I should get a 200 status code
+
+  @normal
+  Scenario: Assets with an explicit Content-Type are served with the correct Content-Type
+    Given I am testing "assets"
+    When I request "/media/59f70d5640f0b66bbc806ed3/questionnaire-for-accommodation-providers-online-hotel-booking.docx"
+    Then I should get a "Content-Type" header of "application/octet-stream"
+
+  @normal
+  Scenario: Assets without an explicit Content-Type are served with the correct Content-Type
+    Given I am testing "assets"
+    When I request "/media/580768d940f0b64fbe000022/Target_incomes_calculator.xls"
+    Then I should get a "Content-Type" header of "application/octet-stream"


### PR DESCRIPTION
This tests for the `Content-Type` header returned by asset-manager. We
have bugs in production where these files are returned without a
`Content-Type` header, causing Internet Explorer to display the file as
plain text.

The first of these files (the .docx) has had a manual fix applied where
the Content-Type header has been set explicitly on the key in S3. The
second (the .xls) relies on nginx passing through the header from
Rails. The theory is that the bug should not happen on the first file.

The bug normally takes around a day to occur due to the day-long
`max-age` returned.