### PR TITLE
Clean-up tests

### DIFF
--- a/features/ab_testing.feature
+++ b/features/ab_testing.feature
@@ -1,24 +1,24 @@
-# Tests for the example A/B testing page. Even though these just test an example
-# page, they're still a useful smoke test of real A/B experiments, because they
-# all A/B tests rely on CDN config to assign users into buckets and handle A/B
-# cookies correctly. So a failure in these tests indicates that all A/B tests
-# may be broken.
-#
-# These tests are only run against Production because they rely on the CDN to
-# manipulate the HTTP request and response headers.
 Feature: A/B Testing
+  Tests for the example A/B testing page. Even though these just test an example
+  page, they're still a useful smoke test of real A/B experiments, because they
+  all A/B tests rely on CDN config to assign users into buckets and handle A/B
+  cookies correctly. So a failure in these tests indicates that all A/B tests
+  may be broken.
+
+  These tests are only run against Production because they rely on the CDN to
+  manipulate the HTTP request and response headers.
+
+  Background:
+    Given there is an AB test setup
+    And I am testing through the full stack
 
   @low @notintegration @notstaging
   Scenario: check we end up in all buckets
-    Given there is an AB test setup
-    And I am testing through the full stack
     When multiple new users visit "/help/ab-testing"
     Then we have shown them all versions of the AB test
 
   @withanalytics @low @notintegration @notstaging
   Scenario: check that an A/B test works
-    Given there is an AB test setup
-    And I am testing through the full stack
     And I do not have any AB testing cookies set
     When I visit "/help/ab-testing"
     Then I am assigned to a test bucket

--- a/features/asset_manager.feature
+++ b/features/asset_manager.feature
@@ -1,7 +1,7 @@
 Feature: Asset Manager
 
   @normal @local-network
-  Scenario: check an asset can be loaded
+  Scenario: Check an asset can be loaded
     Given I am testing "asset-manager" internally
     And I am an authenticated API client
     When I request "/assets/513a0efbed915d425e000002"
@@ -9,7 +9,7 @@ Feature: Asset Manager
     And I should see "120613_Albania_Travel_Advice_WEB_Ed2_jpeg.jpg"
 
   @normal
-  Scenario: check an asset can be served
+  Scenario: Check an asset can be served
     Given I am testing "assets-origin"
     When I request "/media/513a0efbed915d425e000002/120613_Albania_Travel_Advice_WEB_Ed2_jpeg.jpg"
     Then I should get a 200 status code

--- a/features/calculators.feature
+++ b/features/calculators.feature
@@ -1,4 +1,4 @@
-Feature: Calculators app
+Feature: Calculators
 
   @normal
   Scenario: Accessing the child benefit tax calculator

--- a/features/calendars.feature
+++ b/features/calendars.feature
@@ -1,9 +1,11 @@
 Feature: Calendars
 
-  @normal
-  Scenario: check calendars loads
+  Background:
     Given I am testing through the full stack
     And I force a varnish cache miss
+
+  @normal
+  Scenario: check calendars loads
     Then I should be able to visit:
       | Path                       |
       | /when-do-the-clocks-change |
@@ -11,14 +13,12 @@ Feature: Calendars
 
   @normal
   Scenario: check alternative formats are available
-    Given I am testing through the full stack
     Then I should be able to visit:
-      | Path                            |
+      | Path                                           |
       | /when-do-the-clocks-change/united-kingdom.json |
       | /when-do-the-clocks-change/united-kingdom.ics  |
 
   @normal
   Scenario: check bank holidays JSON format is consistent
-    Given I am testing through the full stack
     When I request "/bank-holidays.json"
     Then JSON is returned

--- a/features/collections.feature
+++ b/features/collections.feature
@@ -1,9 +1,11 @@
 Feature: Collections
 
-  @normal
-  Scenario Outline: Check example collection pages
+  Background:
     Given I am testing through the full stack
     And I force a varnish cache miss
+
+  @normal
+  Scenario Outline: Check example collection pages
     When I request "<Path>"
     Then I should see "<Expected string>"
 
@@ -19,7 +21,5 @@ Feature: Collections
 
   @normal
   Scenario: Check services and information pages
