### PR TITLE
Change the asset whitehall uses for a smokey test

### DIFF
--- a/features/whitehall.feature
+++ b/features/whitehall.feature
@@ -115,7 +115,7 @@ Feature: Whitehall
   @normal
   Scenario: Whitehall assets are served
     Given I am testing through the full stack
-    When I request "/government/uploads/system/uploads/attachment_data/file/32409/11-944-higher-education-students-at-heart-of-system.pdf"
+    When I request "/government/uploads/system/uploads/attachment_data/file/618167/government_dietary_recommendations.pdf"
     Then I should get a 200 status code
 
   @normal


### PR DESCRIPTION
The previous asset was returning a 302 which seems to be related to the
parent document it is associated with being unpublished with redirect.
I'm not 100% sure if that behavious is correct or not so raised it with
the asset-management team.

I have though switched this to using a asset of a document that is
published which cuts out a level of ambiguity.