### PR TITLE
Remove redundant/failing tests for asset content-types

### DIFF
--- a/features/assets.feature
+++ b/features/assets.feature
@@ -5,15 +5,3 @@ Feature: Assets
     Given I am testing "assets"
     When I request "/__canary__"
     Then I should get a 200 status code
-
-  @normal
-  Scenario: Assets with an explicit Content-Type are served with the correct Content-Type
-    Given I am testing "assets"
-    When I request "/media/59f70d5640f0b66bbc806ed3/questionnaire-for-accommodation-providers-online-hotel-booking.docx"
-    Then I should get a "Content-Type" header of "application/octet-stream"
-
-  @normal
-  Scenario: Assets without an explicit Content-Type are served with the correct Content-Type
-    Given I am testing "assets"
-    When I request "/media/580768d940f0b64fbe000022/Target_incomes_calculator.xls"
-    Then I should get a "Content-Type" header of "application/octet-stream"


### PR DESCRIPTION
These tests were added in 3725f865d22340698fad39ae7f3cca20d0d2ecfa as part of our investigation into the missing content-type issue captured in https://github.com/alphagov/asset-manager/issues/238. The cause of this problem was fixed in https://github.com/alphagov/asset-manager/pull/343 which rendered these tests redundant.

Not only are these tests redundant but they started failing when we merged https://github.com/alphagov/asset-manager/pull/418 to ensure we're setting the correct content-type for a number of additional file types.
