### PR TITLE
Revert "Disable failing scenario"

### DIFF
--- a/features/gov_uk_redirect.feature
+++ b/features/gov_uk_redirect.feature
@@ -6,7 +6,7 @@ Feature: Redirect of gov.uk to www.gov.uk
     Then I should get a 301 status code
     And I should get a "Location" header of "https://www.gov.uk/"
 
-  @pending
+  @normal
   Scenario: Check redirect from service domain to GOV.UK has HSTS enabled
     When I visit "https://service.gov.uk/" without following redirects
     Then I should get a 302 status code


### PR DESCRIPTION
Reverts alphagov/smokey#419

The service.gov.uk to gov.uk redirect has now been restored.