### PR TITLE
Use chromedriver from the path if available

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "cucumber", "~> 3"
 gem "minitest", "~> 5"
 gem "nokogiri", "~> 1"
 gem "plek", "~> 2"
+gem 'ptools'
 gem "rake", "~> 12"
 gem "rest-client", "~> 2"
 gem "rspec", "~> 3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
     pry-byebug (3.6.0)
       byebug (~> 10.0)
       pry (~> 0.10)
+    ptools (1.3.5)
     public_suffix (3.0.3)
     rack (2.0.5)
     rack-test (1.1.0)
@@ -127,6 +128,7 @@ DEPENDENCIES
   nokogiri (~> 1)
   plek (~> 2)
   pry-byebug (~> 3)
+  ptools
   rake (~> 12)
   rest-client (~> 2)
   rspec (~> 3)

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -3,7 +3,6 @@ require 'capybara/chromedriver/logger'
 require 'capybara/cucumber'
 require 'nokogiri'
 require 'plek'
-require 'chromedriver-helper'
 require 'selenium-webdriver'
 require 'uri'
 
@@ -53,6 +52,15 @@ proxy.blacklist(/^https:\/\/s\.ytimg\.com/i, 200)
 
 # Licensify admin doesn't have favicon.ico so block requests to prevent errors
 proxy.blacklist(/^https:\/\/licensify-admin(.*)\.publishing\.service\.gov\.uk\/favicon\.ico$/i, 200)
+
+chromedriver_from_path = File.which("chromedriver")
+
+if chromedriver_from_path
+  # Use the installed chromedriver, rather than chromedriver-helper
+  Selenium::WebDriver::Chrome.driver_path = chromedriver_from_path
+else
+  require 'chromedriver-helper'
+end
 
 # Use Chrome in headless mode
 Capybara.register_driver :headless_chrome do |app|


### PR DESCRIPTION
Currently Smokey is failing on Integration, probably because it can't
run chromedriver. The machine has chromedriver installed, but because
of the chromedriver-helper gem, this won't be used. Therefore, check
if chromedriver is available, and if it is, use it, rather than
loading chromedriver-helper.