### PR TITLE
Improvements to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ After that, it's a standard Ruby setup:
 bundle install
 ```
 
-### Running the tests
+## Running the tests
 
 Run the suite with:
 
@@ -87,6 +87,24 @@ You can use the following environment variables to configure the tests:
 * `RATE_LIMIT_TOKEN`
   * Default: Blank
   * A token used to bypass the default rate limiting.
+
+### HTTP status code failure
+
+A common test failure is `HTTP status code 550 (RestClient::RequestFailed)`. This is a result of the BrowserMob Proxy java process running as part of a previously aborted smokey-loop and the new smoke tests cannot start a new proxy.
+
+It's necessary to kill the existing java process (replace process numbers as appropriate).
+
+```sh
+$ ps -ef | grep java
+> smokey    6385  6380 26 14:58 ?        00:00:54 java -Dapp.name=browsermob-proxy -Dbasedir=/opt/smokey -jar /opt/smokey/lib/browsermob-dist-2.1.4.jar --port 3222
+$ sudo kill -9 6385
+```
+
+You can even set up an alias in your `~/.bash_profile`:
+
+```sh
+alias killbrowsermob="ps xu | grep browsermob-proxy | grep -v grep | awk '{ print $2 }' | xargs kill -9"
+```
 
 ### Spoofing the target domain
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,20 @@ files to describe single applications (eg
 [`whitehall`](https://github.com/alphagov/whitehall),
 [`frontend`](https://github.com/alphagov/frontend)) or [cross-application behaviour](features/gov_uk.feature).
 
+### Installation
+
+Smokey requires Java to be installed, because of its [use of the BrowserMob Proxy](#use-of-browsermob-proxy). Note that if you're using the Development VM then Java is already installed.
+
+If you're not using the VM, or want to run Smokey on your host Mac, run `brew cask install java`.
+
+If you don't have Homebrew installed, or are not using a Mac, you can [download the Java JDK from the OpenJDK website](https://openjdk.java.net/).
+
+After that, it's a standard Ruby setup:
+
+```
+bundle install
+```
+
 ### Running the tests
 
 Run the suite with:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ applications within the GOV.UK stack.
 These are used to verify releases and also to provide Icinga alerts for major
 features.
 
+The tests are run against integration, staging and production environments, and are triggered by deployments of most GOV.UK applications, CDNs and associated dependencies (`grep -i "smokey" modules/govuk_jenkins/templates/jobs/*` in the [govuk-puppet repository](https://github.com/alphagov/govuk-puppet) for a full list).
+
 ## Technical documentation
 
 The smoke tests are based on [Cucumber](https://cucumber.io/). We use feature


### PR DESCRIPTION
## Java instructions

I was surprised to run `bundle install` and see a system popup about a missing Java SDK, so it's a good idea to be explicit that Java is required.

I also ended up registering for an Oracle account, not knowing about the OpenJDK alternative, so have documented an advised installation process.

## HTTP `RestClient::RequestFailed` error

Whilst [it is documented in the Developer Docs](https://docs.publishing.service.gov.uk/manual/alerts/high-priority-tests.html), this is a common enough error that I believe it's worth a place in the README. The error happens whenever you cancel a running test suite, which you're likely to do if you notice the first test has failed.

## Environments and triggers
Current README doesn't make it clear a) which environments the tests run against, and b) what triggers the tests. I've attempted to clarify it here.