### PR TITLE
Ignore SSL errors

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -57,6 +57,7 @@ proxy.blacklist(/^https:\/\/licensify-admin(.*)\.publishing\.service\.gov\.uk\/f
 # Use Chrome in headless mode
 Capybara.register_driver :headless_chrome do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+    acceptInsecureCerts: true,
     loggingPrefs: { browser: "ALL" },
     proxy: { type: :manual, ssl: "#{proxy.host}:#{proxy.port}" }
   )


### PR DESCRIPTION
This commit sets a Chrome preference to ignore SSL errors during tests. This happens because headless Chrome doesn’t seem to support the same root certificate providers as Chrome in normal mode.

Trello: https://trello.com/c/80OiCEtH/308-more-reliable-smokey-tests-on-aws-environments