### PR TITLE
Use assets domain for checking asset-manager

### DIFF
--- a/features/assets.feature
+++ b/features/assets.feature
@@ -4,7 +4,7 @@ Feature: Assets
 
   @high
   Scenario: Check assets are being served
-    Given I am testing "assets-origin"
+    Given I am testing "assets"
     When I request "/__canary__"
     Then JSON is returned
 
@@ -17,19 +17,19 @@ Feature: Assets
 
   @normal
   Scenario: Check an asset can be served
-    Given I am testing "assets-origin"
+    Given I am testing "assets"
     When I request "/media/513a0efbed915d425e000002/120613_Albania_Travel_Advice_WEB_Ed2_jpeg.jpg"
     And I should get a content length of "212880"
 
   @normal
   Scenario: Check assets with a docx extension are served correctly
-    Given I am testing "assets-origin"
+    Given I am testing "assets"
     When I request "/media/59f70d5640f0b66bbc806ed3/questionnaire-for-accommodation-providers-online-hotel-booking.docx"
     Then I should get a "Content-Type" header of "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
 
   @normal
   Scenario: Check assets with an xls extension are served correctly
-    Given I am testing "assets-origin"
+    Given I am testing "assets"
     When I request "/media/580768d940f0b64fbe000022/Target_incomes_calculator.xls"
     Then I should get a "Content-Type" header of "application/vnd.ms-excel"
 


### PR DESCRIPTION
`assets-origin` is not the correct domain for this since the AWS migration. It should be just `assets` which goes through Fastly. This is similar to `www` vs `www-origin`. Example:

- https://assets.publishing.service.gov.uk/media/513a0efbed915d425e000002/120613_Albania_Travel_Advice_WEB_Ed2_jpeg.jpg
- https://assets-origin.publishing.service.gov.uk/media/513a0efbed915d425e000002/120613_Albania_Travel_Advice_WEB_Ed2_jpeg.jpg

[Trello Card](https://trello.com/c/kIWZu3HP/958-revisit-smokey-tests)