### PR TITLE
Don't run licence finder benchmarks on integration

### DIFF
--- a/features/licencefinder.feature
+++ b/features/licencefinder.feature
@@ -22,6 +22,7 @@ Feature: Licence Finder
 
   @low
   @benchmarking
+  @notintegration
   Scenario: Quickly loading the licence finder home page
     Given I am benchmarking
     And I am testing through the full stack


### PR DESCRIPTION
These tests often fail on integration, causing us to get used to smokey errors.

It's better to skip intermittently failing benchmark scripts so that we'll have more confidence that when something actually fails we need to do something.