### PR TITLE
Smoke tests for data.gov.uk

### DIFF
--- a/features/datagovuk.feature
+++ b/features/datagovuk.feature
@@ -1,0 +1,22 @@
+Feature: Data.gov.uk
+  This is the Find open data service at data.gov.uk
+
+  Background:
+    Given I am testing "https://find-data-beta.cloudapps.digital"
+    And I force a varnish cache miss
+
+  @high
+  Scenario: check home page loads
+    When I request "/"
+    Then I should see "Find open data"
+
+  @high
+  @ignore_javascript_errors
+  Scenario: check search
+    When I search for "data" in datasets
+    Then I should see some dataset results
+
+  @normal
+  Scenario: check RDF API
+    When I request "/dataset/lidar-composite-dsm-1m1.rdf"
+    Then I should get a 200 status code

--- a/features/step_definitions/datagovuk_steps.rb
+++ b/features/step_definitions/datagovuk_steps.rb
@@ -1,0 +1,8 @@
+When /^I search for "(.*)" in datasets$/ do |term|
+  visit_path "#{@host}/search?q=#{term}"
+end
+
+Then /^I should see some dataset results$/ do
+  result_links = page.all(".dgu-results__result")
+  result_links.count.should >= 1
+end


### PR DESCRIPTION
Not sure why I have to turn off JS error checking on the second test. 

It seems that visit_path isn't resolving the static assets URLs, causing JavaScript variables to be undefined in inline scripts.

Hopefully this can be ironed out before merging.