### PR TITLE
Remove testing for policy firehose

### DIFF
--- a/features/finder_frontend.feature
+++ b/features/finder_frontend.feature
@@ -4,7 +4,6 @@ Feature: Finder Frontend
   Background:
     Given I am testing through the full stack
     And I force a varnish cache miss
-    And I am in the "A" group for "PolicyFinderTest" AB testing
 
   @normal
   Scenario: check people page loads

--- a/features/finder_frontend.feature
+++ b/features/finder_frontend.feature
@@ -38,12 +38,6 @@ Feature: Finder Frontend
     And I should see an input field to search
 
   @normal
-  Scenario: check policy finder loads
-    When I visit "/government/policies"
-    Then I should see "Policies"
-    And I should see an input field to search
-
-  @normal
   Scenario: check that contacts finder loads
     When I visit "/government/organisations/hm-revenue-customs/contact"
     Then I should see "HM Revenue &amp; Customs Contacts"

--- a/features/finder_frontend.feature
+++ b/features/finder_frontend.feature
@@ -20,16 +20,6 @@ Feature: Finder Frontend
     And I should see an open facet titled "Organisation" with non-blank values
 
   @normal
-  Scenario: check policy alpha loads
-    When I visit "/government/policies/all"
-    Then I should see "All policy content"
-    And I should see an input field to search
-    And I should see an open facet titled "Document type" with non-blank values
-    And I should see a closed facet titled "Organisation" with non-blank values
-    And I should see a closed facet titled "Policy" with non-blank values
-    And I should see a closed facet titled "People" with non-blank values
-
-  @normal
   Scenario: check world organisations loads
     When I visit "/government/world/organisations"
     Then I should see "Worldwide organisations"


### PR DESCRIPTION
This removes a test for a feature removed in https://github.com/alphagov/policy-publisher/pull/221. Also removes a duplicate of the "check policy page loads" test at L16.

We're no longer testing that the dropdown for "empty values", but as far as I know there aren't any finders with document type, person or policy dropdowns.

https://trello.com/c/YDda1PqI