### PR TITLE
Add a Smokey test for data.gov.uk dataset count

### DIFF
--- a/features/data_gov_uk.feature
+++ b/features/data_gov_uk.feature
@@ -28,3 +28,21 @@ Feature: Data.gov.uk
     And I force a varnish cache miss
     When I request "/"
     Then I should see "Data publisher"
+
+  @high
+  Scenario: Check datasets sync between CKAN and Find
+    Given I am testing "https://ckan.publishing.service.gov.uk"
+    And I force a varnish cache miss
+    When I request "/api/3/action/package_list"
+    And I save the dataset count
+    Given I am testing "https://data.gov.uk"
+    And I force a varnish cache miss
+    When I search for "" in datasets
+    Then I should see a similar dataset count
+
+  @high
+  Scenario: Check there is an accurate number of datasets
+    Given I am testing "https://data.gov.uk"
+    And I force a varnish cache miss
+    When I search for "" in datasets
+    Then I should see an accurate dataset count

--- a/features/step_definitions/datagovuk_steps.rb
+++ b/features/step_definitions/datagovuk_steps.rb
@@ -6,3 +6,26 @@ Then /^I should see some dataset results$/ do
   result_links = page.all(".dgu-results__result")
   expect(result_links.count).to be >= 1
 end
+
+When /^I save the dataset count$/ do
+  json = JSON.parse(@response.body)
+  @package_count = json.fetch("result").count
+end
+
+Then /^I should see a similar dataset count$/ do
+  count_span = page.first(".dgu-results__summary span.bold-small")
+  count = count_span.text.gsub(/[^\d^\.]/, '').to_i
+
+  # to account for a delay in the sync between CKAN and Find, we only check
+  # that the counts are similar, and not exactly the same
+  expect(count).to be_within(25).of(@package_count)
+end
+
+Then /^I should see an accurate dataset count$/ do
+  count_span = page.first(".dgu-results__summary span.bold-small")
+  count = count_span.text.gsub(/[^\d^\.]/, '').to_i
+
+  # this is correct as of the 2nd April 2019, we might need to increase this
+  # number in the future if more datasets are published
+  expect(count).to be_within(1000).of(49557)
+end


### PR DESCRIPTION
This checks that the dataset count in CKAN closely matches the dataset count in the data.gov.uk Find frontend. This is because sometimes the syncing process can fail between CKAN and Find, and this test should alert us to that fact quickly.

[Trello Card](https://trello.com/c/TGd6sSbe/904-add-a-smokey-check-for-the-number-of-datasets-in-datagovuk-find)