### PR TITLE
Add support for bouncer APP_DOMAIN_INTERNAL

### DIFF
--- a/features/support/base_urls.rb
+++ b/features/support/base_urls.rb
@@ -2,6 +2,10 @@ def app_domain
   ENV["GOVUK_APP_DOMAIN"] || "integration.publishing.service.gov.uk"
 end
 
+def app_domain_internal
+  ENV["GOVUK_APP_DOMAIN_INTERNAL"]
+end
+
 def signon_base_url
   application_base_url('signon')
 end
@@ -10,7 +14,7 @@ def application_base_url(app_name)
   case app_name
   when 'asset-manager' then "https://asset-manager.#{app_domain}/"
   when 'assets' then "https://assets-origin.#{app_domain}/"
-  when 'bouncer' then "https://bouncer.#{app_domain}/"
+  when 'bouncer' then app_domain_internal.nil? ? "https://bouncer.#{app_domain}/" : "https://bouncer.#{app_domain_internal}/"
   when 'calendars' then "https://calendars.#{app_domain}/bank-holidays"
   when 'contacts' then "https://www.#{app_domain}/contact/hm-revenue-customs"
   when 'frontend' then "https://frontend.#{app_domain}/"


### PR DESCRIPTION
On AWS some of the end points are internal facing only and are
configured with an internal domain, for instance, Bouncer. Smokey
tests for these endpoints are failing because the monitoring box
is trying to use the public domain specified in GOVUK_APP_DOMAIN.

In this change we add a new environment variable, GOVUK_APP_DOMAIN_INTERNAL,
that, if configured, will be used to create some of the service URLs.

In this case we applied the internal domain to Bouncer.