### PR TITLE
Allow organisation selector to see hidden elements

### DIFF
--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -8,7 +8,7 @@ Then /^I should see some search results$/ do
 end
 
 Then /^I should see organisations in the organisation filter$/ do
-  organisation_options = page.all("#organisations.options-container input")
+  organisation_options = page.all("#organisations.options-container input", visible: false)
   organisation_options.count.should >= 10
 end
 


### PR DESCRIPTION
This is required due to a change in how we are hidding these elements
and not a change in their visibility state.