### PR TITLE
Update announcements tests

### DIFF
--- a/features/email_sign_up.feature
+++ b/features/email_sign_up.feature
@@ -26,8 +26,8 @@ Feature: Email signup
     Then I should see "How often do you want to get updates?"
 
   @normal
-  Scenario: Starting from announcements
-    When I visit "/government/announcements"
+  Scenario: Starting from the news and communications finder
+    When I visit "/search/news-and-communications"
     And I click on the link "email"
     Then I should see "Email alert subscription"
     When I click on the button "Create subscription"

--- a/features/step_definitions/whitehall_steps.rb
+++ b/features/step_definitions/whitehall_steps.rb
@@ -7,10 +7,6 @@ Then /^I should be able to view publications$/ do
   follow_link_to_first_publication_on_publications_page
 end
 
-Then /^I should be able to view announcements$/ do
-  follow_link_to_first_announcement_on_announcements_page
-end
-
 When /^I do a whitehall search for "([^"]*)"$/ do |term|
   visit_path "/government/publications?keywords=#{uri_escape(term)}"
 end
@@ -33,11 +29,6 @@ end
 Then(/^the attachment should be served successfully$/) do
   expect(@response.request.url).to match(@attachment_path)
   expect(@response.code).to eq(200)
-end
-
-def follow_link_to_first_announcement_on_announcements_page
-  visit_path "/government/announcements?page=1"
-  visit_path page.first('.document-row a')['href']
 end
 
 def follow_link_to_first_publication_on_publications_page

--- a/features/whitehall.feature
+++ b/features/whitehall.feature
@@ -25,8 +25,7 @@ Feature: Whitehall
 
   @normal
   Scenario Outline: Check whitehall pages load
-    Then I should be able to view announcements
-    And I should be able to view publications
+    Then I should be able to view publications
     When I request "<Path>"
     Then I should get a 200 status code
 


### PR DESCRIPTION
We're now redirecting /government/announcements requests to /search/news-and-communications
which lives in finder-frontend

Atom feeds and translated announcements finders aren't part of this yet.