-    Given I am testing through the full stack
-    And I force a varnish cache miss
     When I visit "/government/organisations/hm-revenue-customs/services-information"
     Then I see links to pages per topic

--- a/features/contacts.feature
+++ b/features/contacts.feature
@@ -1,15 +1,15 @@
 Feature: Contacts
 
-  @normal
-  Scenario: viewing contacts finder
+  Background:
     Given I am testing through the full stack
     And I force a varnish cache miss
+
+  @normal
+  Scenario: viewing contacts finder
     When I visit "/government/organisations/hm-revenue-customs/contact"
     Then I should see "Contact HM Revenue &amp; Customs"
 
   @normal
   Scenario: viewing a contact
-    Given I am testing through the full stack
-    And I force a varnish cache miss
     When I visit "/government/organisations/hm-revenue-customs/contact/child-benefit"
     Then I should see "Child Benefit"

--- a/features/csv.feature
+++ b/features/csv.feature
@@ -4,6 +4,5 @@ Feature: CSV preview
   Scenario: Accessing a CSV preview
     Given I am testing through the full stack
     And I force a varnish cache miss
-
     When I visit "/government/uploads/system/uploads/attachment_data/file/214962/passport-impact-indicat.csv/preview"
     Then JavaScript should run without any errors

--- a/features/datagovuk.feature
+++ b/features/datagovuk.feature
@@ -10,8 +10,7 @@ Feature: Data.gov.uk
     When I request "/"
     Then I should see "Find open data"
 
-  @high
-  @ignore_javascript_errors
+  @high @ignore_javascript_errors
   Scenario: check search
     When I search for "data" in datasets
     Then I should see some dataset results

--- a/features/licencefinder.feature
+++ b/features/licencefinder.feature
@@ -1,9 +1,11 @@
 Feature: Licence Finder
 
-  @normal
-  Scenario: check licence finder loads
+  Background:
     Given I am testing through the full stack
     And I force a varnish cache miss
+
+  @normal
+  Scenario: check licence finder loads
     Then I should be able to visit:
       | Path                                                              |
       | /licence-finder                                                   |
@@ -15,7 +17,5 @@ Feature: Licence Finder
 
   @normal
   Scenario: check licence finder returns licences
-    Given I am testing through the full stack
-    And I force a varnish cache miss
     When I visit "/licence-finder/licences?activities=149&location=wales&sectors=59"
     Then I should see "A premises licence is for carrying out 'licensable activities' at a particular venue"

--- a/features/performance_platform.feature
+++ b/features/performance_platform.feature
@@ -1,14 +1,15 @@
 Feature: Performance Platform
 
+  Background:
+    Given I am testing through the full stack
+
   @high @notintegration @notstaging
   Scenario: Can visit the Performance Platform homepage
-    Given I am testing through the full stack
     When I visit "/performance"
     Then I should see "Performance"
     And I should see "Find performance data of government services"
 
   @normal @notintegration @notstaging
   Scenario: Can visit a Performance Platform dashboard
-    Given I am testing through the full stack
     When I visit "/performance/register-to-vote"
     Then I should see "Voter registration"

--- a/features/publicapi.feature
+++ b/features/publicapi.feature
@@ -2,6 +2,7 @@ Feature: Public API
 
     Background:
       Given I am testing through the full stack
+      Given I force a varnish cache miss
 
     @normal
     Scenario: Check the search API returns data
@@ -11,28 +12,24 @@ Feature: Public API
 
     @normal
     Scenario: Check the content store returns data
-      Given I force a varnish cache miss
       When I request "/api/content/help"
       Then I should get a 200 status code
       And JSON is returned
 
     @normal
     Scenario: Check the collections organisations API returns data
-      Given I force a varnish cache miss
       When I request "/api/organisations"
       Then I should get a 200 status code
       And JSON is returned
 
     @normal
     Scenario: Check the whitehall governments API returns data
-      Given I force a varnish cache miss
       When I request "/api/governments"
       Then I should get a 200 status code
       And JSON is returned
 
     @normal
     Scenario: Check the whitehall world locations API returns data
