### PR TITLE
Update text to search for on FOI page

### DIFF
--- a/features/feedback.feature
+++ b/features/feedback.feature
@@ -18,4 +18,4 @@ Feature: Feedback
   @normal
   Scenario: Check the FoI page loads correctly
     When I visit "/contact/foi"
-    Then I should see "Make a Freedom of Information request"
+    Then I should see "How to make a freedom of information (FOI) request"


### PR DESCRIPTION
The /contact/foi page has been replaced with a redirect to /make-a-freedom-of-information-request which has a different title.

See https://github.com/alphagov/feedback/pull/703 for more information.

[Trello Card](https://trello.com/c/kIWZu3HP/958-revisit-smokey-tests)