### PR TITLE
Fix capybara deprecation warning

### DIFF
--- a/features/step_definitions/government_frontend_steps.rb
+++ b/features/step_definitions/government_frontend_steps.rb
@@ -24,7 +24,7 @@ Then /^I should be redirected to "(.*?)"$/ do |url_or_path|
 end
 
 def wait_until(&block)
-  max_time_to_try_until = Capybara.default_wait_time
+  max_time_to_try_until = Capybara.default_max_wait_time
   time_between_intervals = 0.1 # in seconds
 
   time_left = max_time_to_try_until


### PR DESCRIPTION
When we run the Smokey tests, we get this warning:

> DEPRECATED: #default_wait_time is deprecated, please use #default_max_wait_time instead

(See https://deploy.publishing.service.gov.uk/job/Smokey/6745/console) 

This was deprecated in [Capybara v2.5.0][capybara] so we should probably resolve the warning.

[capybara]: https://github.com/teamcapybara/capybara/blob/57e3c9d92fc0f86879c2a7290a1d339f6ec86d70/History.md#deprecated