### PR TITLE
Add smokey tests for the different email sign up journeys

### DIFF
--- a/features/email_sign_up.feature
+++ b/features/email_sign_up.feature
@@ -1,0 +1,76 @@
+Feature: Email Signup Journeys
+  There are multiple different ways a user can start their email subscription
+  signup journey
+
+  Background:
+    Given I am testing through the full stack
+    And I force a varnish cache miss
+
+  @high
+  Scenario: Starting from foreign travel advise
+    When I visit "/foreign-travel-advice/turkey"
+    And I click on the link "Get email alerts"
+    Then I should see "Create subscription"
+    When I click on the button "Create subscription"
+    Then I should see "How often do you want to get updates?"
+    When I choose radio button "No more than once a week" and click on "Next"
+    And I input "simulate-delivered@notifications.service.gov.uk" and click subscribe
+    Then I should see "You’ve subscribed successfully"
+
+  @normal
+  Scenario: Starting from organisations
+    When I visit "/government/organisations/department-for-education"
+    And I click on the link "email"
+    Then I should see "Create subscription"
+    When I click on the button "Create subscription"
+    Then I should see "How often do you want to get updates?"
+
+  @normal
+  Scenario: Starting from a finder
+    When I visit "/government/policies/immigration-and-borders"
+    And I click on the link "Subscribe to email alerts"
+    Then I should see "Create subscription"
+    When I click on the button "Create subscription"
+    Then I should see "How often do you want to get updates?"
+
+  @normal
+  Scenario: Starting from announcements
+    When I visit "/government/announcements"
+    And I click on the link "email"
+    Then I should see "Email alert subscription"
+    When I click on the button "Create subscription"
+    Then I should see "How often do you want to get updates?"
+
+  @normal
+  Scenario: Starting from whitehall finder
+    When I visit "/government/publications"
+    And I click on the link "email"
+    Then I should see "Create subscription"
+    When I click on the button "Create subscription"
+    Then I should see "How often do you want to get updates?"
+
+  @normal
+  Scenario: Starting from a taxon page
+    When I visit "/education"
+    Then I should see "Get email alerts for this topic"
+    When I click on the link "Get email alerts for this topic Education, training and skills"
+    Then I should see "What do you want to get alerts about?"
+    When I choose radio button "Teaching and leadership" and click on "Select"
+    And I click on the button "Sign up now"
+    Then I should see "How often do you want to get updates?"
+
+  @normal
+  Scenario: Starting from a topic page
+    When I visit "/topic/transport/motorways-major-roads"
+    Then I should see "Subscribe to email alerts"
+    When I click on the link "Subscribe to email alerts"
+    And I click on the button "Create subscription"
+    Then I should see "How often do you want to get updates?"
+
+  @normal
+  Scenario: Starting from a finder(specialist publisher)
+    When I visit "/cma-cases"
+    Then I should see "Subscribe to email alerts"
+    When I click on the link "Subscribe to email alerts"
+    And I choose the checkbox "Markets" and click on "Create subscription"
+    Then I should see "How often do you want to get updates?"

--- a/features/step_definitions/email_sign_up_steps.rb
+++ b/features/step_definitions/email_sign_up_steps.rb
@@ -1,0 +1,22 @@
+When /^I choose radio button "(.*?)" and click on "(.*?)"$/ do |option, button_text|
+  choose(option, visible: false)
+  step "I click on the button \"#{button_text}\""
+end
+
+When /^I input "(.*)" and click subscribe$/ do |email|
+  fill_in('address', with: email)
+  step "I click on the button \"Subscribe\""
+end
+
+When /^I click on the link "(.*?)"$/ do |link_text|
+  click_link link_text
+end
+
+When /^I choose the checkbox "(.*)" and click on "(.*)"$/ do |option, button_text|
+  check(option, visible: false)
+  step "I click on the button \"#{button_text}\""
+end
+
+When /^I click on the button "(.*?)"$/ do |button_text|
+  click_button button_text
+end

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -165,12 +165,6 @@ Then /^I should be at a location path of "(.*)"$/ do |location_path|
   end
 end
 
-When /^I click "(.*?)"$/ do |link_text|
-  link_href = Nokogiri::HTML.parse(@response.body).at_xpath("//a[text()='#{link_text}']/@href")
-  link_href.should_not == nil
-  step "I visit \"#{link_href.value}\""
-end
-
 When /^I try to post to "(.*)" with "(.*)"$/ do |path, payload|
   @response = post_request "#{@host}#{path}", :payload => "#{payload}"
 end


### PR DESCRIPTION
There is one end to end test which is from "/foreign-travel-advice/turkey"
to the sign up confirmation page. The rest are from different entry points and stop
after getting to the email frequency page, as from then, the journeys follow a standardised route.
Also removed 'I click ...' step as none of the features were using it. 