### PR TITLE
Check status codes

### DIFF
--- a/features/government_frontend.feature
+++ b/features/government_frontend.feature
@@ -5,10 +5,11 @@ Feature: Government Frontend
     And I force a varnish cache miss
 
     @normal
-    Scenario: Check example pages across formats
-      Given I am testing through the full stack
-      And I force a varnish cache miss
-      Then I should be able to visit:
+    Scenario Outline: Check example pages across formats
+      When I request "<Path>"
+      Then I should get a 200 status code
+
+      Examples:
         | Path                                                                                                  |
         | /government/case-studies/out-of-syria-back-into-school                                                |
         | /foreign-travel-advice/belgium                                                                        |

--- a/features/whitehall.feature
+++ b/features/whitehall.feature
@@ -23,11 +23,14 @@ Feature: Whitehall
       | /government/publications.atom  |
 
   @normal
-  Scenario: Check whitehall pages load
+  Scenario Outline: Check whitehall pages load
     Then I should be able to view policies
     And I should be able to view announcements
     And I should be able to view publications
-    Then I should be able to visit:
+    When I request "<Path>"
+    Then I should get a 200 status code
+
+    Examples:
       | Path                             |
       | /government/how-government-works |
       | /government/get-involved         |


### PR DESCRIPTION
https://trello.com/c/ftCfaDhf/452-investigate-frequent-smokey-youtube-error

This is a workaround to the original problem details in the trello card.
The test which was failing used Capybara's `page.visit` for the step _I should be able to visit:_
this sporadically threw the underlying CORS error which made the feature fail.
The test itself didn't do anything other than visit the pages though so it's arguably worthless in its current form, I've amended to check the status codes of the listed paths, this uses `Net::HTTP` and not Capybara which circumvents the js errors but at least checks the pages respond successfully.