### PR TITLE
Update name of HMRC contact finder

### DIFF
--- a/features/contacts.feature
+++ b/features/contacts.feature
@@ -5,7 +5,7 @@ Feature: Contacts
     Given I am testing through the full stack
     And I force a varnish cache miss
     When I visit "/government/organisations/hm-revenue-customs/contact"
-    Then I should see "HM Revenue &amp; Customs Contacts"
+    Then I should see "Contact HM Revenue &amp; Customs"
 
   @normal
   Scenario: viewing a contact

--- a/features/finder_frontend.feature
+++ b/features/finder_frontend.feature
@@ -39,7 +39,7 @@ Feature: Finder Frontend
   @normal
   Scenario: check that contacts finder loads
     When I visit "/government/organisations/hm-revenue-customs/contact"
-    Then I should see "HM Revenue &amp; Customs Contacts"
+    Then I should see "Contact HM Revenue &amp; Customs"
     And I should see an input field to search
 
   @normal


### PR DESCRIPTION
Fix failing Smokey tests that check the HMRC contacts finder, which was renamed in https://github.com/alphagov/contacts-admin/pull/372