### PR TITLE
Make licensify-admin consistent with other paths

### DIFF
--- a/features/step_definitions/licensing.rb
+++ b/features/step_definitions/licensing.rb
@@ -1,4 +1,4 @@
 When /^I login to Licensify$/ do
-  visit_path "#{Plek.new.external_url_for('licensify-admin')}/login"
-  click_button 'Login'
+  visit_path application_external_url("licensify-admin")
+  click_button "Login"
 end

--- a/features/support/base_urls.rb
+++ b/features/support/base_urls.rb
@@ -3,6 +3,7 @@ DEFAULT_PATHS = {
   'contacts' => '/hm-revenue-customs',
   'imminence' => '/admin',
   'licensefinder' => '/licence-finder',
+  'licensify-admin' => '/login',
   'licensing' => '/apply-for-a-license',
   'publisher' => '/admin',
   'smartanswers' => '/calculate-your-maternity-pay',


### PR DESCRIPTION
This commit makes tests on `licensify-admin` with others, where the default path is defined centrally.

Trello: https://trello.com/c/80OiCEtH/308-more-reliable-smokey-tests-on-aws-environments