### PR TITLE
Improvements to data.gov.uk tests

### DIFF
--- a/features/data_gov_uk.feature
+++ b/features/data_gov_uk.feature
@@ -25,15 +25,13 @@ Feature: Data.gov.uk
   @high
   Scenario: Check CKAN loads correctly
     Given I am testing "https://ckan.publishing.service.gov.uk"
-    And I force a varnish cache miss
     When I request "/"
     Then I should see "Data publisher"
 
   @high
   Scenario: Check datasets sync between CKAN and Find
     Given I am testing "https://ckan.publishing.service.gov.uk"
-    And I force a varnish cache miss
-    When I request "/api/3/action/package_list"
+    When I request "/api/3/search/dataset"
     And I save the dataset count
     Given I am testing "https://data.gov.uk"
     And I force a varnish cache miss

--- a/features/step_definitions/datagovuk_steps.rb
+++ b/features/step_definitions/datagovuk_steps.rb
@@ -9,7 +9,7 @@ end
 
 When /^I save the dataset count$/ do
   json = JSON.parse(@response.body)
-  @package_count = json.fetch("result").count
+  @package_count = json.fetch("count")
 end
 
 Then /^I should see a similar dataset count$/ do

--- a/features/step_definitions/datagovuk_steps.rb
+++ b/features/step_definitions/datagovuk_steps.rb
@@ -25,7 +25,7 @@ Then /^I should see an accurate dataset count$/ do
   count_span = page.first(".dgu-results__summary span.bold-small")
   count = count_span.text.gsub(/[^\d^\.]/, '').to_i
 
-  # this is correct as of the 2nd April 2019, we might need to increase this
+  # this is correct as of the 26th April 2019, we might need to increase this
   # number in the future if more datasets are published
-  expect(count).to be_within(1000).of(49557)
+  expect(count).to be_within(1500).of(52823)
 end


### PR DESCRIPTION
This improves the speed by using the quicker search endpoint and improves the accuracy of the dataset count test.

[Trello Card](https://trello.com/c/kIWZu3HP/958-revisit-smokey-tests)