### PR TITLE
Increase the wait time for sign-in page to redirect

### DIFF
--- a/features/step_definitions/government_frontend_steps.rb
+++ b/features/step_definitions/government_frontend_steps.rb
@@ -24,7 +24,7 @@ Then /^I should be redirected to "(.*?)"$/ do |url_or_path|
 end
 
 def wait_until(&block)
-  max_time_to_try_until = Capybara.default_max_wait_time
+  max_time_to_try_until = 5 # in seconds
   time_between_intervals = 0.1 # in seconds
 
   time_left = max_time_to_try_until


### PR DESCRIPTION
This is an attempt to fix: https://deploy.publishing.service.gov.uk/job/Smokey/8124/console

The smokey tests that check the sign-in pages redirect to Goverment Gateway and
Verify are failing in production. We think this is because the default 2 second
max wait time is not enough.

The value for `Capybara.default_max_wait_time` hasn't been overwritten because it
is also being used by the A/B testing tests.