### PR TITLE
Add tests for search analytics

### DIFF
--- a/features/search.feature
+++ b/features/search.feature
@@ -7,22 +7,16 @@ Feature: Search
     And I force a varnish cache miss for search
 
   @high
-  Scenario: Check search results for tax
-    When I search for "tax"
+  Scenario Outline: Check search results
+    When I search for "<keywords>"
     Then I should see some search results
     And the search results should be unique
 
-  @high
-  Scenario: Check search results for passport
-    When I search for "passport"
-    Then I should see some search results
-    And the search results should be unique
-
-  @high
-  Scenario: Check search results for universal credit
-    When I search for "universal credit"
-    Then I should see some search results
-    And the search results should be unique
+    Examples:
+    | keywords         |
+    | tax              |
+    | passport         |
+    | universal credit |
 
   @normal
   Scenario: Check organisation filtering

--- a/features/search.feature
+++ b/features/search.feature
@@ -7,10 +7,17 @@ Feature: Search
     And I force a varnish cache miss for search
 
   @high
-  Scenario Outline: Check search results
+  Scenario Outline: Check search results and analytics
     When I search for "<keywords>"
     Then I should see some search results
     And the search results should be unique
+    And search analytics for "<keywords>" are reported
+    When I expand the search options
+    Then the "filterClicked" event is reported
+    When I go to the next page
+    Then the "contentsClicked" event is reported
+    When I click result 1
+    Then the "navFinderLinkClicked" event for result 1 is reported
 
     Examples:
     | keywords         |

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -2,6 +2,19 @@ When /^I search for "(.*)"$/ do |term|
   visit_path "/search?q=#{term}"
 end
 
+When /^I expand the search options$/ do
+  click_link "+ Show more search options"
+end
+
+When /^I go to the next page$/ do
+  click_link "Next page"
+end
+
+When /^I click result (.*)$/ do |n|
+  result = page.all(".finder-results li a")[n.to_i - 1]
+  click_link result.text
+end
+
 Then /^I should see some search results$/ do
   result_links = page.all(".finder-results li a")
   expect(result_links.count).to be >= 1
@@ -18,4 +31,31 @@ And /^the search results should be unique$/ do
     results << item.text + page.all(".finder-results li p")[idx].text
   end
   expect(results.uniq.count).to eq(results.count)
+end
+
+And /^search analytics for "(.*)" are reported$/ do |term|
+  found = false
+  sought = "dp=#{CGI::escape("/search/all?keywords=#{term.sub(' ', '+')}")}"
+  @@proxy.har.entries.each do |e|
+    found = true if e.request.url.include? sought
+  end
+  expect(found).to be(true)
+end
+
+Then /^the "(.*)" event is reported$/ do |event|
+  found = false
+  sought = "eventCategory=#{event}"
+  @@proxy.har.entries.each do |e|
+    found = true if e.request.url.include? sought
+  end
+  expect(found).to be(true)
+end
+
+Then /^the "(.*)" event for result (.*) is reported$/ do |event, n|
+  found = false
+  sought = "eventCategory=#{event}&eventAction=Search.#{n}"
+  @@proxy.har.entries.each do |e|
+    found = true if e.request.url.include? sought
+  end
+  expect(found).to be(true)
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -38,9 +38,8 @@ server = BrowserMob::Proxy::Server.new("./bin/browsermob-proxy", port: proxy_por
 server.start
 proxy = server.create_proxy
 
-# Set up request logging and make it available across all tests
-proxy.new_har
-@@har = proxy.har
+# Make the proxy available to the tests
+@@proxy = proxy
 
 # Add request headers
 if ENV["RATE_LIMIT_TOKEN"]

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,3 +1,8 @@
+Before do
+  # Clear the request log so that tests only see their requests.
+  @@proxy.new_har
+end
+
 After do
   # Do this manually rather than using `after_example!` so we can configure
   # the log destination to be $stderr rather than $stdout. This prevents


### PR DESCRIPTION
This PR merges the three "Check search results for <keywords>" tests we had, and extends them.  This is what happens now:

1. As before:
    1. A search is done
    1. Checks that (a) there are results and (b) that they're unique
1. New:
    1. Checks that a request is made with `dp=%2Fsearch%2Fall%3Fkeywords%3D...` in the URL
    1. Clicks the "show more search options" link
    1. Checks that a request is made with `eventCategory=filterClicked` in the URL
    1. Clicks the "next page" link
    1. Checks that a request is made with `eventCategory=contentsClicked` in the URL
    1. Clicks the top result (on the second page of results)
    1. Checks that a request is made with `eventCategory= navFinderLinkClicked&eventAction=Search.1` in the URL

To make this work I had to do a little refactoring of how request logging works, but as far as I can tell nothing was using this functionality, so that's fine.

---

[Trello card](https://trello.com/c/TpqoP2Z7/742-add-finder-frontend-and-smokey-tests-for-search-analytics-l)