### PR TITLE
Remove the consultations finder from the whitehall tests

### DIFF
--- a/features/whitehall.feature
+++ b/features/whitehall.feature
@@ -33,7 +33,6 @@ Feature: Whitehall
       | Path                             |
       | /government/how-government-works |
       | /government/get-involved         |
-      | /government/consultations        |
       | /government/ministers            |
       | /government/people/eric-pickles  |
       | /world                           |


### PR DESCRIPTION
This page is now served by finder-frontend