### PR TITLE
Access bouncer internally

### DIFF
--- a/features/bouncer.feature
+++ b/features/bouncer.feature
@@ -2,8 +2,9 @@ Feature: Bouncer
 
   @high
   @benchmarking
+  @local-network
   Scenario: Bouncer application is up
-    Given I am testing "bouncer"
+    Given I am testing "bouncer" internally
     And I am benchmarking
     When I request "http://www.attorneygeneral.gov.uk" from Bouncer directly
     Then I should get a 301 status code


### PR DESCRIPTION
We have to access it internally as it not available from the outside except through Fastly.