### PR TITLE
Don't check for HSTS headers in non-https

### DIFF
--- a/features/gov_uk_redirect.feature
+++ b/features/gov_uk_redirect.feature
@@ -1,11 +1,10 @@
 Feature: Redirect of gov.uk to www.gov.uk
 
   @high
-  Scenario: Check redirect from bare domain to www.gov.uk is working for HTTP and has HSTS enabled
+  Scenario: Check redirect from bare domain to www.gov.uk is working for HTTP
     When I visit "http://gov.uk/" without following redirects
     Then I should get a 301 status code
     And I should get a "Location" header of "https://gov.uk/"
-    And I should get a "Strict-Transport-Security" header of "max-age=63072000; preload"
 
   @high
   Scenario: Check redirect from bare domain to www.gov.uk is working for HTTPS and has HSTS enabled
@@ -15,11 +14,10 @@ Feature: Redirect of gov.uk to www.gov.uk
     And I should get a "Strict-Transport-Security" header of "max-age=63072000; preload"
 
   @high
-  Scenario: Check www.gov.uk redirect from HTTP to HTTPS is working and has HSTS enabled
+  Scenario: Check www.gov.uk redirect from HTTP to HTTPS is working
     When I visit "http://www.gov.uk/" without following redirects
     Then I should get a 301 status code
     And I should get a "Location" header of "https://www.gov.uk/"
-    And I should get a "Strict-Transport-Security" header of "max-age=31536000; preload"
 
   @normal
   Scenario: Check redirect from service domain to GOV.UK has HSTS enabled


### PR DESCRIPTION
These headers are only returned from the https version of gov.uk not the plain http versions.

[Mozilla's information about HSTS headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security#Description) states:

> The `Strict-Transport-Security` header is ignored by the browser when your site is accessed using HTTP; this is because an attacker may intercept HTTP connections and inject the header or remove it. When your site is accessed over HTTPS with no certificate errors, the browser knows your site is HTTPS capable and will honor the `Strict-Transport-Security` header.

[Trello Card](https://trello.com/c/kIWZu3HP/958-revisit-smokey-tests)