### PR TITLE
Send JS errors to $stderr

### DIFF
--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,3 +1,8 @@
 After do
-  Capybara::Chromedriver::Logger::TestHooks.after_example!
+  # Do this manually rather than using `after_example!` so we can configure
+  # the log destination to be $stderr rather than $stdout. This prevents
+  # unformatted JavaScript errors from making their way into the Smokey loop's
+  # JSON output file and breaking it.
+  collector = Capybara::Chromedriver::Logger::Collector.new(log_destination: $stderr)
+  collector.flush_and_check_errors!
 end


### PR DESCRIPTION
This commit changes the JS error logger to send error messages to `$stderr` rather than the default of `$stdout`. This should prevent the messages from appearing at the top of the Smokey loop JSON file and breaking it. They will still appear inside the JSON as an issue so will be flagged up.