### PR TITLE
Test backend validation on email field

### DIFF
--- a/features/step_definitions/feedback_steps.rb
+++ b/features/step_definitions/feedback_steps.rb
@@ -1,4 +1,5 @@
 When /^I input malicious code in the (.*) field$/ do |field|
+  page.execute_script('$("form").attr("novalidate", "novalidate")')
   find(".email").set("<script>alert(document.cookie)</script>")
   click_button("Send message")
 end


### PR DESCRIPTION
This test was failing because it was failing the browser validation on input fields
of type="email". This step removes the browser validation from the email field, forcing
the backend validation to run.