### PR TITLE
Limit 'www' frontend checks to only run on AWS

### DIFF
--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -1,6 +1,6 @@
 # Options specific to a GOV.UK environment
 integration: -t "not @pending" -t "not @notintegration" -t "not @notaws"
-staging: -t "not @pending" -t "not @notstaging"
-production: -t "not @pending" -t "not @notproduction"
+staging: -t "not @pending" -t "not @notstaging" -t "not @aws"
+production: -t "not @pending" -t "not @notproduction" -t "not @aws"
 staging_aws: -t "not @pending" -t "not @notstaging" -t "not @notaws"
 production_aws: -t "not @pending" -t "not @notproduction" -t "not @notaws"

--- a/features/calendars.feature
+++ b/features/calendars.feature
@@ -1,3 +1,4 @@
+@aws
 Feature: Calendars
 
   Background:

--- a/features/contacts.feature
+++ b/features/contacts.feature
@@ -1,3 +1,4 @@
+@aws
 Feature: Contacts
 
   Background:

--- a/features/frontend.feature
+++ b/features/frontend.feature
@@ -1,3 +1,4 @@
+@aws
 Feature: Frontend
 
   Background:

--- a/features/government_frontend.feature
+++ b/features/government_frontend.feature
@@ -1,3 +1,4 @@
+@aws
 Feature: Government Frontend
 
   Background:

--- a/features/router.feature
+++ b/features/router.feature
@@ -1,3 +1,4 @@
+@aws
 Feature: Router
 
   Background:

--- a/features/search.feature
+++ b/features/search.feature
@@ -1,3 +1,4 @@
+@aws
 Feature: Search
   Tests for the GOV.UK search engine.
 

--- a/features/smartanswers.feature
+++ b/features/smartanswers.feature
@@ -1,3 +1,4 @@
+@aws
 Feature: Smart Answers
 
   Background:

--- a/features/whitehall.feature
+++ b/features/whitehall.feature
@@ -1,3 +1,4 @@
+@aws
 Feature: Whitehall
   Tests for the whitehall application that powers some pages under
   www.gov.uk/government and www.gov.uk/world.


### PR DESCRIPTION
Since the migration, our Carrenza machines can no longer access GOV.UK
staging. This limits checks that rely on access to GOV.UK staging to
only run on AWS machines. Even though this isnt' an issue in production,
because we don't limit access to www.gov.uk, it makes sense to not run
these checks there as there's no companion environment to debug them in.