### PR TITLE
Make tags consistent

### DIFF
--- a/features/asset_manager.feature
+++ b/features/asset_manager.feature
@@ -1,7 +1,6 @@
 Feature: Asset Manager
 
-  @local-network
-  @normal
+  @normal @local-network
   Scenario: check an asset can be loaded
     Given I am testing "asset-manager" internally
     And I am an authenticated API client

--- a/features/bouncer.feature
+++ b/features/bouncer.feature
@@ -1,8 +1,6 @@
 Feature: Bouncer
 
-  @high
-  @benchmarking
-  @local-network
+  @high @benchmarking @local-network
   Scenario: Bouncer application is up
     Given I am testing "bouncer" internally
     And I am benchmarking

--- a/features/draft_environment.feature
+++ b/features/draft_environment.feature
@@ -3,7 +3,7 @@ Feature: Draft environment
   GOV.UK. Accessing the draft environment requires a valid signon session.
   Access to the draft stack should be denied without a valid signon session.
 
-  @draft @high
+  @high @draft
   Scenario: visiting a draft page requires a signon session
     When I attempt to go to a case study
     Then I should be prompted to log in
@@ -11,21 +11,21 @@ Feature: Draft environment
     Then I should be on the case study page
     And the page should contain the draft watermark
 
-  @draft
+  @normal @draft
   Scenario: visiting a page served by government-frontend
     When I try to login as a user
     When I attempt to visit "government/case-studies/epic-cic"
     Then I should see "Case study"
     And the page should contain the draft watermark
 
-  @draft
+  @normal @draft
   Scenario: visiting a specialist document served by government-frontend
     When I try to login as a user
     And I attempt to visit a CMA case
     Then I should see "Competition and Markets Authority case"
     And the page should contain the draft watermark
 
-  @draft
+  @normal @draft
   Scenario: visiting a manual served by manuals-frontend
     When I try to login as a user
     And I attempt to visit a manual

--- a/features/feedback.feature
+++ b/features/feedback.feature
@@ -4,10 +4,12 @@ Feature: Feedback
     Given I am testing through the full stack
     And I force a varnish cache miss
 
+  @normal
   Scenario: The "Contact GOV.UK" page
     When I visit "/contact/govuk"
     Then I should see "Contact GOV.UK"
 
+  @high
   Scenario: malicious actor inputs code to carry out XSS attack
     When I visit "contact/govuk"
     And I input malicious code in the email field

--- a/features/government_frontend.feature
+++ b/features/government_frontend.feature
@@ -4,10 +4,12 @@ Feature: Government Frontend
     Given I am testing through the full stack
     And I force a varnish cache miss
 
+  @normal
   Scenario:
     When I visit "/government/case-studies/epic-cic"
     Then I should see "Case study"
 
+  @normal
   Scenario:
     When I visit "/log-in-file-self-assessment-tax-return/sign-in/prove-identity"
     Then I should see "How do you want to sign in?"
@@ -16,18 +18,19 @@ Feature: Government Frontend
     And I should see a radio button for "register-for-self-assessment"
     And I should see a continue button
 
-  @pending
+  @normal
   Scenario:
     When I visit "/log-in-file-self-assessment-tax-return/sign-in/prove-identity"
     When I choose "Sign in with Government Gateway"
     Then I should be redirected to "https://www.tax.service.gov.uk/gg/sign-in?continue=/account"
 
-  @pending
+  @normal
   Scenario:
     When I visit "/log-in-file-self-assessment-tax-return/sign-in/prove-identity"
     When I choose "Sign in with GOV.UK Verify"
     Then I should be redirected to "https://www.signin.service.gov.uk/start"
 
+  @normal
   Scenario:
     When I visit "/log-in-file-self-assessment-tax-return/sign-in/prove-identity"
     When I choose "Register for Self Assessment"

--- a/features/javascript_errors.feature
+++ b/features/javascript_errors.feature
@@ -2,7 +2,7 @@ Feature: Smokey JavaScript error detection
 
   # This test checks that the @ignore_javascript_errors successfully ignores JavaScript errors. It is placed before
   # the JS error detection test to ensure that it is also correctly torn down
-  @ignore_javascript_errors
+  @normal @ignore_javascript_errors
   Scenario: Ignore JS errors with the correct tag
     When I inject a JavaScript error on the page, Smokey does not raise an exception
 

--- a/features/licencefinder.feature
+++ b/features/licencefinder.feature
@@ -20,9 +20,7 @@ Feature: Licence Finder
     When I visit "/licence-finder/licences?activities=149&location=wales&sectors=59"
     Then I should see "A premises licence is for carrying out 'licensable activities' at a particular venue"
 
-  @low
-  @benchmarking
-  @notintegration
+  @low @benchmarking @notintegration
   Scenario: Quickly loading the licence finder home page
     Given I am benchmarking
     And I am testing through the full stack

