### PR TITLE
[DO NOT MERGE] Add smokey tests for the different email sign up journeys

### DIFF
--- a/features/email_sign_up.feature
+++ b/features/email_sign_up.feature
@@ -1,0 +1,78 @@
+Feature: Email Signup Journeys
+  There are multiple different ways a user can start their email subscription
+  signup journey
+
+  Background:
+    Given I am testing through the full stack
+    And I force a varnish cache miss
+
+  @high
+  Scenario: Starting from foreign travel advise
+    When I visit "/foreign-travel-advice/turkey"
+    Then I should see "Get email alerts"
+    When I click "Get email alerts"
+    Then I should see a create subscription button
+    When I click on the button "Create subscription"
+    Then I should see "How often do you want to get updates?"
+    When I choose radio button "No more than once a week" and click on "Next"
+    And I input "email@email.com" and click subscribe
+    Then I should see "Subscribed successfully"
+
+  @normal
+  Scenario: Starting from organisations
+    When I visit "/government/organisations/department-for-education"
+    Then I should see "email"
+    And I click "email"
+    Then I should see a create subscription button
+    When I click on the button "Create subscription"
+    Then I should see "How often do you want to get updates?"
+
+  @normal
+  Scenario: Starting from a finder
+    When I visit "/government/policies/immigration-and-borders"
+    And I click "Subscribe to email alerts"
+    Then I should see a create subscription button
+    When I click on the button "Create subscription"
+    Then I should see "How often do you want to get updates?"
+
+  @normal
+  Scenario: Starting from announcements
+    When I visit "/government/announcements"
+    And I click "email"
+    Then I should see a create subscription button
+    When I click on the button "Create subscription"
+    Then I should see "How often do you want to get updates?"
+
+  @normal
+  Scenario: Starting from whitehall finder
+    When I visit "/government/publications"
+    And I click "email"
+    Then I should see a create subscription button
+    When I click on the button "Create subscription"
+    Then I should see "How often do you want to get updates?"
+
+  @normal
+  Scenario: Starting from a taxon page
+    When I visit "/education"
+    Then I should see "Get email alerts for this topic"
+    When I click on the link with path "/email-signup/?topic=/education"
+    Then I should see "What do you want to get alerts about?"
+    When I choose radio button "Teaching and leadership" and click on "Select"
+    And I click on the button "Sign up now"
+    Then I should see "How often do you want to get updates?"
+
+  @normal
+  Scenario: Starting from a topic page
+    When I visit "/topic/transport/motorways-major-roads"
+    Then I should see "Subscribe to email alerts"
+    When I click on the link with path "/topic/transport/motorways-major-roads/email-signup"
+    And I click on the button "Create subscription"
+    Then I should see "How often do you want to get updates?"
+
+  @normal
+  Scenario: Starting from a finder(specialist publisher)
+    When I visit "/cma-cases"
+    Then I should see "Subscribe to email alerts"
+    When I click "Subscribe to email alerts"
+    And I choose the checkbox "Markets" and click on "Create subscription"
+    Then I should see "How often do you want to get updates?"

--- a/features/step_definitions/email_sign_up_steps.rb
+++ b/features/step_definitions/email_sign_up_steps.rb
@@ -1,0 +1,36 @@
+Then /^I should see a create subscription button$/ do
+  expect(page).to have_selector("button", text: "Create subscription")
+end
+
+When /^I choose radio button "(.*?)" and click on "(.*?)"$/ do |option, button_text|
+  choose(option, visible: false)
+  button_click(button_text)
+end
+
+When /^I input "(.*)" and click subscribe$/ do |email|
+  fill_in('address', with: 'email@email.com')
+  button_click('Subscribe')
+end
+
+When /^I click on the link with path "(.*?)"$/ do |href|
+  #either this way or individual css selector for two entry email links?
+  link = find(:xpath, "//a[@href='#{href}']")
+  link.should_not == nil
+  step "I visit \"#{href}\""
+end
+
+When /^I choose the checkbox "(.*)" and click on "(.*)"$/ do |option, button_text|
+  check(option, visible: false)
+  button_click(button_text)
+end
+
+When /^I click on the button "(.*?)"$/ do |button_text|
+  button = Nokogiri::HTML.parse(page.body)
+           .at_xpath("//button[normalize-space(text() = '#{button_text}')]")
+  button.should_not == nil
+  button_click(button_text)
+end
+
+def button_click(button_text)
+  click_button button_text
+end

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -158,9 +158,14 @@ Then /^I should be at a location path of "(.*)"$/ do |location_path|
 end
 
 When /^I click "(.*?)"$/ do |link_text|
-  link_href = Nokogiri::HTML.parse(@response.body).at_xpath("//a[text()='#{link_text}']/@href")
+  if @response
+    link_href = Nokogiri::HTML.parse(@response.body).at_xpath("//a[text()='#{link_text}']/@href")
+  elsif body
+    link_href = Nokogiri::HTML.parse(page.body)
+                .at_xpath("//a[text()='#{link_text}']/@href")
+  end
   link_href.should_not == nil
-  step "I visit \"#{link_href.value}\""
+  step  "I visit \"#{link_href.value}\""
 end
 
 When /^I try to post to "(.*)" with "(.*)"$/ do |path, payload|


### PR DESCRIPTION
There is one end to end test which is from "/foreign-travel-advice/turkey"
to the sign up confirmation page. The rest are from different entry points and stop
after getting to the email frequency page, as from then, the journeys are pretty
much the same.