### PR TITLE
Fix and improve Whitehall attachment scenarios

### DIFF
--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -38,16 +38,14 @@ When /^I go to the "([^"]*)" landing page$/ do |app_name|
   visit_path application_external_url(app_name)
 end
 
-When /^I (try to )?request "(.*)"( without following redirects)?$/ do |attempt_only, path_or_url, avoid_redirects|
+When /^I (try to )?request "(.*)"$/ do |attempt_only, path_or_url|
   url = if path_or_url.start_with?("http")
     path_or_url
   else
     "#{@host}#{path_or_url}"
   end
   request_method = attempt_only ? :try_get_request : :get_request
-  request_options = default_request_options
-  request_options[:avoid_redirects] = true if avoid_redirects
-  @response = send(request_method, url, request_options)
+  @response = send(request_method, url, default_request_options)
 end
 
 When /^I visit "(.*)"$/ do |path_or_url|

--- a/features/step_definitions/whitehall_steps.rb
+++ b/features/step_definitions/whitehall_steps.rb
@@ -19,8 +19,18 @@ When /^I do a whitehall search for "([^"]*)"$/ do |term|
   visit_path "/government/publications?keywords=#{uri_escape(term)}"
 end
 
+When(/^I request an attachment$/) do
+  @attachment_path = '/government/uploads/system/uploads/attachment_data/file/618167/government_dietary_recommendations.pdf'
+  step %Q(I request "#{@attachment_path}")
+end
+
 Then(/^I should be redirected to the asset host$/) do
   expect(@response.request.url).to match(Plek.new.public_asset_host)
+end
+
+Then(/^the attachment should be served successfully$/) do
+  expect(@response.request.url).to match(@attachment_path)
+  expect(@response.code).to eq(200)
 end
 
 def follow_link_to_first_policy_on_policies_page

--- a/features/support/http_requests.rb
+++ b/features/support/http_requests.rb
@@ -105,9 +105,6 @@ def do_http_request(url, method = :get, options = {}, &block)
     payload: options[:payload],
     verify_ssl: options[:verify_ssl],
   }
-  if options[:avoid_redirects]
-    request_options[:max_redirects] = 0
-  end
   RestClient::Request.new(request_options).execute &block
 rescue RestClient::Unauthorized => e
   raise "Unable to fetch '#{url}' due to '#{e.message}'. Maybe you need to set AUTH_USERNAME and AUTH_PASSWORD?"

--- a/features/whitehall.feature
+++ b/features/whitehall.feature
@@ -113,16 +113,12 @@ Feature: Whitehall
     Then the elapsed time should be less than 2 seconds
 
   @normal
-  Scenario: Whitehall assets are redirected to the asset host
+  Scenario: Whitehall assets are redirected to and served from the asset host
     Given I am testing through the full stack
-    When I request "/government/uploads/system/uploads/attachment_data/file/618167/government_dietary_recommendations.pdf"
+    And I force a varnish cache miss
+    When I request an attachment
     Then I should be redirected to the asset host
-
-  @normal
-  Scenario: Whitehall assets are served from the asset host
-    Given I am testing "assets-origin"
-    When I request "/government/uploads/system/uploads/attachment_data/file/618167/government_dietary_recommendations.pdf" without following redirects
-    Then I should get a 200 status code
+    And the attachment should be served successfully
 
   @normal
   @benchmarking


### PR DESCRIPTION
These two scenarios started failing in production after we deployed [Whitehall release 13388][1]. This release contains a change that ensures we're redirecting all attachment requests to the asset host.

The scenario titled "Whitehall assets are redirected to the asset host" was failing because the response was cached and we weren't including the "I force a varnish cache miss" step in the scenario.

The scenario titled "Whitehall assets are served from the asset host" was failing because we were expecting to be able to view an asset at assets-origin.publishing.service.gov.uk but we were being redirected to assets.publishing.service.gov.uk. We weren't allowing any redirects as we didn't want a repeat of the problem described in [Smokey PR 345][2].

I've attempted to fix both failures by combining the scenarios into one that asserts that a request for a Whitehall attachment on gov.uk ends up being served successfully by the asset host. Checking that the request URL matches the attachment URL in the "the attachment should be served successfully" step should ensure we don't introduce a problem similar to that fixed in [PR 345][2] again.

I'm not particularly keen on calling the "I request <url>" step from within "I request an attachment". I'd prefer the logic in "I request <url>" to be encapsulated in a method and to call that directly.

I used the following commands to test this against the three environments:

    # Integration
    $ GOVUK_ASSET_HOST=https://assets-origin.integration.publishing.service.gov.uk \
      AUTH_USERNAME=<username> \
      AUTH_PASSWORD=<password> \
      bundle exec cucumber features/whitehall.feature:116

    # Staging
    $ GOVUK_ASSET_HOST=https://assets-origin.staging.publishing.service.gov.uk \
      GOVUK_WEBSITE_ROOT=https://www-origin.staging.publishing.service.gov.uk \
      bundle exec cucumber features/whitehall.feature:116

    # Production
    $ GOVUK_ASSET_HOST=https://assets.publishing.service.gov.uk \
      GOVUK_WEBSITE_ROOT=https://www.gov.uk \
      bundle exec cucumber features/whitehall.feature:116

[1]: https://github.com/alphagov/whitehall/releases/tag/release_13388
[2]: https://github.com/alphagov/smokey/pull/345
