### PR TITLE
Check that smart answers strip postcodes

### DIFF
--- a/features/smartanswers.feature
+++ b/features/smartanswers.feature
@@ -132,3 +132,8 @@ Feature: Smart Answers
       | /benefit-cap-calculator/y/yes/no/none/bereavement/1000.0/1000.0/single/EH99%201SP | Outside London benefit cap |
       | /landlord-immigration-check/y/SW1A%202AA                                          | Is the person renting      |
       | /landlord-immigration-check/y/EH99%201SP                                          | check in England           |
+
+  @normal
+  Scenario: Excluding personal information
+    When I visit "/marriage-abroad/y"
+    Then I should see that postcodes are stripped from analytics data

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -100,6 +100,17 @@ def should_see(text)
   expect(@response.body).to have_content(text)
 end
 
+Then /^I should see that postcodes are stripped from analytics data$/ do
+  name = "govuk:static-analytics:strip-postcodes"
+  if @response
+    tags = Nokogiri::HTML.parse(@response.body).css("meta[name='#{name}']")
+    fail "Missing #{name} meta tag" if tags.nil? or tags.empty?
+  else
+    tags = Nokogiri::HTML.parse(page.body).css("meta[name='#{name}']")
+    fail "Missing #{name} meta tag" if tags.nil? or tags.empty?
+  end
+end
+
 Then /^I should be able to visit:$/ do |table|
   table.hashes.each do |row|
     visit_path row['Path']


### PR DESCRIPTION
There are no tests for static, so let's look for a meta tag set in https://github.com/alphagov/static/blob/master/app/views/govuk_component/analytics_meta_tags.raw.html.erb.

[Trello card](https://trello.com/c/ikOjBdox/92-add-missing-smokey-tests-for-frontend-apps-2)