### PR TITLE
Fix mirror failing tests on Integration

### DIFF
--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -2,4 +2,3 @@
 integration: -t ~@pending -t ~@notintegration
 staging: -t ~@pending -t ~@notstaging
 production: -t ~@pending -t ~@notproduction
-aws: -t ~@pending -t ~@notaws

--- a/features/mirror.feature
+++ b/features/mirror.feature
@@ -1,4 +1,4 @@
-@notaws
+@notintegration
 @local-network
 Feature: Mirror
 


### PR DESCRIPTION
The mirror tests are failing on Integration because
it is ignoring the @notaws tag and trying to run the
mirror tests. Now that Integration is on AWS it can
not access the mirrors on Carrenza.

By changing the tag to @notintegration the mirror
tests will not be run on Integration.