### PR TITLE
Fix proxy server config for chrome driver

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -58,12 +58,12 @@ Capybara.register_driver :headless_chrome do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
     acceptInsecureCerts: true,
     loggingPrefs: { browser: "ALL" },
-    proxy: { type: :manual, ssl: "#{proxy.host}:#{proxy.port}" }
   )
 
   options = Selenium::WebDriver::Chrome::Options.new
   options.add_argument("--headless")
   options.add_argument("--disable-gpu")
+  options.add_argument(%(--proxy-server="http=#{proxy.host}:#{proxy.port};https=#{proxy.host}:#{proxy.port}"))
 
   Capybara::Selenium::Driver.new(
     app,


### PR DESCRIPTION
https://trello.com/c/ftCfaDhf/452-investigate-frequent-smokey-youtube-error

Fixes proxy configuration for Selenium chrome driver using the appropriate chrome option 'directly'.
See https://www.chromium.org/developers/design-documents/network-settings

The failing feature is `features/government_frontend.feature` as the page containing a Youtube video (youtube urls should be blacklisted as per the env config) is https://www.gov.uk/government/case-studies/out-of-syria-back-into-school

example fail: 
https://deploy.staging.publishing.service.gov.uk/job/Smokey/10362/console

