### PR TITLE
Fix detection if Javascript has failed

### DIFF
--- a/features/step_definitions/csv_steps.rb
+++ b/features/step_definitions/csv_steps.rb
@@ -1,5 +1,5 @@
 Then /^JavaScript should run without any errors$/ do
-  # If the `report-a-problem-toggle-wrapper` element exists then JavaScript
+  # If the `js-enabled` class exists on the body then JavaScript
   # is running on the page and there are no SRI or similar errors
-  expect(page).to have_selector('.report-a-problem-toggle-wrapper')
+  expect(page).to have_selector('body.js-enabled')
 end


### PR DESCRIPTION
We currently test whether Javascript has failed by looking at the wrapper for the "Is there anything wrong with this page" link. We've replaced that feature with the Feedback component so it has stopped working.

This replaces the detection by looking at the `js-enabled` class, which is a better indicator of whether or not there have been Javascript errors.

https://trello.com/c/5ZyHQaB4/139-fix-smokey-test