### PR TITLE
Make Chrome headless

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -62,6 +62,7 @@ Capybara.register_driver :headless_chrome do |app|
   )
 
   options = Selenium::WebDriver::Chrome::Options.new
+  options.add_argument("--headless")
   options.add_argument("--disable-gpu")
 
   Capybara::Selenium::Driver.new(


### PR DESCRIPTION
This commit makes Chrome run in headless mode so that it works when run in an automated fashion.

Trello: https://trello.com/c/80OiCEtH/308-more-reliable-smokey-tests-on-aws-environments