### PR TITLE
Add s3 CSP test for organograms previews

### DIFF
--- a/features/data_gov_uk.feature
+++ b/features/data_gov_uk.feature
@@ -44,3 +44,10 @@ Feature: Data.gov.uk
     And I force a varnish cache miss
     When I search for "" in datasets
     Then I should see an accurate dataset count
+
+  @high
+  Scenario: Check that we don't get any s3 CSP errors for organogram previews
+    Given I am testing "https://data.gov.uk"
+    When I preview an organogram
+    Then I should see "View the full organogram"
+    And I don't get any s3 CSP errors

--- a/features/step_definitions/datagovuk_steps.rb
+++ b/features/step_definitions/datagovuk_steps.rb
@@ -29,3 +29,15 @@ Then /^I should see an accurate dataset count$/ do
   # number in the future if more datasets are published
   expect(count).to be_within(1500).of(52823)
 end
+
+When /^I preview an organogram$/ do
+  visit_path "#{@host}/dataset/7d114298-919b-4108-9600-9313e34ce3b8/organogram-of-staff-roles-salaries-september-2018/datafile/83a8d9f0-2d7c-433b-96f3-77866cddf058/preview"
+end
+
+And /^I don't get any s3 CSP errors$/ do
+  messages = Capybara.current_session.driver.browser.manage.logs.get(:browser).map(&:message)
+  regex = /Refused to connect to 'https:\/\/s3.*because it violates the following Content Security Policy directive: "connect-src/
+  messages.each do |message|
+    expect(message).to_not match(regex)
+  end
+end


### PR DESCRIPTION
- Check that it is an organogram page by relying on the
  'View the full organogram' text of the button
- Check that we don't get any errors similar to:
  ```
  Refused to connect to
  'https://s3-<organogram bucket>.csv' because it violates the following
  Content Security Policy directive: "connect-src...".
  ```

Co-Authored-By: Ken Tsang <ken.tsang@digital.cabinet-office.gov.uk>

## Reference

https://trello.com/c/wh8pUMOm/982-fix-display-of-organogram-visualisations-on-datagovuk