-      Given I force a varnish cache miss
       When I request "/api/world-locations"
       Then I should get a 200 status code
       And JSON is returned

--- a/features/router.feature
+++ b/features/router.feature
@@ -1,17 +1,17 @@
 Feature: Router
 
-  @high
-  Scenario: Router loads home page
+  Background:
     Given I am testing through the full stack
     And I force a varnish cache miss
+
+  @high
+  Scenario: Router loads home page
     Then I should be able to visit:
       | Path      |
       | /         |
 
   @normal
   Scenario: Department short URLs redirect correctly
-    Given I am testing through the full stack
-    And I force a varnish cache miss
     Then I should be redirected when I try to visit:
       | Path                      |
       | /ago                      |

--- a/features/search.feature
+++ b/features/search.feature
@@ -1,47 +1,39 @@
 Feature: Search
 
-  @high
-  Scenario: check search results for tax
+  Background:
     Given I am testing through the full stack
     And I force a varnish cache miss
+
+  @high
+  Scenario: check search results for tax
     When I search for "tax"
     Then I should see some search results
     And the search results should be unique
 
   @high
   Scenario: check search results for passport
-    Given I am testing through the full stack
-    And I force a varnish cache miss
     When I search for "passport"
     Then I should see some search results
     And the search results should be unique
 
   @high
   Scenario: check search results for universal credit
-    Given I am testing through the full stack
-    And I force a varnish cache miss
     When I search for "universal credit"
     Then I should see some search results
     And the search results should be unique
 
   @normal
   Scenario: check organisation filtering
-    Given I am testing through the full stack
-    And I force a varnish cache miss
     When I search for "policy"
     Then I should see organisations in the organisation filter
 
   @normal @notintegration
   Scenario: check sitemap
-    Given I am testing through the full stack
-    And I force a varnish cache miss
     When I get the sitemap index
     Then It should contain a link to at least one sitemap file
     And I should be able to get all the referenced sitemap files
 
   @high
   Scenario: malicious actor inputs malicious code to effect XSS attack
-    Given I am testing through the full stack
-    And I force a varnish cache miss
     When I search for "<script>alert(document.cookie)</script>"
     Then I see the code returned in the page

--- a/features/service_manual.feature
+++ b/features/service_manual.feature
@@ -8,22 +8,18 @@ Feature: Service Manual
   Scenario: check Service Manual
     When I visit "/service-manual"
     Then I should see "Service Manual"
-    And I should get a 200 status code
 
   @normal
   Scenario: Visiting a topic page
     When I visit "/service-manual/agile-delivery"
     Then I should see "Agile delivery"
-    And I should get a 200 status code
 
   @normal
   Scenario: Visiting a guide page
     When I visit "/service-manual/agile-delivery/writing-user-stories"
     Then I should see "Writing user stories"
-    And I should get a 200 status code
 
   @normal
   Scenario: Visiting the service standard page
     When I visit "/service-manual/service-standard"
     Then I should see "Digital Service Standard"
-    And I should get a 200 status code

--- a/features/smartanswers.feature
+++ b/features/smartanswers.feature
@@ -1,9 +1,11 @@
 Feature: Smart Answers
 
-  @normal
-  Scenario: Check selected smart answer start pages
+  Background:
     Given I am testing through the full stack
     And I force a varnish cache miss
+
+  @normal
+  Scenario: Check selected smart answer start pages
     Then I should be able to visit:
     | Path                                        |
     | /additional-commodity-code/y                |
@@ -17,8 +19,6 @@ Feature: Smart Answers
 
   @normal
   Scenario: step through a smart answer
-    Given I am testing through the full stack
-    And I force a varnish cache miss
     Then I should be able to visit:
     | Path                                        |
     | /vat-payment-deadlines                      |
@@ -28,8 +28,6 @@ Feature: Smart Answers
 
   @normal
   Scenario: Step through a smart answer using Imminence
-    Given I am testing through the full stack
-    And I force a varnish cache miss
     Then I should be able to visit:
     | Path                                              |
     | /landlord-immigration-check                       |
