### PR TITLE
Fix failing test related to email signups

### DIFF
--- a/features/email_sign_up.feature
+++ b/features/email_sign_up.feature
@@ -21,8 +21,10 @@ Feature: Email signup
   Scenario: Starting from an organisation home page
     When I visit "/government/organisations/department-for-education"
     And I click on the link "email"
-    Then I should see "Create subscription"
-    When I click on the button "Create subscription"
+    Then I should see "Get email alerts"
+    When I click on the link "Select"
+    Then I should see "What you’ll get"
+    When I click on the button "Sign up now"
     Then I should see "How often do you want to get updates?"
 
   @normal


### PR DESCRIPTION
This process has changed and the test wasn't updated with it. This and https://github.com/alphagov/smokey/pull/506 should fix the two email sign up tests which are currently failing in production.

[Trello Card](https://trello.com/c/kIWZu3HP/958-revisit-smokey-tests)