### PR TITLE
[DO NOT MERGE] Check which frontend app renders the response

### DIFF
--- a/features/calculators.feature
+++ b/features/calculators.feature
@@ -7,6 +7,8 @@ Feature: Calculators app
 
     When I visit "/child-benefit-tax-calculator"
     Then I should see "Child Benefit tax calculator"
+     And The frontend app is "frontend"
 
     When I visit "/child-benefit-tax-calculator/main"
     Then I should see "Child Benefit tax calculator"
+     And The frontend app is "calculators"

--- a/features/frontend.feature
+++ b/features/frontend.feature
@@ -14,26 +14,31 @@ Feature: Frontend
   Scenario: check quick answers load
     When I visit "/vat-rates"
     Then I should see "VAT rates"
+     And The frontend app is "government-frontend"
 
   @normal
   Scenario: check guides load
     When I visit "/getting-an-mot"
     Then I should see "Getting an MOT"
+     And The frontend app is "government-frontend"
 
   @normal
   Scenario: check transactions load
     When I visit "/apply-renew-passport"
     Then I should see "UK passport"
+     And The frontend app is "frontend"
 
   @normal
   Scenario: check benefit schemes load
     When I visit "/pension-credit"
     Then I should see "Pension Credit"
+     And The frontend app is "government-frontend"
 
   @normal
   Scenario: check homepage content type & charset
     When I request "/"
     Then I should get a "Content-Type" header of "text/html; charset=utf-8"
+     And The frontend app is "frontend"
 
   @normal
   Scenario: check 404 page content type & charset
@@ -45,35 +50,44 @@ Feature: Frontend
     When I visit "/busking-licence"
     Then I should see "Busking licence"
      And I should see an input field for postcode
+     And The frontend app is "frontend"
     When I try to post to "/busking-licence" with "postcode=E20+2ST"
     Then I should get a 200 status code
      And I should see "Busking licence"
+     And The frontend app is "frontend"
 
   @normal
   Scenario: check local transactions load
     When I visit "/pay-council-tax"
     Then I should see "Pay your Council Tax"
+     And The frontend app is "frontend"
     When I try to post to "/pay-council-tax" with "postcode=WC2B+6SE"
     Then I should see "Camden"
+     And The frontend app is "frontend"
 
   @normal
   Scenario: check find my nearest returns results
     When I visit "/ukonline-centre-internet-access-computer-training"
-    And I should see "UK online centres"
+    Then I should see "UK online centres"
+     And The frontend app is "frontend"
     When I try to post to "/ukonline-centre-internet-access-computer-training" with "postcode=WC2B+6NH"
     Then I should get a 200 status code
-    And I should see "Holborn Library"
+     And I should see "Holborn Library"
+     And The frontend app is "frontend"
 
   @normal
   Scenario: check campaign pages load
     When I visit "/workplacepensions"
     Then I should be at a location path of "/workplace-pensions"
+     And The frontend app is "government-frontend"
 
   @normal
   Scenario: check browse page load, and links
     When I visit "/browse/driving"
     Then I should get a 200 status code
-    And I should see "Teaching people to drive"
+     And I should see "Teaching people to drive"
+     And The frontend app is "collections"
     When I click on the section "Teaching people to drive"
     Then I should get a 200 status code
-    And I should see "Apply to become a driving instructor"
+     And I should see "Apply to become a driving instructor"
+     And The frontend app is "collections"

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -206,6 +206,19 @@ Then /^JSON is returned$/ do
   JSON.parse(@response.body).class.should == Hash
 end
 
+Then /^The frontend app is "(.*)"$/ do |application|
+  name = "govuk:rendering-application"
+  if @response
+    tags = Nokogiri::HTML.parse(@response.body).css("meta[name='#{name}']")
+    fail "Missing #{name} meta tag" if tags.nil? or tags.empty?
+    tags[0]["content"].should == application
+  else
+    tags = Nokogiri::HTML.parse(page.body).css("meta[name='#{name}']")
+    fail "Missing #{name} meta tag" if tags.nil? or tags.empty?
+    tags[0]["content"].should == application
+  end
+end
+
 def random_path_selection(opts={})
   size = opts[:size] || 3
   anchor_tags = opts[:anchor_tags] || []


### PR DESCRIPTION
A demo of checking which frontend app renders the response.  This is useful to ensure that we don't accidentally lose coverage when pages migrate between apps.  Approach copied from https://github.com/alphagov/publishing-e2e-tests/blob/e79bf84e2c3e5f27e1396ca498c0a7bd278f72fa/spec/support/frontend_helpers.rb#L2-L7