### PR TITLE
Cache bust correctly for search API

### DIFF
--- a/features/publicapi.feature
+++ b/features/publicapi.feature
@@ -2,34 +2,38 @@ Feature: Public API
 
     Background:
       Given I am testing through the full stack
-      Given I force a varnish cache miss
 
     @normal
     Scenario: Check the search API returns data
+      Given I force a varnish cache miss for search
       When I request "/api/search.json"
       Then I should get a 200 status code
       And JSON is returned
 
     @normal
     Scenario: Check the content store returns data
+      Given I force a varnish cache miss
       When I request "/api/content/help"
       Then I should get a 200 status code
       And JSON is returned
 
     @normal
     Scenario: Check the collections organisations API returns data
+      Given I force a varnish cache miss
       When I request "/api/organisations"
       Then I should get a 200 status code
       And JSON is returned
 
     @normal
     Scenario: Check the whitehall governments API returns data
+      Given I force a varnish cache miss
       When I request "/api/governments"
       Then I should get a 200 status code
       And JSON is returned
 
     @normal
     Scenario: Check the whitehall world locations API returns data
+      Given I force a varnish cache miss
       When I request "/api/world-locations"
       Then I should get a 200 status code
       And JSON is returned


### PR DESCRIPTION
`/api/search.json` needs to use `c` rather than `cache_bust` for cache busting.

Trello: https://trello.com/c/80OiCEtH/308-more-reliable-smokey-tests-on-aws-environments