### PR TITLE
Remove tests related to policies

### DIFF
--- a/features/finder_frontend.feature
+++ b/features/finder_frontend.feature
@@ -12,13 +12,6 @@ Feature: Finder Frontend
     And I should see an input field to search
 
   @normal
-  Scenario: Check policy page loads correctly
-    When I visit "/government/policies"
-    Then I should see "Policies"
-    And I should see an input field to search
-    And I should see a closed facet titled "Organisation" with non-blank values
-
-  @normal
   Scenario: Check world organisations loads correctly
     When I visit "/world/organisations"
     Then I should see "Worldwide organisations"

--- a/features/step_definitions/whitehall_steps.rb
+++ b/features/step_definitions/whitehall_steps.rb
@@ -3,10 +3,6 @@ Then /^I should see the departments and policies section on the homepage$/ do
   assert page.first('#departments-and-policy')
 end
 
-Then /^I should be able to view policies$/ do
-  follow_link_to_first_policy_on_policies_page
-end
-
 Then /^I should be able to view publications$/ do
   follow_link_to_first_publication_on_publications_page
 end
@@ -37,11 +33,6 @@ end
 Then(/^the attachment should be served successfully$/) do
   expect(@response.request.url).to match(@attachment_path)
   expect(@response.code).to eq(200)
-end
-
-def follow_link_to_first_policy_on_policies_page
-  visit_path "/government/policies"
-  visit_path page.first('.document a')['href']
 end
 
 def follow_link_to_first_announcement_on_announcements_page

--- a/features/whitehall.feature
+++ b/features/whitehall.feature
@@ -24,8 +24,7 @@ Feature: Whitehall
 
   @normal
   Scenario Outline: Check whitehall pages load
-    Then I should be able to view policies
-    And I should be able to view announcements
+    Then I should be able to view announcements
     And I should be able to view publications
     When I request "<Path>"
     Then I should get a 200 status code


### PR DESCRIPTION
The policy pages have now been replaced by the Topic Taxonomy, so
remove the tests as the policy pages are now being removed.