### PR TITLE
Remove test dependency on related links for foreign travel advice pages

### DIFF
--- a/features/foreign_travel_advice.feature
+++ b/features/foreign_travel_advice.feature
@@ -16,7 +16,6 @@ Feature: Foreign Travel Advice
     When I visit "/foreign-travel-advice/luxembourg"
     Then I should see "Luxembourg"
     And I should see "Summary"
-    And I should see "About Foreign and Commonwealth Office travel advice"
 
   @normal
   Scenario: Check feeds are available for both index and countries


### PR DESCRIPTION
This PR removes the dependency on related links for the test scenario _Check a country page loads correctly_. Related links are changeable pieces of content and therefore should not be directly tied to the automated tests which check our production environment is operational.

This was raised from the recent A/B tests around related links, which for the B variant of this test has removed the related link being relied upon.

Solo: @karlbaker02