### PR TITLE
Add feature tests for service sign-in pages

### DIFF
--- a/features/government_frontend.feature
+++ b/features/government_frontend.feature
@@ -7,3 +7,26 @@ Feature: Government Frontend
   Scenario:
     When I visit "/government/case-studies/epic-cic"
     Then I should see "Case study"
+
+  Scenario:
+    When I visit "/log-in-file-self-assessment-tax-return/sign-in/prove-identity"
+    Then I should see "Prove your identity to continue"
+    And I should see a radio button for "use-government-gateway"
+    And I should see a radio button for "use-gov-uk-verify"
+    And I should see a radio button for "register-for-self-assessment"
+    And I should see a continue button
+
+  Scenario:
+    When I visit "/log-in-file-self-assessment-tax-return/sign-in/prove-identity"
+    When I choose "Use Government Gateway"
+    Then I should be redirected to "https://www.tax.service.gov.uk/gg/sign-in?continue=/account"
+
+  Scenario:
+    When I visit "/log-in-file-self-assessment-tax-return/sign-in/prove-identity"
+    When I choose "Use GOV.UK Verify"
+    Then I should be redirected to "https://www.signin.service.gov.uk/start"
+
+  Scenario:
+    When I visit "/log-in-file-self-assessment-tax-return/sign-in/prove-identity"
+    When I choose "Register for Self Assessment"
+    Then I should be redirected to "/log-in-file-self-assessment-tax-return/sign-in/register-self-assessment"

--- a/features/step_definitions/government_frontend_steps.rb
+++ b/features/step_definitions/government_frontend_steps.rb
@@ -1,0 +1,36 @@
+Then /^I should see a radio button for "(.*?)"$/ do |value|
+  # We set visible to false since our radios are styled labels
+  expect(page).to have_field("option", with: value, visible: false)
+end
+
+Then /^I should see a continue button$/ do
+  # We set visible to false since our radios are styled labels
+  expect(page).to have_selector("button", text: "Continue")
+end
+
+When /^I choose "(.*?)"$/ do |option|
+  choose(option, visible: false)
+  click_button "Continue"
+end
+
+Then /^I should be redirected to "(.*?)"$/ do |url_or_path|
+  if url_or_path.start_with?('http')
+    # Some urls do a double redirect, we only care about the URL we end up on.
+    wait_until { page.current_url == url_or_path }
+    expect(page.current_url).to(eq(url_or_path))
+  else
+    expect(page.current_path).to(eq(url_or_path))
+  end
+end
+
+def wait_until(&block)
+  max_time_to_try_until = Capybara.default_wait_time
+  time_between_intervals = 0.1 # in seconds
+
+  time_left = max_time_to_try_until
+  loop do
+    break if yield || time_left <= 0
+    sleep(time_between_intervals)
+    time_left -= time_between_intervals
+  end
+end


### PR DESCRIPTION
Tests the new service sign-in radio routing behaviour.

Uses a wait_until method since GOV.UK Verify does some odd double redirect behaviours.

As part of https://trello.com/c/9bkRCWy4/253-update-smokey-test