### PR TITLE
Use the "wait-until" logic for search analytics checks

### DIFF
--- a/features/search.feature
+++ b/features/search.feature
@@ -11,13 +11,13 @@ Feature: Search
     When I search for "<keywords>"
     Then I should see some search results
     And the search results should be unique
-    When I expand the search options
-    And I go to the next page
-    And I click result 1
     Then search analytics for "<keywords>" are reported
-    And the "filterClicked" event is reported
-    And the "contentsClicked" event is reported
-    And the "navFinderLinkClicked" event for result 1 is reported
+    When I expand the search options
+    Then the "filterClicked" event is reported
+    When I go to the next page
+    Then the "contentsClicked" event is reported
+    When I click result 1
+    Then the "navFinderLinkClicked" event for result 1 is reported
 
     Examples:
     | keywords         |

--- a/features/step_definitions/government_frontend_steps.rb
+++ b/features/step_definitions/government_frontend_steps.rb
@@ -22,18 +22,3 @@ Then /^I should be redirected to "(.*?)"$/ do |url_or_path|
     expect(page.current_path).to(eq(url_or_path))
   end
 end
-
-class WaitUntilTimeout < StandardError; end
-
-def wait_until(&block)
-  max_time_to_try_until = 5 # in seconds
-  time_between_intervals = 0.1 # in seconds
-
-  time_left = max_time_to_try_until
-  loop do
-    raise WaitUntilTimeout if time_left <= 0
-    break if yield
-    sleep(time_between_intervals)
-    time_left -= time_between_intervals
-  end
-end

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -6,11 +6,11 @@ When /^I expand the search options$/ do
   click_link "+ Show more search options"
 end
 
-And /^I go to the next page$/ do
+When /^I go to the next page$/ do
   click_link "Next page"
 end
 
-And /^I click result (.*)$/ do |n|
+When /^I click result (.*)$/ do |n|
   result = page.all(".finder-results li a")[n.to_i - 1]
   click_link result.text
 end
@@ -39,13 +39,13 @@ Then /^search analytics for "(.*)" are reported$/ do |term|
   expect(proxy_has_request_containing sought).to be(true)
 end
 
-And /^the "(.*)" event is reported$/ do |event|
+Then /^the "(.*)" event is reported$/ do |event|
   sought = "eventCategory=#{event}"
   wait_until { proxy_has_request_containing sought }
   expect(proxy_has_request_containing sought).to be(true)
 end
 
-And /^the "(.*)" event for result (.*) is reported$/ do |event, n|
+Then /^the "(.*)" event for result (.*) is reported$/ do |event, n|
   sought = "eventCategory=#{event}&eventAction=Search.#{n}"
   wait_until { proxy_has_request_containing sought }
   expect(proxy_has_request_containing sought).to be(true)

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -34,28 +34,27 @@ And /^the search results should be unique$/ do
 end
 
 Then /^search analytics for "(.*)" are reported$/ do |term|
-  found = false
   sought = "dp=#{CGI::escape("/search/all?keywords=#{term.sub(' ', '+')}")}"
-  $proxy.har.entries.each do |e|
-    found = true if e.request.url.include? sought
-  end
-  expect(found).to be(true)
+  wait_until { proxy_has_request_containing sought }
+  expect(proxy_has_request_containing sought).to be(true)
 end
 
 And /^the "(.*)" event is reported$/ do |event|
-  found = false
   sought = "eventCategory=#{event}"
-  $proxy.har.entries.each do |e|
-    found = true if e.request.url.include? sought
-  end
-  expect(found).to be(true)
+  wait_until { proxy_has_request_containing sought }
+  expect(proxy_has_request_containing sought).to be(true)
 end
 
 And /^the "(.*)" event for result (.*) is reported$/ do |event, n|
-  found = false
   sought = "eventCategory=#{event}&eventAction=Search.#{n}"
+  wait_until { proxy_has_request_containing sought }
+  expect(proxy_has_request_containing sought).to be(true)
+end
+
+def proxy_has_request_containing(sought)
+  found = false
   $proxy.har.entries.each do |e|
     found = true if e.request.url.include? sought
   end
-  expect(found).to be(true)
+  found
 end

--- a/features/support/delay.rb
+++ b/features/support/delay.rb
@@ -1,0 +1,14 @@
+class WaitUntilTimeout < StandardError; end
+
+def wait_until(&block)
+  max_time_to_try_until = 5 # in seconds
+  time_between_intervals = 0.1 # in seconds
+
+  time_left = max_time_to_try_until
+  loop do
+    raise WaitUntilTimeout if time_left <= 0
+    break if yield
+    sleep(time_between_intervals)
+    time_left -= time_between_intervals
+  end
+end


### PR DESCRIPTION
Checking for the async analytics requests is pretty flaky.  Moving them to the end, after all the sync requests, hasn't helped.  So instead use the `wait_until` function from the government-frontend step definitions to wait until the request has been made.  There is a max delay of 5s.

---

[Trello card](https://trello.com/c/u7D6Yx0c/770-fix-flaky-search-analytics-test)