### PR TITLE
Reduce quantity of finder frontend XSS tests and address flakiness

### DIFF
--- a/features/finder_frontend.feature
+++ b/features/finder_frontend.feature
@@ -61,51 +61,7 @@ Feature: Finder Frontend
     Then There should be no alert
     And I should see the string <keyword>
 
-  Examples: news-and-communications finder
-    | keyword                                              |  finder                      |
-    |<script>alert(123)</script>                           | news-and-communications      |
-    |&lt;script&gt;alert(&#39;123&#39;);&lt;/script&gt;    | news-and-communications      |
-    |<img src=x onerror=alert(123) />                      | news-and-communications      |
-    |<svg><script>123<1>alert(123)</script>                | news-and-communications      |
-    |\"><script>alert(123)</script>                        | news-and-communications      |
-    |'><script>alert(123)</script>                         | news-and-communications      |
-    |><script>alert(123)</script>                          | news-and-communications      |
-    |</script><script>alert(123)</script>                  | news-and-communications      |
-    |< / script >< script >alert(123)< / script >          | news-and-communications      |
-    | onfocus=JaVaSCript:alert(123) autofocus              | news-and-communications      |
-    |\" onfocus=JaVaSCript:alert(123) autofocus            | news-and-communications      |
-    |' onfocus=JaVaSCript:alert(123) autofocus             | news-and-communications      |
-    |＜script＞alert(123)＜/script＞                        | news-and-communications      |
-    |<sc<script>ript>alert(123)</sc</script>ript>          | news-and-communications      |
-    |--><script>alert(123)</script>                        | news-and-communications      |
-    |\";alert(123);t=\"                                    | news-and-communications      |
-    |';alert(123);t='                                      | news-and-communications      |
-    |JavaSCript:alert(123)                                 | news-and-communications      |
-    |;alert(123);                                          | news-and-communications      |
-    |\"><script>alert(123);</script x=\"                   | news-and-communications      |
-    |'><script>alert(123);</script x='                     | news-and-communications      |
-    |><script>alert(123);</script x=                       | news-and-communications      |
-  Examples: all finder
-    | keyword                                              |  finder                      |
-    |<script>alert(123)</script>                           | all                          |
-    |&lt;script&gt;alert(&#39;123&#39;);&lt;/script&gt;    | all                          |
-    |<img src=x onerror=alert(123) />                      | all                          |
-    |<svg><script>123<1>alert(123)</script>                | all                          |
-    |\"><script>alert(123)</script>                        | all                          |
-    |'><script>alert(123)</script>                         | all                          |
-    |><script>alert(123)</script>                          | all                          |
-    |</script><script>alert(123)</script>                  | all                          |
-    |< / script >< script >alert(123)< / script >          | all                          |
-    | onfocus=JaVaSCript:alert(123) autofocus              | all                          |
-    |\" onfocus=JaVaSCript:alert(123) autofocus            | all                          |
-    |' onfocus=JaVaSCript:alert(123) autofocus             | all                          |
-    |＜script＞alert(123)＜/script＞                        | all                          |
-    |<sc<script>ript>alert(123)</sc</script>ript>          | all                          |
-    |--><script>alert(123)</script>                        | all                          |
-    |\";alert(123);t=\"                                    | all                          |
-    |';alert(123);t='                                      | all                          |
-    |JavaSCript:alert(123)                                 | all                          |
-    |;alert(123);                                          | all                          |
-    |\"><script>alert(123);</script x=\"                   | all                          |
-    |'><script>alert(123);</script x='                     | all                          |
-    |><script>alert(123);</script x=                       | all                          |
+  Examples:
+    | keyword                     | finder                  |
+    | <script>alert(123)</script> | news-and-communications |
+    | <script>alert(123)</script> | all                     |

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -36,7 +36,7 @@ end
 And /^search analytics for "(.*)" are reported$/ do |term|
   found = false
   sought = "dp=#{CGI::escape("/search/all?keywords=#{term.sub(' ', '+')}")}"
-  @@proxy.har.entries.each do |e|
+  $proxy.har.entries.each do |e|
     found = true if e.request.url.include? sought
   end
   expect(found).to be(true)
@@ -45,7 +45,7 @@ end
 Then /^the "(.*)" event is reported$/ do |event|
   found = false
   sought = "eventCategory=#{event}"
-  @@proxy.har.entries.each do |e|
+  $proxy.har.entries.each do |e|
     found = true if e.request.url.include? sought
   end
   expect(found).to be(true)
@@ -54,7 +54,7 @@ end
 Then /^the "(.*)" event for result (.*) is reported$/ do |event, n|
   found = false
   sought = "eventCategory=#{event}&eventAction=Search.#{n}"
-  @@proxy.har.entries.each do |e|
+  $proxy.har.entries.each do |e|
     found = true if e.request.url.include? sought
   end
   expect(found).to be(true)

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -79,7 +79,7 @@ end
 
 And /^I fill in the keyword field with (.+)$/ do |content|
   page.fill_in id: 'finder-keyword-search', with: "#{content}\n"
-  page.find('button[data-name="keywords"]', match: :first)
+  page.find('button[data-name="keywords"]', match: :first, wait: 5)
 end
 
 

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -74,11 +74,11 @@ And /^There should be no alert$/ do
 end
 
 And /^I should see the string (.+)$/ do |content|
-  expect(page.find_field('finder-keyword-search').value).to eq(content)
+  expect(page.find('#finder-keyword-search').value).to eq(content)
 end
 
 And /^I fill in the keyword field with (.+)$/ do |content|
-  page.fill_in 'finder-keyword-search', with: "#{content}\n"
+  page.fill_in id: 'finder-keyword-search', with: "#{content}\n"
   page.find('button[data-name="keywords"]', match: :first)
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -39,7 +39,7 @@ server.start
 proxy = server.create_proxy
 
 # Make the proxy available to the tests
-@@proxy = proxy
+$proxy = proxy
 
 # Add request headers
 if ENV["RATE_LIMIT_TOKEN"]

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,6 +1,6 @@
 Before do
   # Clear the request log so that tests only see their requests.
-  @@proxy.new_har
+  $proxy.new_har
 end
 
 After do


### PR DESCRIPTION
This is raised to address problems we have been seeing from 2nd line regarding the recently added Finder Frontend XSS tests: https://github.com/alphagov/smokey/pull/533

This does some work to reduce the time these tests take to run by about 4-5 seconds per test, it adds a greater timeout to try stop the tests failing as often as they do, and it reduces the amount of tests as these seem too thorough for something testing at an end-to-end level.

Further details in commit messages.