### PR TITLE
Add AWS variations of the test Rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,22 +1,12 @@
 require 'rubygems'
 require 'cucumber/rake/task'
 
-Cucumber::Rake::Task.new("test:integration",
-    "Run all tests that are valid in our integration environment") do |t|
-  t.profile = "integration"
-  t.cucumber_opts = %w{ENVIRONMENT=integration --format pretty -t "not @benchmarking"}
-end
-
-Cucumber::Rake::Task.new("test:staging",
-                         "Run all tests that are valid in our staging environment") do |t|
-  t.profile = "staging"
-  t.cucumber_opts = %w{ENVIRONMENT=staging --format pretty -t "not @benchmarking"}
-end
-
-Cucumber::Rake::Task.new("test:production",
-    "Run all tests that are valid in our production environment") do |t|
-  t.profile = "production"
-  t.cucumber_opts = %w{ENVIRONMENT=production --format pretty -t "not @benchmarking"}
+%w(integration staging staging_aws production production_aws).each do |environment|
+  Cucumber::Rake::Task.new("test:#{environment}",
+      "Run all tests that are valid in our #{environment} environment") do |t|
+    t.profile = environment
+    t.cucumber_opts = %W{ENVIRONMENT=#{environment} --format pretty -t "not @benchmarking"}
+  end
 end
 
 Cucumber::Rake::Task.new("test:notlocalnetwork",

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -24,7 +24,7 @@ when "production", "production_aws"
   ENV["GOVUK_APP_DOMAIN"] ||= "publishing.service.gov.uk"
   ENV["GOVUK_WEBSITE_ROOT"] ||= "https://www.gov.uk"
 else
-  raise "ENVIRONMENT should be one of integration, staging or production"
+  raise "ENVIRONMENT should be one of integration, staging, staging_aws, production or production_aws"
 end
 
 # Set up basic URLs


### PR DESCRIPTION
These are run by the Smokey job in Jenkins https://github.com/alphagov/govuk-puppet/commit/ebb986a591d402c735456741cd74e1560dab0816 but the job itself doesn't currently exist.

[Trello Card](https://trello.com/c/d5e240P1/873-fix-smokey-in-aws)