### PR TITLE
Add test for Services and Information pages

### DIFF
--- a/features/services_information.feature
+++ b/features/services_information.feature
@@ -1,0 +1,8 @@
+Feature: Services and information pages
+
+  @high
+  Scenario: Check Services and Information pages
+    Given I am testing through the full stack
+    And I force a varnish cache miss
+    When I visit "/government/organisations/hm-revenue-customs/services-information"
+    Then I see links to pages per topic

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -217,6 +217,13 @@ When /^I inject a JavaScript error on the page, Smokey( does not)? raises? an ex
   end
 end
 
+When /^I see links to pages per topic$/ do
+  pages = Nokogiri::HTML.parse(page.body).css(".browse-container a")
+  unless pages.any?
+    fail "There are no links on this Services and Information page"
+  end
+end
+
 Before('@ignore_javascript_errors') do
   page.driver.browser.js_errors = false
 end


### PR DESCRIPTION
We recently had an outage on Services and Information pages (like https://www.gov.uk/government/organisations/hm-revenue-customs/services-information). This adds a test that would have picked up the issue.

cc @suzannehamilton 