### PR TITLE
Use new “expect” syntax rather than “should”

### DIFF
--- a/features/step_definitions/ab_testing_steps.rb
+++ b/features/step_definitions/ab_testing_steps.rb
@@ -25,7 +25,7 @@ end
 
 Then(/^we have shown them all versions of the AB test$/) do
   buckets = @responses.map { |r| ab_bucket(r.body) }.to_set
-  buckets.should == (Set.new ["A", "B"])
+  expect(buckets).to eq(Set.new ["A", "B"])
 end
 
 Then(/^I am assigned to a test bucket$/) do
@@ -58,7 +58,7 @@ Then(/^the bucket is reported to Google Analytics$/) do
 
   query = Rack::Utils.parse_query URI(analytics.first.url).query
 
-  query['cd40'].should == "Example:#{@ab_cookie_value}"
+  expect(query['cd40']).to eq("Example:#{@ab_cookie_value}")
 end
 
 Then(/^I stay on the same bucket when I keep visiting "(.*?)"$/) do |path|
@@ -66,7 +66,7 @@ Then(/^I stay on the same bucket when I keep visiting "(.*?)"$/) do |path|
     request_options = default_request_options.merge(cookies: {"ABTest-Example": @ab_cookie_value})
     response = get_request("#{@host}#{path}", request_options)
 
-    ab_bucket(response.body).should == @original_bucket
+    expect(ab_bucket(response.body)).to eq(@original_bucket)
   end
 end
 

--- a/features/step_definitions/benchmark_steps.rb
+++ b/features/step_definitions/benchmark_steps.rb
@@ -3,5 +3,5 @@ Given /^I am benchmarking$/ do
 end
 
 Then /^the elapsed time should be less than (\d+) seconds?$/ do |time|
-  (@scenario_start_time - Time.now).should > time.to_i * -1
+  expect(@scenario_start_time - Time.now).to be > time.to_i * -1
 end

--- a/features/step_definitions/calculators_steps.rb
+++ b/features/step_definitions/calculators_steps.rb
@@ -8,6 +8,6 @@ end
 
 Then(/^I should be able to see the previous tax year$/) do
   within(".tax-year") do
-    page.should have_content(previous_tax_years.join(" to "))
+    expect(page).to have_content(previous_tax_years.join(" to "))
   end
 end

--- a/features/step_definitions/collections_steps.rb
+++ b/features/step_definitions/collections_steps.rb
@@ -1,9 +1,9 @@
 Then(/^I can see an accordion$/) do
-  page.should have_css('.app-c-accordion--active')
+  expect(page).to have_css('.app-c-accordion--active')
 end
 
 Then(/^I cannot see any of the accordion content$/) do
-  page.should_not have_css('.js-panel')
+  expect(page).not_to have_css('.js-panel')
 end
 
 When(/^I toggle the first accordion section$/) do
@@ -15,9 +15,9 @@ Then(/^I can(not)? see the accordion content for only the first item$/) do |cann
 
   all('.js-section').each_with_index do |subsection, index|
     if index == 0 && should_see_accordion
-      subsection.should have_css('.js-panel')
+      expect(subsection).to have_css('.js-panel')
     else
-      subsection.should_not have_css('.js-panel')
+      expect(subsection).not_to have_css('.js-panel')
     end
   end
 end

--- a/features/step_definitions/datagovuk_steps.rb
+++ b/features/step_definitions/datagovuk_steps.rb
@@ -4,5 +4,5 @@ end
 
 Then /^I should see some dataset results$/ do
   result_links = page.all(".dgu-results__result")
-  result_links.count.should >= 1
+  expect(result_links.count).to be >= 1
 end

--- a/features/step_definitions/draft_environment_steps.rb
+++ b/features/step_definitions/draft_environment_steps.rb
@@ -15,7 +15,7 @@ When /^I attempt to visit a manual$/ do
 end
 
 Then /^I should be prompted to log in$/ do
-  page.should have_content('Sign in')
+  expect(page).to have_content('Sign in')
 end
 
 When /^I log in using valid credentials$/ do
@@ -25,10 +25,10 @@ When /^I log in using valid credentials$/ do
 end
 
 Then /^I should be on the case study page$/ do
-  page.current_path.should eq("/government/case-studies/libraries-unlimited")
-  page.should have_content('Case study')
+  expect(page.current_path).to eq("/government/case-studies/libraries-unlimited")
+  expect(page).to have_content('Case study')
 end
 
 Then /^the page should contain the draft watermark$/ do
-  page.should have_css('body.draft')
+  expect(page).to have_css('body.draft')
 end

--- a/features/step_definitions/finder_frontend_steps.rb
+++ b/features/step_definitions/finder_frontend_steps.rb
@@ -1,10 +1,10 @@
 Then /^I should see an input field to search$/ do
