### PR TITLE
Remove status code checks

### DIFF
--- a/features/asset_manager.feature
+++ b/features/asset_manager.feature
@@ -5,12 +5,10 @@ Feature: Asset Manager
     Given I am testing "asset-manager" internally
     And I am an authenticated API client
     When I request "/assets/513a0efbed915d425e000002"
-    Then I should get a 200 status code
     And I should see "120613_Albania_Travel_Advice_WEB_Ed2_jpeg.jpg"
 
   @normal
   Scenario: Check an asset can be served
     Given I am testing "assets-origin"
     When I request "/media/513a0efbed915d425e000002/120613_Albania_Travel_Advice_WEB_Ed2_jpeg.jpg"
-    Then I should get a 200 status code
     And I should get a content length of "212880"

--- a/features/assets.feature
+++ b/features/assets.feature
@@ -4,7 +4,7 @@ Feature: Assets
   Scenario: Assets are being served
     Given I am testing "assets-origin"
     When I request "/__canary__"
-    Then I should get a 200 status code
+    Then JSON is returned
 
   @normal
   Scenario: Assets with a docx extension

--- a/features/frontend.feature
+++ b/features/frontend.feature
@@ -7,7 +7,6 @@ Feature: Frontend
   @normal
   Scenario: check robots.txt
     When I request "/robots.txt"
-    Then I should get a 200 status code
     Then I should see "User-agent:"
 
   @normal
@@ -46,8 +45,7 @@ Feature: Frontend
     Then I should see "Busking licence"
      And I should see an input field for postcode
     When I try to post to "/busking-licence" with "postcode=E20+2ST"
-    Then I should get a 200 status code
-     And I should see "Busking licence"
+    Then I should see "Busking licence"
 
   @normal
   Scenario: check local transactions load
@@ -61,8 +59,7 @@ Feature: Frontend
     When I visit "/ukonline-centre-internet-access-computer-training"
     And I should see "UK online centres"
     When I try to post to "/ukonline-centre-internet-access-computer-training" with "postcode=WC2B+6NH"
-    Then I should get a 200 status code
-    And I should see "Holborn Library"
+    Then I should see "Holborn Library"
 
   @normal
   Scenario: check campaign pages load
@@ -72,8 +69,6 @@ Feature: Frontend
   @normal
   Scenario: check browse page load, and links
     When I visit "/browse/driving"
-    Then I should get a 200 status code
     And I should see "Teaching people to drive"
     When I click on the section "Teaching people to drive"
-    Then I should get a 200 status code
-    And I should see "Apply to become a driving instructor"
+    Then I should see "Apply to become a driving instructor"

--- a/features/gov_uk.feature
+++ b/features/gov_uk.feature
@@ -25,5 +25,5 @@ Feature: Core GOV.UK behaviour
   Scenario: partially upper case slugs do not redirect
     Given I am testing through the full stack
     And I force a varnish cache miss
-    When I try to visit "/government/publicatIONS"
-    Then I should get a 404 status code
+    When I visit "/government/publicatIONS"
+    Then I should see "Page not found"

--- a/features/smartanswers.feature
+++ b/features/smartanswers.feature
@@ -5,17 +5,19 @@ Feature: Smart Answers
     And I force a varnish cache miss
 
   @normal
-  Scenario: Check selected smart answer start pages
-    Then I should be able to visit:
-    | Path                                        |
-    | /additional-commodity-code/y                |
-    | /calculate-employee-redundancy-pay/y        |
-    | /calculate-married-couples-allowance/y      |
-    | /marriage-abroad/y                          |
-    | /pay-leave-for-parents/y                    |
-    | /register-a-death/y                         |
-    | /vat-payment-deadlines/y                    |
-    And I should get a 200 status code
+  Scenario Outline: Check selected smart answer start pages
+    When I request "<Path>"
+    Then I should see "<Expected string>"
+
+    Examples:
+      | Path                                        | Expected string                                      |
+      | /additional-commodity-code/y                | How much starch or glucose does the product contain? |
+      | /calculate-employee-redundancy-pay/y        | What date was your employee made redundant?          |
+      | /calculate-married-couples-allowance/y      | Were you or your partner born before 6 April 1935?   |
+      | /marriage-abroad/y                          | Where do you want to get married?                    |
+      | /pay-leave-for-parents/y                    | Will the mother care for the child with a partner?   |
+      | /register-a-death/y                         | Where did the death happen?                          |
+      | /vat-payment-deadlines/y                    | When does your VAT accounting period end?            |
 
   @normal
   Scenario: step through a smart answer

--- a/features/whitehall.feature
+++ b/features/whitehall.feature
@@ -55,9 +55,11 @@ Feature: Whitehall
     And the attachment should be served successfully
 
   @normal
-  Scenario: Formats rendered by Whitehall respond OK
-    Then I should be able to visit:
-      | Path                                     |
-      | /government/how-government-works         |
-      | /government/people/eric-pickles          |
-    And I should get a 200 status code
+  Scenario Outline: Formats rendered by Whitehall respond OK
+    When I request "<Path>"
+    Then I should see "<Expected string>"
+
+    Examples:
+      | Path                             | Expected string             |
+      | /government/how-government-works | How government works        |
+      | /government/people/eric-pickles  | The Rt Hon Sir Eric Pickles |


### PR DESCRIPTION
This commit removes status code checks when they use the PhantomJS stack rather than the rack-test stack. Selenium does not support status code checks, so these will break once we switch. In addition, these checks are better made by looking for strings on the resulting page.

Trello: https://trello.com/c/80OiCEtH/308-more-reliable-smokey-tests-on-aws-environments