### PR TITLE
Update following service standard rename

### DIFF
--- a/features/service_manual.feature
+++ b/features/service_manual.feature
@@ -22,4 +22,4 @@ Feature: Service Manual
   @normal
   Scenario: Check the service standard page loads correctly
     When I visit "/service-manual/service-standard"
-    Then I should see "Digital Service Standard"
+    Then I should see "Service Standard"


### PR DESCRIPTION
The 'Digital' has been dropped from the name.