@@ -41,8 +39,6 @@ Feature: Smart Answers
 
   @normal
   Scenario: Step through a smart answer using the Worldwide API
-    Given I am testing through the full stack
-    And I force a varnish cache miss
     Then I should be able to visit:
     | Path                                                |
     | /marriage-abroad                                    |
@@ -54,8 +50,6 @@ Feature: Smart Answers
 
   @normal
   Scenario Outline: Viewing countries in a select element
-    Given I am testing through the full stack
-    And I force a varnish cache miss
     When I request "<Path>"
     Then I should see a populated country select
 
@@ -73,8 +67,6 @@ Feature: Smart Answers
 
   @normal
   Scenario Outline: Country names are correctly formatted
-    Given I am testing through the full stack
-    And I force a varnish cache miss
     When I request "<Path>"
     Then I should see "<Expected string>"
 
@@ -87,8 +79,6 @@ Feature: Smart Answers
 
   @normal
   Scenario Outline: Country slugs are correctly validated
-    Given I am testing through the full stack
-    And I force a varnish cache miss
     When I request "<Path>"
     Then the slug should be <Valid>
 
@@ -107,8 +97,6 @@ Feature: Smart Answers
 
   @normal
   Scenario Outline: Country FCOs can be looked up
-    Given I am testing through the full stack
-    And I force a varnish cache miss
     When I request "<Path>"
     Then I should see "<Expected string>"
 
@@ -120,8 +108,6 @@ Feature: Smart Answers
 
   @normal
   Scenario Outline: Postcode lookup
-    Given I am testing through the full stack
-    And I force a varnish cache miss
     When I request "<Path>"
     Then I should see "<Expected string>"
 

--- a/features/whitehall.feature
+++ b/features/whitehall.feature
@@ -2,16 +2,16 @@ Feature: Whitehall
   This is the Whitehall application that powers most pages under
   www.gov.uk/government and the detailed guidance format type.
 
-  @normal
-  Scenario: Government publishing section on GOV.UK homepage
+  Background:
     Given I am testing through the full stack
     And I force a varnish cache miss
+
+  @normal
+  Scenario: Government publishing section on GOV.UK homepage
     Then I should see the departments and policies section on the homepage
 
   @normal @notintegration
   Scenario: There should be no authentication for Whitehall
-    Given I am testing through the full stack
-    And I force a varnish cache miss
     Then I should be able to view policies
     And I should be able to view announcements
     And I should be able to view publications
@@ -24,15 +24,11 @@ Feature: Whitehall
 
   @normal
   Scenario: Searching for an existing consultation on whitehall via elastic search
-    Given I am testing through the full stack
-    And I force a varnish cache miss
     When I do a whitehall search for "Assessing radioactive waste disposal sites"
     Then I should see "Assessing radioactive waste disposal sites"
 
   @normal
   Scenario: Feeds should be available for documents
-    Given I am testing through the full stack
-    And I force a varnish cache miss
     Then I should be able to visit:
       | Path                           |
       | /government/announcements.atom |
@@ -40,8 +36,6 @@ Feature: Whitehall
 
   @normal
   Scenario: Visiting whitehall
-    Given I am testing through the full stack
-    And I force a varnish cache miss
     Then I should be able to view policies
     And I should be able to view announcements
     And I should be able to view publications
@@ -56,16 +50,12 @@ Feature: Whitehall
 
   @normal
   Scenario: Whitehall assets are redirected to and served from the asset host
-    Given I am testing through the full stack
-    And I force a varnish cache miss
     When I request an attachment
     Then I should be redirected to the asset host
     And the attachment should be served successfully
 
   @normal
   Scenario: Formats rendered by Whitehall respond OK
-    Given I am testing through the full stack
-    And I force a varnish cache miss
     Then I should be able to visit:
       | Path                                     |
       | /government/how-government-works         |


### PR DESCRIPTION
This commit cleans up the existing tests in a number of ways:

* Moves repeated steps within tests into “background” sections in each feature
* Standardises naming and spacing
* Removes some checks for HTTP status where we are also testing for other measures of success

Trello: https://trello.com/c/80OiCEtH/308-more-reliable-smokey-tests-on-aws-environments