### PR TITLE
Allow setting environment from custom application

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -10,6 +10,10 @@ if [ -z $MYTASK ]; then
   MYTASK="test:production"
 fi
 
+if [ -z $GOVUK_SETENV_APP ]; then
+  GOVUK_SETENV_APP=default
+fi
+
 # This removes rbenv shims from the PATH where there is no
 # .ruby-version file. This is because certain gems call their
 # respective tasks with ruby -S which causes the following error to
@@ -19,4 +23,4 @@ if [ ! -f .ruby-version ]; then
 fi
 
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
-RESTCLIENT_LOG="log/smokey-rest-client.log" govuk_setenv default bundle exec rake $MYTASK
+RESTCLIENT_LOG="log/smokey-rest-client.log" govuk_setenv $GOVUK_SETENV_APP bundle exec rake $MYTASK

--- a/tests_json_output.sh
+++ b/tests_json_output.sh
@@ -24,8 +24,13 @@ if [ -n "$2" ]; then
     PROFILE="--profile $2"
 fi
 
+GOVUK_SETENV_APP=default
+if [ -n "$3" ]; then
+  GOVUK_SETENV_APP=$3
+fi
+
 rm -f ${TMP_FILE}
-/usr/local/bin/govuk_setenv default \
+/usr/local/bin/govuk_setenv $GOVUK_SETENV_APP \
     bundle exec cucumber --expand --format json ${PROFILE:-} \
         -t ~@disabled_in_icinga > ${TMP_FILE} || true
 mv ${TMP_FILE} ${CACHE_FILE}


### PR DESCRIPTION
On AWS we want to run tests for the publishing and stack specific
domains. We also need to add new variables to have the tests working.

The smokey tests are called from Jenkins, as a job, via `jenkins.sh`
script, and are also running as a service in the monitoring server. In
both cases environment variables are first loaded from the environment
or from a `/etc/smokey.sh` file, and then set with `govuk_setenv default`.

This makes dificult to set up the right environment in first place and
have tests running with more than one setting, so this change allows us
to change the default `govuk_setenv` to load the environment from several
Smokey applications.