### PR TITLE
Add finder frontend XSS tests

### DIFF
--- a/features/finder_frontend.feature
+++ b/features/finder_frontend.feature
@@ -53,6 +53,59 @@ Feature: Finder Frontend
     Then I should see filtered documents
 
   @high
-  Scenario: Check malicious code does not execute
-    When I visit "/government/organisations/hm-revenue-customs/contact?keywords=<script>alert(document.cookie);</script>"
-    Then I should see "&lt;script&gt;alert(document.cookie)"
+  Scenario Outline: Check malicious code does not execute
+    When I visit the "<finder>" finder with keywords <keyword>
+    Then There should be no alert
+    When I visit the "<finder>" finder without keywords
+    And I fill in the keyword field with <keyword>
+    Then There should be no alert
+    And I should see the string <keyword>
+
+  Examples: news-and-communications finder
+    | keyword                                              |  finder                      |
+    |<script>alert(123)</script>                           | news-and-communications      |
+    |&lt;script&gt;alert(&#39;123&#39;);&lt;/script&gt;    | news-and-communications      |
+    |<img src=x onerror=alert(123) />                      | news-and-communications      |
+    |<svg><script>123<1>alert(123)</script>                | news-and-communications      |
+    |\"><script>alert(123)</script>                        | news-and-communications      |
+    |'><script>alert(123)</script>                         | news-and-communications      |
+    |><script>alert(123)</script>                          | news-and-communications      |
+    |</script><script>alert(123)</script>                  | news-and-communications      |
+    |< / script >< script >alert(123)< / script >          | news-and-communications      |
+    | onfocus=JaVaSCript:alert(123) autofocus              | news-and-communications      |
+    |\" onfocus=JaVaSCript:alert(123) autofocus            | news-and-communications      |
+    |' onfocus=JaVaSCript:alert(123) autofocus             | news-and-communications      |
+    |＜script＞alert(123)＜/script＞                        | news-and-communications      |
+    |<sc<script>ript>alert(123)</sc</script>ript>          | news-and-communications      |
+    |--><script>alert(123)</script>                        | news-and-communications      |
+    |\";alert(123);t=\"                                    | news-and-communications      |
+    |';alert(123);t='                                      | news-and-communications      |
+    |JavaSCript:alert(123)                                 | news-and-communications      |
+    |;alert(123);                                          | news-and-communications      |
+    |\"><script>alert(123);</script x=\"                   | news-and-communications      |
+    |'><script>alert(123);</script x='                     | news-and-communications      |
+    |><script>alert(123);</script x=                       | news-and-communications      |
+  Examples: all finder
+    | keyword                                              |  finder                      |
+    |<script>alert(123)</script>                           | all                          |
+    |&lt;script&gt;alert(&#39;123&#39;);&lt;/script&gt;    | all                          |
+    |<img src=x onerror=alert(123) />                      | all                          |
+    |<svg><script>123<1>alert(123)</script>                | all                          |
+    |\"><script>alert(123)</script>                        | all                          |
+    |'><script>alert(123)</script>                         | all                          |
+    |><script>alert(123)</script>                          | all                          |
+    |</script><script>alert(123)</script>                  | all                          |
+    |< / script >< script >alert(123)< / script >          | all                          |
+    | onfocus=JaVaSCript:alert(123) autofocus              | all                          |
+    |\" onfocus=JaVaSCript:alert(123) autofocus            | all                          |
+    |' onfocus=JaVaSCript:alert(123) autofocus             | all                          |
+    |＜script＞alert(123)＜/script＞                        | all                          |
+    |<sc<script>ript>alert(123)</sc</script>ript>          | all                          |
+    |--><script>alert(123)</script>                        | all                          |
+    |\";alert(123);t=\"                                    | all                          |
+    |';alert(123);t='                                      | all                          |
+    |JavaSCript:alert(123)                                 | all                          |
+    |;alert(123);                                          | all                          |
+    |\"><script>alert(123);</script x=\"                   | all                          |
+    |'><script>alert(123);</script x='                     | all                          |
+    |><script>alert(123);</script x=                       | all                          |

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -57,6 +57,32 @@ When /^I visit "(.*)"$/ do |path_or_url|
   visit_path path_or_url
 end
 
+When /^I visit the "([^"]+)" finder with keywords (.*)$/ do |finder, keywords|
+  path = "/search/#{finder}?keywords=#{keywords}"
+  visit_path path
+end
+
+When /^I visit the "([^"]+)" finder without keywords$/ do |finder|
+  path = "/search/#{finder}"
+  visit_path path
+end
+
+And /^There should be no alert$/ do
+  expect {
+    page.driver.browser.switch_to.alert.accept
+  }.to raise_error(Selenium::WebDriver::Error::NoSuchAlertError)
+end
+
+And /^I should see the string (.+)$/ do |content|
+  expect(page.find_field('finder-keyword-search').value).to eq(content)
+end
+
+And /^I fill in the keyword field with (.+)$/ do |content|
+  page.fill_in 'finder-keyword-search', with: "#{content}\n"
+  page.find('button[data-name="keywords"]', match: :first)
+end
+
+
 When /^I visit "(.*)" without following redirects$/ do |path|
   @response = single_http_request("#{@host}#{path}")
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -73,6 +73,7 @@ Capybara.register_driver :headless_chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new
   options.add_argument("--headless")
   options.add_argument("--disable-gpu")
+  options.add_argument("--disable-xss-auditor")
 
   Capybara::Selenium::Driver.new(
     app,


### PR DESCRIPTION
Add XSS tests for finder frontend.

Attempts a number of the "naughty strings",
https://github.com/minimaxir/big-list-of-naughty-strings to see
if finder-frontend can be forced to run javascript to display
an alert.

This tests inputting text in the keywords text field through javascript 
and by submitting the keywords through the URL

Trello: https://trello.com/c/eaa0vKa2/726-add-tests-for-xss-in-text-fields-in-finder-frontend-and-smokey-l