### PR TITLE
Remove absolute check on DGU datasets

### DIFF
--- a/features/data_gov_uk.feature
+++ b/features/data_gov_uk.feature
@@ -39,13 +39,6 @@ Feature: Data.gov.uk
     Then I should see a similar dataset count
 
   @high @notintegration @notstaging @nottraining
-  Scenario: Check there is an accurate number of datasets
-    Given I am testing "https://data.gov.uk"
-    And I force a varnish cache miss
-    When I search for "" in datasets
-    Then I should see an accurate dataset count
-
-  @high @notintegration @notstaging @nottraining
   Scenario: Check that we don't get any s3 CSP errors for organogram previews
     Given I am testing "https://data.gov.uk"
     When I preview an organogram

--- a/features/step_definitions/datagovuk_steps.rb
+++ b/features/step_definitions/datagovuk_steps.rb
@@ -21,15 +21,6 @@ Then /^I should see a similar dataset count$/ do
   expect(count).to be_within(25).of(@package_count)
 end
 
-Then /^I should see an accurate dataset count$/ do
-  count_span = page.first(".dgu-results__summary span.bold-small")
-  count = count_span.text.gsub(/[^\d^\.]/, '').to_i
-
-  # this is correct as of the 26th April 2019, we might need to increase this
-  # number in the future if more datasets are published
-  expect(count).to be_within(1500).of(52823)
-end
-
 When /^I preview an organogram$/ do
   visit_path "#{@host}/dataset/7d114298-919b-4108-9600-9313e34ce3b8/organogram-of-staff-roles-salaries-september-2018/datafile/83a8d9f0-2d7c-433b-96f3-77866cddf058/preview"
 end


### PR DESCRIPTION
https://trello.com/c/Au6s6UMP/639-smokey-tests-failing-in-all-environments-various-reasons

Previously we experienced an issue where a significant number of
datasets disappeared from the DGU Find frontend due to a suspected API
discrepancy from CKAN. We added two features to detect this issue in
future, but one requires manual intervention to keep the check accurate.

This removes the accuracy feature, since we believe it is covered by the
other feature we added to check the agreement between the number of
datasets reported by CKAN vs. DGU Find. In particular, there is no
evidence that the total count of datasets reported by CKAN was at fault.

https://github.com/alphagov/smokey/pull/493