### PR TITLE
Ensure the related content appears on Travel Advice

### DIFF
--- a/features/travel_advice.feature
+++ b/features/travel_advice.feature
@@ -16,6 +16,7 @@ Feature: Travel Advice
     When I visit "/foreign-travel-advice/luxembourg"
     Then I should see "Luxembourg"
     And I should see "Summary"
+    And I should see "About Foreign and Commonwealth Office travel advice"
 
   @normal
   Scenario: Feeds should be available for index and countries


### PR DESCRIPTION
With the current Taxonomy changes, it would be easy to break
the hardcoded related content for Travel Advice. This checks
for the existance of the link to the "About" page.