### PR TITLE
Add smoke tests for cache

### DIFF
--- a/features/caching.feature
+++ b/features/caching.feature
@@ -1,0 +1,23 @@
+@aws
+Feature: Caching
+  Tests that pages are correctly cached
+
+  Background:
+    Given I am testing through the full stack
+
+  @normal
+  Scenario: Check council lookup
+    When I try to post to "/find-local-council" with "postcode=WC2B+6SE" without following redirects
+    Then I should not hit the cache
+    Then I should see "camden"
+
+  @normal
+  Scenario: Check licence lookup
+    When I try to post to "/busking-licence" with "postcode=E20+2ST" without following redirects
+    Then I should not hit the cache
+    Then I should see "newham"
+
+  @low
+  Scenario: Check homepage is served by Varnish
+    When I request "/"
+    Then I should hit the cache

--- a/features/support/http_requests.rb
+++ b/features/support/http_requests.rb
@@ -41,6 +41,8 @@ def post_request(url, options = {})
         args.delete :payload
       end
 
+      return response if options[:dont_follow_redirects]
+
       response.follow_redirection(&block)
     else
       response.return!(&block)
@@ -64,6 +66,7 @@ def do_http_request(url, method = :get, options = {}, &block)
   headers = {
     'User-Agent' => 'Smokey Test / Ruby',
     'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+    'FASTLY-DEBUG' => '1',
   }
 
   started_at = Time.now


### PR DESCRIPTION
This adds a few small checks that caching works

It checks only the homepage, and that post requests
aren't cached.

At the moment CDN changes aren't checked specifically
by the smoke tests.

Trello: https://trello.com/c/IPbLTDLq/806