### PR TITLE
User asset-manager with internal domain

### DIFF
--- a/features/support/base_urls.rb
+++ b/features/support/base_urls.rb
@@ -12,7 +12,7 @@ end
 
 def application_base_url(app_name)
   case app_name
-  when 'asset-manager' then "https://asset-manager.#{app_domain}/"
+  when 'asset-manager' then app_domain_internal.nil? ? "https://asset-manager.#{app_domain}/" : "https://asset-manager.#{app_domain_internal}/"
   when 'assets' then "https://assets-origin.#{app_domain}/"
   when 'bouncer' then app_domain_internal.nil? ? "https://bouncer.#{app_domain}/" : "https://bouncer.#{app_domain_internal}/"
   when 'calendars' then "https://calendars.#{app_domain}/bank-holidays"


### PR DESCRIPTION
On AWS we are seeing the error:

```
Failed to open TCP connection to asset-manager.integration.publishing.service.gov.uk:443 (getaddrinfo: Name or service not known) (SocketError)
```

asset-manager doesn't have a public domain, so we need to connect
internally.