### PR TITLE
Update frequency wording for email alert signups

### DIFF
--- a/features/email_sign_up.feature
+++ b/features/email_sign_up.feature
@@ -14,7 +14,7 @@ Feature: Email signup
     When I click on the button "Create subscription"
     Then I should see "How often do you want to get updates?"
     And the "immediately" option should be preselected by default
-    When I choose radio button "No more than once a week" and click on "Next"
+    When I choose radio button "Once a week" and click on "Next"
     And I input "simulate-delivered@notifications.service.gov.uk" and click subscribe
     Then I should see "You’ve subscribed successfully"
 


### PR DESCRIPTION
This commit changes the wording that is looked for on email signup pages for frequency from "no more than once a week" to "once a week" to reflect wording improvements.