### PR TITLE
Fix email sign up

### DIFF
--- a/features/email_sign_up.feature
+++ b/features/email_sign_up.feature
@@ -37,7 +37,7 @@ Feature: Email signup
 
   @normal
   Scenario: Starting from a whitehall finder
-    When I visit "/government/publications"
+    When I visit "/government/statistics"
     And I click on the link "email"
     Then I should see "Create subscription"
     When I click on the button "Create subscription"


### PR DESCRIPTION
The old /government/publications route has been replaced by a redirect to search and is no longer available as Whitehall finder. /government/statistics still exists as a finder so we can switch to using that one.

[Trello Card](https://trello.com/c/kIWZu3HP/958-revisit-smokey-tests)