### PR TITLE
Change the handling of base URLs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "plek", "1.11.0"
+gem "plek"
 gem "rake", "0.9.2.2"
 gem "rspec", "2.11.0"
 gem "minitest", "5.8.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,7 @@ GEM
     netrc (0.11.0)
     nokogiri (1.7.0.1)
       mini_portile2 (~> 2.1.0)
-    plek (1.11.0)
+    plek (2.1.1)
     poltergeist (1.13.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -72,11 +72,11 @@ DEPENDENCIES
   cucumber (= 1.3.20)
   minitest (= 5.8.4)
   nokogiri (~> 1.7)
-  plek (= 1.11.0)
+  plek
   poltergeist (= 1.13.0)
   rake (= 0.9.2.2)
   rest-client (= 1.8.0)
   rspec (= 2.11.0)
 
 BUNDLED WITH
-   1.12.5
+   1.16.1

--- a/features/asset_manager.feature
+++ b/features/asset_manager.feature
@@ -3,7 +3,7 @@ Feature: Asset Manager
   @local-network
   @normal
   Scenario: check an asset can be loaded
-    Given I am testing "asset-manager"
+    Given I am testing "asset-manager" internally
     And I am an authenticated API client
     When I request "/assets/513a0efbed915d425e000002"
     Then I should get a 200 status code

--- a/features/licensing.feature
+++ b/features/licensing.feature
@@ -2,7 +2,7 @@ Feature: Licensing
 
   @normal @notintegration @ignore_javascript_errors
   Scenario: check licensing app is present
-    Given I am testing "licensing"
+    Given I am testing "licensing" internally
       And I am testing through the full stack
       And I force a varnish cache miss
     Then I should be able to visit:
@@ -13,7 +13,7 @@ Feature: Licensing
 
   @normal @notintegration @benchmarking
   Scenario: Loading a pdf in a reasonable amount of time
-    Given I am testing "licensing"
+    Given I am testing "licensing" internally
       And I am benchmarking
       And I am testing through the full stack
       And I force a varnish cache miss

--- a/features/step_definitions/signon_steps.rb
+++ b/features/step_definitions/signon_steps.rb
@@ -1,7 +1,7 @@
 When /^I try to login as a user$/ do
   assert ENV["SIGNON_EMAIL"] && ENV["SIGNON_PASSWORD"], "Please ensure that the signon user credentials are available in the environment"
 
-  visit signon_base_url
+  visit application_external_url("signon")
 
   fill_in "Email", :with => ENV["SIGNON_EMAIL"]
   fill_in "Passphrase", :with => ENV["SIGNON_PASSWORD"]

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -4,7 +4,15 @@ Given /^I am testing "(.*)"/ do |host|
   if host.include? "://"
     @host = host
   else
-    @host = application_base_url(host)
+    @host = application_external_url(host)
+  end
+end
+
+Given /^I am testing "(.*)" internally/ do |host|
+  if host.include? "://"
+    @host = host
+  else
+    @host = application_internal_url(host)
   end
 end
 
@@ -27,7 +35,7 @@ Given /^I am an authenticated API client$/ do
 end
 
 When /^I go to the "([^"]*)" landing page$/ do |app_name|
-  visit_path application_base_url(app_name)
+  visit_path application_external_url(app_name)
 end
 
 When /^I (try to )?request "(.*)"$/ do |attempt_only, path_or_url|
@@ -53,7 +61,7 @@ When /^I visit "(.*)" without following redirects$/ do |path|
 end
 
 When /^I visit "([^"]*)" on the "([^"]*)" application$/ do |path, application|
-  application_host = application_base_url(application)
+  application_host = application_internal_url(application)
   @response = get_request("#{application_host}#{path}", default_request_options)
 end
 

--- a/features/support/base_urls.rb
+++ b/features/support/base_urls.rb
@@ -1,39 +1,20 @@
-def app_domain
-  ENV["GOVUK_APP_DOMAIN"] || "integration.publishing.service.gov.uk"
+DEFAULT_PATHS = {
+  'calendars' => '/bank-holidays',
+  'contacts' => '/hm-revenue-customs',
+  'imminence' => '/admin',
+  'licensefinder' => '/licence-finder',
+  'licensing' => '/apply-for-a-licence',
+  'licensing' => '/apply-for-a-license',
+  'publisher' => '/admin',
+  'smartanswers' => '/calculate-your-maternity-pay',
+  'travel-advice-publisher' => '/admin',
+  'whitehall' => '/government/how-government-works'
+}
+
+def application_external_url(app_name)
+  "#{Plek.new.external_url_for(app_name)}/#{DEFAULT_PATHS.fetch(app_name,'')}"
 end
 
-def app_domain_internal
-  ENV["GOVUK_APP_DOMAIN_INTERNAL"]
-end
-
-def signon_base_url
-  application_base_url('signon')
-end
-
-def application_base_url(app_name)
-  case app_name
-  when 'asset-manager' then app_domain_internal.nil? ? "https://asset-manager.#{app_domain}/" : "https://asset-manager.#{app_domain_internal}/"
-  when 'assets' then "https://assets-origin.#{app_domain}/"
-  when 'bouncer' then app_domain_internal.nil? ? "https://bouncer.#{app_domain}/" : "https://bouncer.#{app_domain_internal}/"
-  when 'calendars' then "https://calendars.#{app_domain}/bank-holidays"
-  when 'contacts' then "https://www.#{app_domain}/contact/hm-revenue-customs"
-  when 'frontend' then "https://frontend.#{app_domain}/"
-  when 'imminence' then "https://imminence.#{app_domain}/"
-  when 'licencefinder' then "https://licencefinder.#{app_domain}/licence-finder"
-  when 'licensing' then "https://licensify.#{app_domain}/apply-for-a-licence"
-  when 'local-links-manager' then "https://local-links-manager.#{app_domain}"
-  when 'manuals-publisher' then "https://manuals-publisher.#{app_domain}"
-  when 'publisher' then "https://publisher.#{app_domain}/admin"
-  when 'signon' then "https://signon.#{app_domain}/"
-  when 'smartanswers' then "https://smartanswers.#{app_domain}/calculate-your-maternity-pay"
-  when 'static' then "https://static.#{app_domain}/"
-  when 'whitehall' then app_domain_internal.nil? ? "https://whitehall-frontend.#{app_domain}/government/how-government-works" : "https://whitehall-frontend.#{app_domain_internal}/government/how-government-works"
-  when 'whitehall-frontend' then app_domain_internal.nil? ? "https://whitehall-frontend.#{app_domain}" : "https://whitehall-frontend.#{app_domain_internal}"
-  when 'whitehall-admin' then "https://whitehall-admin.#{app_domain}"
-  when 'imminence' then "https://imminence.#{app_domain}/admin"
-  when 'travel-advice-publisher' then "https://travel-advice-publisher.#{app_domain}/admin"
-  when 'transition' then "https://transition.#{app_domain}"
-  else
-    raise "Application '#{app_name}' not recognised, unable to boot it up"
-  end
+def application_internal_url(app_name)
+  "#{Plek.new.find(app_name)}/#{DEFAULT_PATHS.fetch(app_name,'')}"
 end


### PR DESCRIPTION
Previously a rather awkward list of URLs was used. This replaces that
list with using Plek, and a hash of default paths. I don't think all
default paths are used, but just include all of the ones specified
previously for now.

This uses the new external_url_for method in Plek 2.1.0 to find
external URLs for services. Some changes to the step definitions are
made here to explicitly use external URLs in some circumstances.