### PR TITLE
Fix 'killbrowsermob' alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ $ sudo kill -9 6385
 You can even set up an alias in your `~/.bash_profile`:
 
 ```sh
-alias killbrowsermob="ps xu | grep browsermob-proxy | grep -v grep | awk '{ print $2 }' | xargs kill -9"
+alias killbrowsermob="ps xu | grep [b]rowsermob-proxy | grep -v grep | awk '{ print \$2 }' | xargs kill -9"
 ```
 
 ### Spoofing the target domain


### PR DESCRIPTION
Command worked on the basis that the browsermob process would be the first thing in the grepped output, and the grep command itself would be the second thing. But when stored as an alias, the grep command is the first thing and the browsermob process is the second thing.

Changing browsermob -> [b]rowsermob ensures that the browsermob process is still found ("find the first b followed by rowsermob"), but that the grep process itself isn't matched.

Secondly, the \$2 was getting evaluated too early, so the ID wasn't being grabbed properly. That is now escaped."