### PR TITLE
Fix data.gov.uk smokey test for .rdf links

### DIFF
--- a/features/datagovuk.feature
+++ b/features/datagovuk.feature
@@ -19,4 +19,4 @@ Feature: Data.gov.uk
   @normal
   Scenario: check RDF API
     When I request "/dataset/lidar-composite-dsm-1m1.rdf"
-    Then I should get a 200 status code
+    Then I should get a 301 status code


### PR DESCRIPTION
This URL now returns a 301 rather than a 200