### PR TITLE
Fix failing Whitehall attachments scenario

### DIFF
--- a/features/step_definitions/whitehall_steps.rb
+++ b/features/step_definitions/whitehall_steps.rb
@@ -19,6 +19,10 @@ When /^I do a whitehall search for "([^"]*)"$/ do |term|
   visit_path "/government/publications?keywords=#{uri_escape(term)}"
 end
 
+Then(/^I should be redirected to the asset host$/) do
+  expect(@response.request.url).to match(Plek.new.public_asset_host)
+end
+
 def follow_link_to_first_policy_on_policies_page
   visit_path "/government/policies"
   visit_path page.first('.document a')['href']

--- a/features/whitehall.feature
+++ b/features/whitehall.feature
@@ -113,8 +113,14 @@ Feature: Whitehall
     Then the elapsed time should be less than 2 seconds
 
   @normal
-  Scenario: Whitehall assets are served
+  Scenario: Whitehall assets are redirected to the asset host
     Given I am testing through the full stack
+    When I request "/government/uploads/system/uploads/attachment_data/file/618167/government_dietary_recommendations.pdf"
+    Then I should be redirected to the asset host
+
+  @normal
+  Scenario: Whitehall assets are served from the asset host
+    Given I am testing "assets-origin"
     When I request "/government/uploads/system/uploads/attachment_data/file/618167/government_dietary_recommendations.pdf" without following redirects
     Then I should get a 200 status code
 


### PR DESCRIPTION
Whitehall [PR 3918][1] added functionality to redirect requests for attachments from gov.uk to the asset host. This functionality caused the "Whitehall assets are served" scenario to fail because it was expecting to be able to request an asset without it being redirected.

The fix is to assert that Whitehall attachments _are_ redirected from gov.uk to the asset host, and to separately assert that Whitehall attachments are successfully served from the asset host.

[1]: https://github.com/alphagov/whitehall/pull/3918