### PR TITLE
Change "view publications" step for migrated finder

### DIFF
--- a/features/step_definitions/whitehall_steps.rb
+++ b/features/step_definitions/whitehall_steps.rb
@@ -33,5 +33,5 @@ end
 
 def follow_link_to_first_publication_on_publications_page
   visit_path "/government/publications"
-  visit_path page.first('.document-row a')['href']
+  visit_path page.first('.document a')['href']
 end


### PR DESCRIPTION
This is now in finder-frontend, which has slightly different HTML.