### PR TITLE
Fix finder facet selector

### DIFF
--- a/features/step_definitions/finder_frontend_steps.rb
+++ b/features/step_definitions/finder_frontend_steps.rb
@@ -19,7 +19,7 @@ And /^I should see an? (open|closed) facet titled "(.*?)" with non-blank values$
     facet.find('button').click
   end
 
-  labels = facet.all('.options-container label').map(&:text)
+  labels = facet.all('.js-options-container label').map(&:text)
   blank_labels = labels.select { |label| label.strip.empty? }
 
   expect(labels).not_to be_empty


### PR DESCRIPTION
This was changed in https://github.com/alphagov/finder-frontend/commit/b6f42dfe6b318e0937d963591c5c0600826dc5ae but the Smokey tests weren't updated. The class name is now prefixed with `js-`.

[Trello Card](https://github.com/alphagov/finder-frontend/commit/b6f42dfe6b318e0937d963591c5c0600826dc5ae)