### PR TITLE
Remove Whitehall publications finder from tests

### DIFF
--- a/features/email_sign_up.feature
+++ b/features/email_sign_up.feature
@@ -35,7 +35,7 @@ Feature: Email signup
 
   @normal
   Scenario: Starting from a whitehall finder
-    When I visit "/government/publications"
+    When I visit "/government/statistics"
     And I click on the link "email"
     Then I should see "Create subscription"
     When I click on the button "Create subscription"

--- a/features/gov_uk.feature
+++ b/features/gov_uk.feature
@@ -24,13 +24,13 @@ Feature: Core GOV.UK behaviour
   Scenario: Check entirely upper case slugs redirect to lowercase
     Given I am testing through the full stack
     And I force a varnish cache miss
-    When I visit "/GOVERNMENT/PUBLICATIONS" without following redirects
+    When I visit "/GOVERNMENT/STATISTICS" without following redirects
     Then I should get a 301 status code
-    And I should be at a location path of "/government/publications"
+    And I should be at a location path of "/government/statistics"
 
   @normal
   Scenario: Check partially upper case slugs do not redirect
     Given I am testing through the full stack
     And I force a varnish cache miss
-    When I visit "/government/publicatIONS" without following redirects
+    When I visit "/government/statisTICS" without following redirects
     Then I should see "Page not found"

--- a/features/step_definitions/whitehall_steps.rb
+++ b/features/step_definitions/whitehall_steps.rb
@@ -3,14 +3,6 @@ Then /^I should see the departments and policies section on the homepage$/ do
   assert page.first('#departments-and-policy')
 end
 
-Then /^I should be able to view publications$/ do
-  follow_link_to_first_publication_on_publications_page
-end
-
-When /^I do a whitehall search for "([^"]*)"$/ do |term|
-  visit_path "/government/publications?keywords=#{uri_escape(term)}"
-end
-
 When(/^I request an attachment$/) do
   @attachment_path = '/government/uploads/system/uploads/attachment_data/file/618167/government_dietary_recommendations.pdf'
   step %Q(I request "#{@attachment_path}")
@@ -29,9 +21,4 @@ end
 Then(/^the attachment should be served successfully$/) do
   expect(@response.request.url).to match(@attachment_path)
   expect(@response.code).to eq(200)
-end
-
-def follow_link_to_first_publication_on_publications_page
-  visit_path "/government/publications"
-  visit_path page.first('.document a')['href']
 end

--- a/features/whitehall.feature
+++ b/features/whitehall.feature
@@ -12,20 +12,14 @@ Feature: Whitehall
     Then I should see the departments and policies section on the homepage
 
   @normal
-  Scenario: Check searching for an existing consultation on whitehall
-    When I do a whitehall search for "Assessing radioactive waste disposal sites"
-    Then I should see "Assessing radioactive waste disposal sites"
-
-  @normal
   Scenario: Check feeds are available for documents
     Then I should be able to visit:
       | Path                           |
       | /government/announcements.atom |
-      | /government/publications.atom  |
+      | /government/statistics.atom  |
 
   @normal
   Scenario Outline: Check whitehall pages load
-    Then I should be able to view publications
     When I request "<Path>"
     Then I should get a 200 status code
 


### PR DESCRIPTION
This PR removes tests which are specific to the Whitehall publications finder, which is being removed as it does map directly to any of the new finders.

Tests for existing documents rendered by `government-frontend` and including the URL `/government/publications/path/to/doc` will continue to be rendered in this way, so these tests are not removed in this commit.

Trello: https://trello.com/c/3BuGZK2A