--- a/features/mirror.feature
+++ b/features/mirror.feature
@@ -1,5 +1,4 @@
-@notintegration
-@local-network
+@notintegration @local-network
 Feature: Mirror
 
     @high

--- a/features/performance_platform.feature
+++ b/features/performance_platform.feature
@@ -7,7 +7,7 @@ Feature: Performance Platform
     Then I should see "Performance"
     And I should see "Find performance data of government services"
 
-  @notintegration @notstaging
+  @normal @notintegration @notstaging
   Scenario: Can visit a Performance Platform dashboard
     Given I am testing through the full stack
     When I visit "/performance/register-to-vote"

--- a/features/search.feature
+++ b/features/search.feature
@@ -17,7 +17,6 @@ Feature: Search
     And the search results should be unique
 
   @high
-  @notintegration
   Scenario: check search results for universal credit
     Given I am testing through the full stack
     And I force a varnish cache miss
@@ -32,8 +31,7 @@ Feature: Search
     When I search for "policy"
     Then I should see organisations in the organisation filter
 
-  @normal
-  @notintegration
+  @normal @notintegration
   Scenario: check sitemap
     Given I am testing through the full stack
     And I force a varnish cache miss
@@ -41,6 +39,7 @@ Feature: Search
     Then It should contain a link to at least one sitemap file
     And I should be able to get all the referenced sitemap files
 
+  @high
   Scenario: malicious actor inputs malicious code to effect XSS attack
     Given I am testing through the full stack
     And I force a varnish cache miss

--- a/features/service_manual.feature
+++ b/features/service_manual.feature
@@ -4,21 +4,25 @@ Feature: Service Manual
     Given I am testing through the full stack
     And I force a varnish cache miss
 
+  @normal
   Scenario: check Service Manual
     When I visit "/service-manual"
     Then I should see "Service Manual"
     And I should get a 200 status code
 
+  @normal
   Scenario: Visiting a topic page
     When I visit "/service-manual/agile-delivery"
     Then I should see "Agile delivery"
     And I should get a 200 status code
 
+  @normal
   Scenario: Visiting a guide page
     When I visit "/service-manual/agile-delivery/writing-user-stories"
     Then I should see "Writing user stories"
     And I should get a 200 status code
 
+  @normal
   Scenario: Visiting the service standard page
     When I visit "/service-manual/service-standard"
     Then I should see "Digital Service Standard"

--- a/features/topics.feature
+++ b/features/topics.feature
@@ -1,5 +1,6 @@
 Feature: Topics
 
+  @normal
   Scenario: dynamically checking topic hierarchy
     Given I am testing through the full stack
     And I force a varnish cache miss

--- a/features/whitehall.feature
+++ b/features/whitehall.feature
@@ -8,7 +8,7 @@ Feature: Whitehall
     And I force a varnish cache miss
     Then I should see the departments and policies section on the homepage
 
-  @notintegration
+  @normal @notintegration
   Scenario: There should be no authentication for Whitehall
     Given I am testing through the full stack
     And I force a varnish cache miss
@@ -29,7 +29,7 @@ Feature: Whitehall
     When I do a whitehall search for "Assessing radioactive waste disposal sites"
     Then I should see "Assessing radioactive waste disposal sites"
 
-  @disabled_in_icinga
+  @normal
   Scenario: Feeds should be available for documents
     Given I am testing through the full stack
     And I force a varnish cache miss
@@ -54,9 +54,7 @@ Feature: Whitehall
       | /government/ministers            |
       | /government/world                |
 
-  @local-network
-  @low
-  @benchmarking
+  @low @benchmarking @local-network
   Scenario: Whitehall frontend website should be fast
     Given I am benchmarking
     And I am testing through the full stack
@@ -64,8 +62,7 @@ Feature: Whitehall
     When I visit "/government/how-government-works"
     Then the elapsed time should be less than 2 seconds
 
-  @normal
-  @benchmarking
+  @normal @benchmarking
   Scenario: Whitehall offers a world location API
     Given I am benchmarking
     And I am testing through the full stack
@@ -81,8 +78,7 @@ Feature: Whitehall
     Then I should be redirected to the asset host
     And the attachment should be served successfully
 
-  @normal
-  @benchmarking
+  @normal @benchmarking
   Scenario: National statistics release calendar is served
     Given I am testing through the full stack
     And I force a varnish cache miss


### PR DESCRIPTION
This commit mostly puts tags on one line to make them consistent, and adds `@normal` tags to tests that didn’t have any tags.

`@high` tags are added to tests that look for XSS vulnerabilities.

One test tagged `@ disabled_in_icinga` is now tagged `@normal` since there’s no reason for it to be ignored by Icinga.

Tests for Government Gateway redirects are now made live.

Trello: https://trello.com/c/80OiCEtH/308-more-reliable-smokey-tests-on-aws-environments