### PR TITLE
Ensure the asset url requested is not redirected

### DIFF
--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -38,14 +38,16 @@ When /^I go to the "([^"]*)" landing page$/ do |app_name|
   visit_path application_external_url(app_name)
 end
 
-When /^I (try to )?request "(.*)"$/ do |attempt_only, path_or_url|
+When /^I (try to )?request "(.*)"( without following redirects)?$/ do |attempt_only, path_or_url, avoid_redirects|
   url = if path_or_url.start_with?("http")
     path_or_url
   else
     "#{@host}#{path_or_url}"
   end
   request_method = attempt_only ? :try_get_request : :get_request
-  @response = send(request_method, url, default_request_options)
+  request_options = default_request_options
+  request_options[:avoid_redirects] = true if avoid_redirects
+  @response = send(request_method, url, request_options)
 end
 
 When /^I visit "(.*)"$/ do |path_or_url|

--- a/features/support/http_requests.rb
+++ b/features/support/http_requests.rb
@@ -105,6 +105,9 @@ def do_http_request(url, method = :get, options = {}, &block)
     payload: options[:payload],
     verify_ssl: options[:verify_ssl],
   }
+  if options[:avoid_redirects]
+    request_options[:max_redirects] = 0
+  end
   RestClient::Request.new(request_options).execute &block
 rescue RestClient::Unauthorized => e
   raise "Unable to fetch '#{url}' due to '#{e.message}'. Maybe you need to set AUTH_USERNAME and AUTH_PASSWORD?"

--- a/features/support/http_requests.rb
+++ b/features/support/http_requests.rb
@@ -95,7 +95,7 @@ def do_http_request(url, method = :get, options = {}, &block)
     headers["Rate-Limit-Token"] = rate_limit_token
   end
 
-  RestClient::Request.new(
+  request_options = {
     url: url,
     method: method,
     user: user,
@@ -104,7 +104,8 @@ def do_http_request(url, method = :get, options = {}, &block)
     timeout: 10,
     payload: options[:payload],
     verify_ssl: options[:verify_ssl],
-  ).execute &block
+  }
+  RestClient::Request.new(request_options).execute &block
 rescue RestClient::Unauthorized => e
   raise "Unable to fetch '#{url}' due to '#{e.message}'. Maybe you need to set AUTH_USERNAME and AUTH_PASSWORD?"
 rescue RestClient::Exception => e

--- a/features/whitehall.feature
+++ b/features/whitehall.feature
@@ -115,7 +115,7 @@ Feature: Whitehall
   @normal
   Scenario: Whitehall assets are served
     Given I am testing through the full stack
-    When I request "/government/uploads/system/uploads/attachment_data/file/618167/government_dietary_recommendations.pdf"
+    When I request "/government/uploads/system/uploads/attachment_data/file/618167/government_dietary_recommendations.pdf" without following redirects
     Then I should get a 200 status code
 
   @normal


### PR DESCRIPTION
A recent failure in this test highlighted that it hadn't been passing for the right reason: the attachment being requested belonged to an unpublished document and, because [RestClient follows redirects by default][1], we were actually asserting that the resulting document page was a 200.

This test was originally added in c9d72358e97fbdd92c7fe99517fac4b874870dee but there's no indication in the commit note or associated Pivotal Tracker story that we were expecting anything other than to receive the actual attachment directly.

By not following redirects when we make the request for the asset we should avoid similar false positives in future.

[1]: https://github.com/rest-client/rest-client#redirection