### PR TITLE
Test CKAN in all envs, only test DGU in production

### DIFF
--- a/features/data_gov_uk.feature
+++ b/features/data_gov_uk.feature
@@ -1,21 +1,21 @@
 Feature: Data.gov.uk
   Tests for "Find open data" and CKAN on data.gov.uk
 
-  @high
+  @high @notintegration @notstaging
   Scenario: Check home page loads correctly
     Given I am testing "https://data.gov.uk"
     And I force a varnish cache miss
     When I request "/"
     Then I should see "Find open data"
 
-  @high
+  @high @notintegration @notstaging
   Scenario: Check search works
     Given I am testing "https://data.gov.uk"
     And I force a varnish cache miss
     When I search for "data" in datasets
     Then I should see some dataset results
 
-  @normal
+  @normal @notintegration @notstaging
   Scenario: Check RDF API loads
     Given I am testing "https://data.gov.uk"
     And I force a varnish cache miss
@@ -28,7 +28,7 @@ Feature: Data.gov.uk
     When I request "/"
     Then I should see "Data publisher"
 
-  @high
+  @high @notintegration @notstaging
   Scenario: Check datasets sync between CKAN and Find
     Given I am testing "https://ckan.publishing.service.gov.uk"
     When I request "/api/3/action/package_search"
@@ -38,14 +38,14 @@ Feature: Data.gov.uk
     When I search for "" in datasets
     Then I should see a similar dataset count
 
-  @high
+  @high @notintegration @notstaging
   Scenario: Check there is an accurate number of datasets
     Given I am testing "https://data.gov.uk"
     And I force a varnish cache miss
     When I search for "" in datasets
     Then I should see an accurate dataset count
 
-  @high
+  @high @notintegration @notstaging
   Scenario: Check that we don't get any s3 CSP errors for organogram previews
     Given I am testing "https://data.gov.uk"
     When I preview an organogram

--- a/features/data_gov_uk.feature
+++ b/features/data_gov_uk.feature
@@ -24,7 +24,7 @@ Feature: Data.gov.uk
 
   @high
   Scenario: Check CKAN loads correctly
-    Given I am testing "https://ckan.publishing.service.gov.uk"
+    Given I am testing "ckan"
     When I request "/"
     Then I should see "Data publisher"
 


### PR DESCRIPTION
We have CKAN running in integration, staging and production but DGU only runs in production. This tests CKAN in each environment but specifies not to run DGU tests in integration or staging since they're only testing production.