### PR TITLE
Fix failing tests for asset content-types

### DIFF
--- a/features/assets.feature
+++ b/features/assets.feature
@@ -7,13 +7,13 @@ Feature: Assets
     Then I should get a 200 status code
 
   @normal
-  Scenario: Assets with an explicit Content-Type are served with the correct Content-Type
+  Scenario: Assets with a docx extension
     Given I am testing "assets"
     When I request "/media/59f70d5640f0b66bbc806ed3/questionnaire-for-accommodation-providers-online-hotel-booking.docx"
-    Then I should get a "Content-Type" header of "application/octet-stream"
+    Then I should get a "Content-Type" header of "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
 
   @normal
-  Scenario: Assets without an explicit Content-Type are served with the correct Content-Type
+  Scenario: Assets with a xls extension
     Given I am testing "assets"
     When I request "/media/580768d940f0b64fbe000022/Target_incomes_calculator.xls"
-    Then I should get a "Content-Type" header of "application/octet-stream"
+    Then I should get a "Content-Type" header of "application/vnd.ms-excel"


### PR DESCRIPTION
These tests started failing when we merged https://github.com/alphagov/asset-manager/pull/418 to set the correct content-type for a number of additional file types.

These tests were added in 3725f865d22340698fad39ae7f3cca20d0d2ecfa as part of our investigation into the missing content-type issue captured in https://github.com/alphagov/asset-manager/issues/238. The cause of this problem was fixed in https://github.com/alphagov/asset-manager/pull/343 but we're keeping these tests around to help catch regression in future.