### PR TITLE
Check for unique link in search results feature

### DIFF
--- a/features/search.feature
+++ b/features/search.feature
@@ -17,6 +17,7 @@ Feature: Search
     And the search results should be unique
 
   @high
+  @notintegration
   Scenario: check search results for universal credit
     Given I am testing through the full stack
     And I force a varnish cache miss


### PR DESCRIPTION
We want to make sure that the returned search results are unique and have previously done this by using the title of a document. In practice our content does not always have unique titles so swap this to use links instead.