### PR TITLE
Remove extra slash

### DIFF
--- a/features/support/base_urls.rb
+++ b/features/support/base_urls.rb
@@ -12,9 +12,9 @@ DEFAULT_PATHS = {
 }
 
 def application_external_url(app_name)
-  "#{Plek.new.external_url_for(app_name)}/#{DEFAULT_PATHS.fetch(app_name,'')}"
+  "#{Plek.new.external_url_for(app_name)}#{DEFAULT_PATHS.fetch(app_name,'')}"
 end
 
 def application_internal_url(app_name)
-  "#{Plek.new.find(app_name)}/#{DEFAULT_PATHS.fetch(app_name,'')}"
+  "#{Plek.new.find(app_name)}#{DEFAULT_PATHS.fetch(app_name,'')}"
 end


### PR DESCRIPTION
This was causing tests for licensing-admin to fail since that apps doesn’t normalise more than one consecutive slash.

Trello: https://trello.com/c/80OiCEtH/308-more-reliable-smokey-tests-on-aws-environments