### PR TITLE
Fix name of Content Data

### DIFF
--- a/features/content_data_admin.feature
+++ b/features/content_data_admin.feature
@@ -7,7 +7,7 @@ Feature: Content Data Admin
     When I go to the "content-data-admin" landing page
     And I try to login as a user
     And I go to the "content-data-admin" landing page
-    Then I should see "Content data"
+    Then I should see "Content Data"
     And I should see "Log out"
 
   @normal
@@ -16,4 +16,3 @@ Feature: Content Data Admin
     And I visit "/metrics/government/organisations/government-digital-service" on the "content-data-admin" application
     Then I should see "Page data"
     And I should see "Organisation"
-


### PR DESCRIPTION
The word 'data' has been capitalised in the name as of https://github.com/alphagov/content-data-admin/commit/557b828ea4f2d63dba6cbc5a8b063e0859b00ebe.