### PR TITLE
Fix search cache busting

### DIFF
--- a/features/search.feature
+++ b/features/search.feature
@@ -2,7 +2,7 @@ Feature: Search
 
   Background:
     Given I am testing through the full stack
-    And I force a varnish cache miss
+    And I force a varnish cache miss for search
 
   @high
   Scenario: check search results for tax

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -19,11 +19,16 @@ end
 Given /^I am testing through the full stack$/ do
   @host = ENV["GOVUK_WEBSITE_ROOT"]
   @bypass_varnish = false
+  @bypass_varnish_for_search = false
   @authenticated = true
 end
 
 Given /^I force a varnish cache miss$/ do
   @bypass_varnish = true
+end
+
+Given /^I force a varnish cache miss for search$/ do
+  @bypass_varnish_for_search = true
 end
 
 Given /^I am not an authenticated user$/ do

--- a/features/support/http_requests.rb
+++ b/features/support/http_requests.rb
@@ -22,7 +22,7 @@ def uri_escape(s)
 end
 
 def default_request_options
-  { auth: @authenticated, cache_bust: @bypass_varnish, client_auth: @authenticated_as_client }
+  { auth: @authenticated, cache_bust: @bypass_varnish, search_cache_bust: @bypass_varnish_for_search, client_auth: @authenticated_as_client }
 end
 
 # Make a POST.
@@ -48,8 +48,8 @@ def post_request(url, options = {})
   }
 end
 
-def cache_bust(url)
-  cache_bust = 'cache_bust=' + rand.to_s
+def cache_bust(url, param: 'cache_bust')
+  cache_bust = "#{param}=#{rand}"
   separator = url.include?("?") ? "&" : "?"
   "#{url}#{separator}#{cache_bust}"
 end
@@ -75,7 +75,11 @@ def do_http_request(url, method = :get, options = {}, &block)
     # FIXME: this is set only in the interests of the migration period
     options[:verify_ssl] = false
   end
-  url = options[:cache_bust] ? cache_bust(url) : url
+  if options[:cache_bust]
+    url = cache_bust(url, param: 'cache_bust')
+  elsif options[:search_cache_bust]
+    url = cache_bust(url, param: 'c')
+  end
   if options[:auth]
     user     = ENV['AUTH_USERNAME']
     password = ENV['AUTH_PASSWORD']


### PR DESCRIPTION
This commit changes tests that use the search engine to cache bust with the `c` query string param (which is recognised by rummager) as opposed to `cache_bust` (which is not, but which is more descriptive).

Trello: https://trello.com/c/80OiCEtH/308-more-reliable-smokey-tests-on-aws-environments