### PR TITLE
Switch assets to assets-origin

### DIFF
--- a/features/asset_manager.feature
+++ b/features/asset_manager.feature
@@ -11,7 +11,7 @@ Feature: Asset Manager
 
   @normal
   Scenario: check an asset can be served
-    Given I am testing "assets"
+    Given I am testing "assets-origin"
     When I request "/media/513a0efbed915d425e000002/120613_Albania_Travel_Advice_WEB_Ed2_jpeg.jpg"
     Then I should get a 200 status code
     And I should get a content length of "212880"

--- a/features/assets.feature
+++ b/features/assets.feature
@@ -2,18 +2,18 @@ Feature: Assets
 
   @high
   Scenario: Assets are being served
-    Given I am testing "assets"
+    Given I am testing "assets-origin"
     When I request "/__canary__"
     Then I should get a 200 status code
 
   @normal
   Scenario: Assets with a docx extension
-    Given I am testing "assets"
+    Given I am testing "assets-origin"
     When I request "/media/59f70d5640f0b66bbc806ed3/questionnaire-for-accommodation-providers-online-hotel-booking.docx"
     Then I should get a "Content-Type" header of "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
 
   @normal
   Scenario: Assets with a xls extension
-    Given I am testing "assets"
+    Given I am testing "assets-origin"
     When I request "/media/580768d940f0b64fbe000022/Target_incomes_calculator.xls"
     Then I should get a "Content-Type" header of "application/vnd.ms-excel"


### PR DESCRIPTION
Previously this was hardcoded in the base_urls file, but now Plek is
used instead, so use the actual hostname that is required, rather than
assets.