### PR TITLE
Move tests from whitehall to other apps

### DIFF
--- a/features/collections.feature
+++ b/features/collections.feature
@@ -5,15 +5,17 @@ Feature: Collections
     Given I am testing through the full stack
     And I force a varnish cache miss
     When I request "<Path>"
-    Then I should get a 200 status code
+    Then I should see "<Expected string>"
 
     Examples:
-      | Path                                                            |
-      | /browse/births-deaths-marriages/register-offices                |
-      | /health-and-social-care/childrens-health                        |
-      | /international/living-abroad                                    |
-      | /society-and-culture/poverty-and-social-justice                 |
-      | /welfare                                                        |
+      | Path                                             | Expected string                                           |
+      | /government/organisations                        | Departments, agencies and public bodies                   |
+      | /government/organisations/hm-revenue-customs     | HM Revenue &amp; Customs                                  |
+      | /browse/births-deaths-marriages/register-offices | Certificates, register offices, changes of name or gender |
+      | /health-and-social-care/childrens-health         | Children's health                                         |
+      | /international/living-abroad                     | Living abroad                                             |
+      | /society-and-culture/poverty-and-social-justice  | Poverty and social justice                                |
+      | /welfare                                         | Welfare                                                   |
 
   @normal
   Scenario: Check services and information pages

--- a/features/publicapi.feature
+++ b/features/publicapi.feature
@@ -17,16 +17,16 @@ Feature: Public API
       And JSON is returned
 
     @normal
-    Scenario: Check the whitehall governments API returns data
+    Scenario: Check the collections organisations API returns data
       Given I force a varnish cache miss
-      When I request "/api/governments"
+      When I request "/api/organisations"
       Then I should get a 200 status code
       And JSON is returned
 
     @normal
-    Scenario: Check the whitehall organisations API returns data
+    Scenario: Check the whitehall governments API returns data
       Given I force a varnish cache miss
-      When I request "/api/organisations"
+      When I request "/api/governments"
       Then I should get a 200 status code
       And JSON is returned
 

--- a/features/router.feature
+++ b/features/router.feature
@@ -1,9 +1,47 @@
 Feature: Router
 
   @high
-  Scenario: check router loads homepage
+  Scenario: Router loads home page
     Given I am testing through the full stack
     And I force a varnish cache miss
     Then I should be able to visit:
       | Path      |
       | /         |
+
+  @normal
+  Scenario: Department short URLs redirect correctly
+    Given I am testing through the full stack
+    And I force a varnish cache miss
+    Then I should be redirected when I try to visit:
+      | Path                      |
+      | /ago                      |
+      | /airports-commission      |
+      | /bis                      |
+      | /brac                     |
+      | /cabinetoffice            |
+      | /cabinet-office           |
+      | /communities              |
+      | /dclg                     |
+      | /dcms                     |
+      | /decc                     |
+      | /defra                    |
+      | /dfe                      |
+      | /dfid                     |
+      | /dft                      |
+      | /dh                       |
+      | /dsa                      |
+      | /dwp                      |
+      | /fco                      |
+      | /hmrc                     |
+      | /home-office              |
+      | /mod                      |
+      | /moj                      |
+      | /nio                      |
+      | /oag                      |
+      | /office-for-life-sciences |
+      | /phe                      |
+      | /pins                     |
+      | /planning-inspectorate    |
+      | /scotland-office          |
+      | /treasury                 |
+      | /wales-office             |

--- a/features/whitehall.feature
+++ b/features/whitehall.feature
@@ -20,7 +20,6 @@ Feature: Whitehall
       | /government/topics        |
       | /government/consultations |
       | /government/ministers     |
-      | /government/organisations |
       | /government/world         |
 
   @normal
@@ -53,45 +52,7 @@ Feature: Whitehall
       | /government/topics               |
       | /government/consultations        |
       | /government/ministers            |
-      | /government/organisations        |
       | /government/world                |
-
-  @normal
-  Scenario: Department short URLs redirect correctly
-    Given I am testing through the full stack
-    Then I should be redirected when I try to visit:
-      | Path                      |
-      | /ago                      |
-      | /airports-commission      |
-      | /bis                      |
-      | /brac                     |
-      | /cabinetoffice            |
-      | /cabinet-office           |
-      | /communities              |
-      | /dclg                     |
-      | /dcms                     |
-      | /decc                     |
-      | /defra                    |
-      | /dfe                      |
-      | /dfid                     |
-      | /dft                      |
-      | /dh                       |
-      | /dsa                      |
-      | /dwp                      |
-      | /fco                      |
-      | /hmrc                     |
-      | /home-office              |
-      | /mod                      |
-      | /moj                      |
-      | /nio                      |
-      | /oag                      |
-      | /office-for-life-sciences |
-      | /phe                      |
-      | /pins                     |
-      | /planning-inspectorate    |
-      | /scotland-office          |
-      | /treasury                 |
-      | /wales-office             |
 
   @local-network
   @low
@@ -138,5 +99,4 @@ Feature: Whitehall
       | Path                                     |
       | /government/how-government-works         |
       | /government/people/eric-pickles          |
-      | /government/organisations/cabinet-office |
     And I should get a 200 status code


### PR DESCRIPTION
whitehall no longer serves `/api/organisations` or organisation home pages (now served by collections). It also doesn’t serve organisation short URLs, which should be tested as part of the router tests.

Trello: https://trello.com/c/80OiCEtH/308-more-reliable-smokey-tests-on-aws-environments