### PR TITLE
Use more accurate dataset count

### DIFF
--- a/features/data_gov_uk.feature
+++ b/features/data_gov_uk.feature
@@ -31,7 +31,7 @@ Feature: Data.gov.uk
   @high
   Scenario: Check datasets sync between CKAN and Find
     Given I am testing "https://ckan.publishing.service.gov.uk"
-    When I request "/api/3/search/dataset"
+    When I request "/api/3/action/package_search"
     And I save the dataset count
     Given I am testing "https://data.gov.uk"
     And I force a varnish cache miss

--- a/features/step_definitions/datagovuk_steps.rb
+++ b/features/step_definitions/datagovuk_steps.rb
@@ -9,7 +9,7 @@ end
 
 When /^I save the dataset count$/ do
   json = JSON.parse(@response.body)
-  @package_count = json.fetch("count")
+  @package_count = json.fetch("result").fetch("count")
 end
 
 Then /^I should see a similar dataset count$/ do


### PR DESCRIPTION
It turns out there are multiple ways of counting the number of datasets in CKAN:

- https://ckan.publishing.service.gov.uk/api/3/action/package_search
- https://ckan.publishing.service.gov.uk/api/3/search/dataset
- https://ckan.publishing.service.gov.uk/api/3/action/package_list

Each one gives a slightly different package count. This is because some of them get their data from Solr and some of them get it from Postgres. Solr is meant to be an accurate representation of the Postgres database, but there are no guarantees and sometimes it can end up out of sync. By using the Postgres count, we'll get the most accurate value.

[Trello Card](https://trello.com/c/FkQuWu3i/943-investigate-datagovukpublish-being-unable-to-access-ckan-api-sometimes)