### PR TITLE
Set `govuk_setenv` to "smokey" env

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -19,4 +19,4 @@ if [ ! -f .ruby-version ]; then
 fi
 
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
-RESTCLIENT_LOG="log/smokey-rest-client.log" govuk_setenv default bundle exec rake $MYTASK
+RESTCLIENT_LOG="log/smokey-rest-client.log" govuk_setenv smokey bundle exec rake $MYTASK

--- a/tests_json_output.sh
+++ b/tests_json_output.sh
@@ -9,8 +9,6 @@ set -e
 
 cd $(dirname "$0")
 
-[ -e /etc/smokey.sh ] && . /etc/smokey.sh
-
 if [ "$1" == "" ]; then
   echo "Usage: ./tests_json_output.sh /tmp/smokey.json [environment]"
   exit 1
@@ -25,7 +23,7 @@ if [ -n "$2" ]; then
 fi
 
 rm -f ${TMP_FILE}
-/usr/local/bin/govuk_setenv default \
+/usr/local/bin/govuk_setenv smokey \
     bundle exec cucumber --expand --format json ${PROFILE:-} \
         -t ~@disabled_in_icinga > ${TMP_FILE} || true
 mv ${TMP_FILE} ${CACHE_FILE}


### PR DESCRIPTION
Set to use Smokey environment variables like other applications rather than sourcing an independent file created by Puppet. This allows us to manage Smokey in a more consistent and less confusing way.