-  page.body.should have_field('keywords')
+  expect(page.body).to have_field('keywords')
 end
 
 Then(/^I should see filtered documents$/) do
   result_links = page.all(".filtered-results li a")
-  result_links.count.should >= 1
+  expect(result_links.count).to be >= 1
 end
 
 And /^I should see an? (open|closed) facet titled "(.*?)" with non-blank values$/ do |open_closed, title|

--- a/features/step_definitions/frontend_steps.rb
+++ b/features/step_definitions/frontend_steps.rb
@@ -1,9 +1,9 @@
 When /^I click on the section "(.*?)"$/ do |section_name|
   link_href = Nokogiri::HTML.parse(page.body).at_xpath("//h3[text()='#{section_name}']/../@href")
-  link_href.should_not == nil
+  expect(link_href).not_to be_nil
   step "I visit \"#{link_href.value}\""
 end
 
 Then /^I should see an input field for postcode$/ do
-  page.body.should have_field('postcode')
+  expect(page.body).to have_field('postcode')
 end

--- a/features/step_definitions/mirror_steps.rb
+++ b/features/step_definitions/mirror_steps.rb
@@ -19,7 +19,7 @@ Then /^I should get a (\d+) response from "(.*)" on the mirrors$/ do |status, pa
       host_header: "www-origin.mirror.production.govuk.service.gov.uk",
       verify_ssl: false,
     )
-    response.code.should == status.to_i
+    expect(response.code).to eq(status.to_i)
     @responses << response
   end
 end

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -4,12 +4,12 @@ end
 
 Then /^I should see some search results$/ do
   result_links = page.all(".results-list li a")
-  result_links.count.should >= 1
+  expect(result_links.count).to be >= 1
 end
 
 Then /^I should see organisations in the organisation filter$/ do
   organisation_options = page.all("#organisations.options-container input", visible: false)
-  organisation_options.count.should >= 10
+  expect(organisation_options.count).to be >= 10
 end
 
 And /^the search results should be unique$/ do

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -93,7 +93,7 @@ end
 
 def should_visit(path)
   @response = get_request("#{@host}#{path}", default_request_options)
-  @response.code.should == 200
+  expect(@response.code).to eq(200)
 end
 
 def should_see(text)
@@ -120,7 +120,7 @@ end
 Then /^I should be redirected when I try to visit:$/ do |table|
   table.hashes.each do |row|
     visit_path row['Path']
-    page.current_path.should_not == row['Path']
+    expect(page.current_path).not_to eq(row['Path'])
   end
 end
 
@@ -143,16 +143,16 @@ Then /^I should get a "(.*)" header of "(.*)"$/ do |header_name, header_value|
   header_as_symbol = header_name.gsub('-', '_').downcase.to_sym
 
   if @response.respond_to? :headers
-    @response.headers[header_as_symbol].should == header_value
+    expect(@response.headers[header_as_symbol]).to eq(header_value)
   elsif @response[header_name]
-    @response[header_name].should == header_value
+    expect(@response[header_name]).to eq(header_value)
   else
     raise "Couldn't find header '#{header_name}' in response"
   end
 end
 
 Then /I should get a content length of "(\d+)"/ do |length|
-  @response.net_http_res['content-length'].to_i.should == length
+  expect(@response.net_http_res['content-length'].to_i).to eq(length)
 end
 
 Then /^I should see "(.*)"$/ do |content|
@@ -170,9 +170,9 @@ end
 Then /^I should be at a location path of "(.*)"$/ do |location_path|
   url = "#{@host}#{location_path}"
   if @response
-    @response['location'].should == url
+    expect(@response['location']).to eq(url)
   else
-    page.current_url.should == url
+    expect(page.current_url).to eq(url)
   end
 end
 
@@ -182,11 +182,11 @@ end
 
 Then /^the logo should link to the homepage$/ do
   logo = Nokogiri::HTML.parse(page.body).at_css('#logo')
-  logo.attributes['href'].value.should == ENV['EXPECTED_GOVUK_WEBSITE_ROOT']
+  expect(logo.attributes['href'].value).to eq(ENV['GOVUK_WEBSITE_ROOT'])
 end
 
 Then /^I should see Publisher's publication index$/ do
-  page.should have_selector("#publication-list-container")
+  expect(page).to have_selector("#publication-list-container")
 end
 
 Then /^I should be able to navigate the topic hierarchy$/ do
@@ -214,7 +214,7 @@ Then /^I should be able to navigate the browse pages$/ do
 end
 
 Then /^JSON is returned$/ do
-  JSON.parse(@response.body).class.should == Hash
+  expect(JSON.parse(@response.body).class).to eq(Hash)
 end
 
 def random_path_selection(opts={})


### PR DESCRIPTION
The “should” syntax is deprecated and has been replaced with the “expect” syntax.

Trello: https://trello.com/c/80OiCEtH/308-more-reliable-smokey-tests-on-aws-environments