### PR TITLE
Fix mirror feature

### DIFF
--- a/features/mirror.feature
+++ b/features/mirror.feature
@@ -2,29 +2,29 @@
 Feature: Mirror
     Tests for the GOV.UK mirrors that serve content if origin is unavailable.	
 
-    @high
+    @high @notintegration @notstaging @nottraining
     Scenario: Check Fastly probe request
       Given S3 mirrors
       Then I should get a 200 response from "/www.gov.uk/index.html" on the mirrors
 
-    @high
+    @high @notintegration @notstaging @nottraining
     Scenario: Check homepage is served by all the mirrors
       Given S3 mirrors
       Then I should get a 200 response from "/www.gov.uk/index.html" on the mirrors
       And I should see "Welcome to GOV.UK"
 
-    @high
+    @high @notintegration @notstaging @nottraining
     Scenario: Check a deep-linked page is served by all the mirrors
       Given S3 mirrors
       Then I should get a 200 response from "/www.gov.uk/book-theory-test.html" on the mirrors
       And I should see "Book your theory test"
 
-    @high
+    @high @notintegration @notstaging @nottraining
     Scenario: Check a non-existent page returns a AccessDenied error from all the mirrors
       Given S3 mirrors
       Then I should get a 403 response from "/www.gov.uk/jasdu3jjasd" on the mirrors
 
-    @high
+    @high @notintegration @notstaging @nottraining
     Scenario: Check that search returns an error on all the mirrors
       Given S3 mirrors
       Then I should get a 403 response from "/www.gov.uk/search" on the mirrors

--- a/features/step_definitions/mirror_steps.rb
+++ b/features/step_definitions/mirror_steps.rb
@@ -1,4 +1,4 @@
-Given /^S3 mirrors/ do |url|	
+Given /^S3 mirrors/ do
   @hosts = Array.new()	
   @hosts.push("https://govuk-production-mirror.s3.amazonaws.com")
   @hosts.push("https://govuk-production-mirror-replica.s3.amazonaws.com")


### PR DESCRIPTION
We are seeing:
```
    Given S3 mirrors
      Your block takes 1 argument, but the Regexp matched 0 arguments.
      features/step_definitions/mirror_steps.rb:1:in `/^S3 mirrors/'
```

Disable mirror tests on integration/staging/training, only
production instances have access to the mirror buckets.