### PR TITLE
Add scenario to ensure draft-assets is protected by signon

### DIFF
--- a/features/assets.feature
+++ b/features/assets.feature
@@ -17,3 +17,8 @@ Feature: Assets
     Given I am testing "assets-origin"
     When I request "/media/580768d940f0b64fbe000022/Target_incomes_calculator.xls"
     Then I should get a "Content-Type" header of "application/vnd.ms-excel"
+
+  @normal @draft-assets
+  Scenario: Draft assets
+    When I visit "/media/123/filename.extension"
+    Then I should be redirected to signon

--- a/features/step_definitions/signon_steps.rb
+++ b/features/step_definitions/signon_steps.rb
@@ -7,3 +7,9 @@ When /^I try to login as a user$/ do
   fill_in "Passphrase", :with => ENV["SIGNON_PASSWORD"]
   click_button "Sign in"
 end
+
+Then(/^I should be redirected to signon$/) do
+  signon_url = application_external_url("signon")
+
+  expect(page.current_url).to match(signon_url)
+end

--- a/features/support/draft.rb
+++ b/features/support/draft.rb
@@ -7,3 +7,13 @@ Around('@draft') do |scenario, block|
     Capybara.app_host = old_app_host
   end
 end
+
+Around('@draft-assets') do |scenario, block|
+  old_app_host = Capybara.app_host
+  begin
+    Capybara.app_host = application_external_url("draft-assets")
+    block.call
+  ensure
+    Capybara.app_host = old_app_host
+  end
+end


### PR DESCRIPTION
I noticed that visiting draft-assets is currently redirecting us to the internal signon URL instead of the external URL.

Adding this scenario should help us avoid similar problems in future.