### PR TITLE
Remove extra / for licensify-admin URL

### DIFF
--- a/features/step_definitions/licensing.rb
+++ b/features/step_definitions/licensing.rb
@@ -1,4 +1,4 @@
 When /^I login to Licensify$/ do
-  visit_path "#{application_external_url('licensify-admin')}/login"
+  visit_path "#{Plek.new.external_url_for('licensify-admin')}/login"
   click_button 'Login'
 end


### PR DESCRIPTION
The application_external_url function puts a / on the end of the URL,
which resulted in two forward slashes, this doesn't work.

Instead, just use Plek, as that avoids this extra complexity.