### PR TITLE
Update cucumber tags syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ AUTH_USERNAME="<username>" \
 AUTH_PASSWORD="<password>" \
 bundle exec cucumber \
 --format pretty \
---tags ~@pending \
---tags ~@local-network \
---tags ~@notintegration
+--tags "not @pending" \
+--tags "not @local-network" \
+--tags "not @notintegration"
 ```
 
 ### Test configuration

--- a/Rakefile
+++ b/Rakefile
@@ -4,24 +4,24 @@ require 'cucumber/rake/task'
 Cucumber::Rake::Task.new("test:integration",
     "Run all tests that are valid in our integration environment") do |t|
   t.profile = "integration"
-  t.cucumber_opts = %w{--format progress -t ~@benchmarking}
+  t.cucumber_opts = %w{--format progress -t "not @benchmarking"}
 end
 
 Cucumber::Rake::Task.new("test:staging",
                          "Run all tests that are valid in our staging environment") do |t|
   t.profile = "staging"
-  t.cucumber_opts = %w{--format progress -t ~@benchmarking}
+  t.cucumber_opts = %w{--format progress -t "not @benchmarking"}
 end
 
 Cucumber::Rake::Task.new("test:production",
     "Run all tests that are valid in our production environment") do |t|
   t.profile = "production"
-  t.cucumber_opts = %w{--format progress -t ~@benchmarking}
+  t.cucumber_opts = %w{--format progress -t "not @benchmarking"}
 end
 
 Cucumber::Rake::Task.new("test:notlocalnetwork",
     "Run all tests that do not make use of the local network") do |t|
-  t.cucumber_opts = %w{--format pretty -t ~@pending -t ~@local-network}
+  t.cucumber_opts = %w{--format pretty -t "not @pending" -t "not @local-network"}
 end
 
 Cucumber::Rake::Task.new("test:wip",
@@ -29,8 +29,8 @@ Cucumber::Rake::Task.new("test:wip",
   t.cucumber_opts = %w{--format pretty -t @wip}
 end
 
-Cucumber::Rake::Task.new(:remote, "Excludes nagios tests") do |t|
-  t.cucumber_opts = %w{--format pretty -t ~@pending -t ~@disabled_in_icinga}
+Cucumber::Rake::Task.new(:remote, "Excludes Nagios tests") do |t|
+  t.cucumber_opts = %w{--format pretty -t "not @pending" -t "not @disabled_in_icinga"}
 end
 
 task :default => "test:notlocalnetwork"

--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -1,4 +1,4 @@
 # Options specific to a GOV.UK environment
-integration: -t ~@pending -t ~@notintegration
-staging: -t ~@pending -t ~@notstaging
-production: -t ~@pending -t ~@notproduction
+integration: -t "not @pending" -t "not @notintegration"
+staging: -t "not @pending" -t "not @notstaging"
+production: -t "not @pending" -t "not @notproduction"

--- a/tests_json_output.sh
+++ b/tests_json_output.sh
@@ -25,5 +25,5 @@ fi
 rm -f ${TMP_FILE}
 /usr/local/bin/govuk_setenv smokey \
     bundle exec cucumber --expand --format json ${PROFILE:-} \
-        -t ~@disabled_in_icinga > ${TMP_FILE} || true
+        -t "not @disabled_in_icinga" > ${TMP_FILE} || true
 mv ${TMP_FILE} ${CACHE_FILE}


### PR DESCRIPTION
Using “~@tag” to exclude tagged tests from running is deprecated. The new syntax is “not @tag”.

Trello: https://trello.com/c/80OiCEtH/308-more-reliable-smokey-tests-on-aws-environments