### PR TITLE
Check for previous tax year option

### DIFF
--- a/features/calculators.feature
+++ b/features/calculators.feature
@@ -10,3 +10,4 @@ Feature: Calculators app
 
     When I visit "/child-benefit-tax-calculator/main"
     Then I should see "Child Benefit tax calculator"
+    And I should be able to see the previous tax year

--- a/features/step_definitions/calculators_steps.rb
+++ b/features/step_definitions/calculators_steps.rb
@@ -1,0 +1,13 @@
+def previous_tax_years
+  today = Date.today
+  threshold = Date.new(today.year, 4, 5)
+  years = [today.year - 1, today.year]
+  years = years.map { |y| y - 1 } if today < threshold
+  years
+end
+
+Then(/^I should be able to see the previous tax year$/) do
+  within(".tax-year") do
+    page.should have_content(previous_tax_years.join(" to "))
+  end
+end


### PR DESCRIPTION
Related to https://trello.com/c/zrlw5CNd/98-asap-was-missed-in-uprating-add-2017-18-to-child-benefit-tax-calculator-2

Adds a check that the previous tax year is displayed in the calculators form.