### PR TITLE
Don't directly access Whitehall Frontend

### DIFF
--- a/features/whitehall.feature
+++ b/features/whitehall.feature
@@ -100,7 +100,7 @@ Feature: Whitehall
     Given I am benchmarking
     And I am testing through the full stack
     And I force a varnish cache miss
-    When I visit "/government/how-government-works" on the "whitehall-frontend" application
+    When I visit "/government/how-government-works"
     Then the elapsed time should be less than 2 seconds
 
   @normal

--- a/features/whitehall.feature
+++ b/features/whitehall.feature
@@ -109,7 +109,7 @@ Feature: Whitehall
     Given I am benchmarking
     And I am testing through the full stack
     And I force a varnish cache miss
-    When I visit "/api/world-locations" on the "whitehall-admin" application
+    When I visit "/api/world-locations"
     Then the elapsed time should be less than 2 seconds
 
   @normal


### PR DESCRIPTION
This test is confusing, as it seems to suggest it's testing through
the full stack, including varnish, but then attempts to access
whitehall-frontend directly.

This doesn't work on the new AWS Integration, so lets change this to
just visit the URL via the normal route.