### PR TITLE
Add S3 Mirrors tests

### DIFF
--- a/features/mirror.feature
+++ b/features/mirror.feature
@@ -1,0 +1,30 @@
+@aws @local-network
+Feature: Mirror
+    Tests for the GOV.UK mirrors that serve content if origin is unavailable.	
+
+    @high
+    Scenario: Check Fastly probe request
+      Given S3 mirrors
+      Then I should get a 200 response from "/www.gov.uk/index.html" on the mirrors
+
+    @high
+    Scenario: Check homepage is served by all the mirrors
+      Given S3 mirrors
+      Then I should get a 200 response from "/www.gov.uk/index.html" on the mirrors
+      And I should see "Welcome to GOV.UK"
+
+    @high
+    Scenario: Check a deep-linked page is served by all the mirrors
+      Given S3 mirrors
+      Then I should get a 200 response from "/www.gov.uk/book-theory-test.html" on the mirrors
+      And I should see "Book your theory test"
+
+    @high
+    Scenario: Check a non-existent page returns a AccessDenied error from all the mirrors
+      Given S3 mirrors
+      Then I should get a 403 response from "/www.gov.uk/jasdu3jjasd" on the mirrors
+
+    @high
+    Scenario: Check that search returns an error on all the mirrors
+      Given S3 mirrors
+      Then I should get a 403 response from "/www.gov.uk/search" on the mirrors

--- a/features/step_definitions/mirror_steps.rb
+++ b/features/step_definitions/mirror_steps.rb
@@ -1,0 +1,23 @@
+Given /^S3 mirrors/ do |url|	
+  @hosts = Array.new()	
+  @hosts.push("https://govuk-production-mirror.s3.amazonaws.com")
+  @hosts.push("https://govuk-production-mirror-replica.s3.amazonaws.com")
+end	
+
+Then /^I should get a (\d+) response from "(.*)" on the mirrors$/ do |status, path|	
+  @responses = []	
+  @hosts.each do |mirror_host|	
+    response = try_get_request(	
+      "#{mirror_host}#{path}",	
+      verify_ssl: false,	
+    )	
+    expect(response.code).to eq(status.to_i)	
+    @responses << response	
+  end	
+end	
+
+Then /^I should see a technical difficulties message$/ do	
+  @responses.each do |response|	
+    expect(response.body).to include("Sorry, we're experiencing technical difficulties")	
+  end	
+end


### PR DESCRIPTION
The Mirror feature was previously disabled in 2d3f792a4fa4f651f763c49f6566495425ed78fd
when the mirrors were migrated to S3. We are adding the tests back,
refactored to work with S3.