### PR TITLE
Fix expected smartanswers text

### DIFF
--- a/features/smartanswers.feature
+++ b/features/smartanswers.feature
@@ -103,7 +103,7 @@ Feature: Smart Answers
     Examples:
       | Path                                                           | Expected string                 |
       | /marriage-abroad/y/afghanistan/uk/partner_british/opposite_sex | Embassy of Afghanistan          |
-      | /register-a-death/y/overseas/north-korea/same_country          | Pyongyang.enquiries@fco.gov.uk  |
+      | /register-a-death/y/overseas/north-korea/same_country          | British Embassy Pyongyang       |
 
   @normal
   Scenario Outline: Check postcode lookup


### PR DESCRIPTION
The email address is no longer present on https://www.gov.uk/register-a-death/y/overseas/north-korea/same_country

Resolves https://alert.production.govuk.digital/cgi-bin/icinga/extinfo.cgi?type=2&host=ip-10-13-5-163.eu-west-1.compute.internal&service=Run+smartanswers+normal+priority+tests