### PR TITLE
adds test to ensure default web acl rule in place

### DIFF
--- a/features/step_definitions/waf_steps.rb
+++ b/features/step_definitions/waf_steps.rb
@@ -1,0 +1,13 @@
+
+Given /^I set header ([^\s]+) to ([^\s]+)/ do |header_name, header_value|
+	@headers ||= {}
+	@headers[header_name.to_sym] = header_value
+end
+
+When /^I send a (\w+) request to "(.*?)"$/ do |method, path|
+	@response = do_http_request("#{@host}#{path}", method.downcase.to_sym, default_request_options.merge({:headers => @headers}))
+end
+
+Then /^the response status should be "([^"]*)"$/ do |status|
+  expect(@response.code).to eq(status)
+end

--- a/features/support/http_requests.rb
+++ b/features/support/http_requests.rb
@@ -107,7 +107,7 @@ def do_http_request(url, method = :get, options = {}, &block)
     method: method,
     user: user,
     password: password,
-    headers: headers,
+	headers: headers.merge(options[:headers] || {}),
     timeout: 10,
     payload: options[:payload],
     verify_ssl: options[:verify_ssl],

--- a/features/waf.feature
+++ b/features/waf.feature
@@ -1,0 +1,9 @@
+@aws @local-network
+Feature: WAF
+    Tests to ensure expected WAF rules are in place
+
+    @high
+    Scenario: Check that the X-Always-Block rule is in place
+      Given I set header X-Always-Block to true
+      When I send a GET request to /
+      Then the response status should be 403


### PR DESCRIPTION
the default web acl in place on the cache ALB has a rule that blocks
traffic if the header X-Always-Block: true is set on a request. We can
use this as an basic sanity check that the waf is associated with the
ALB and as a initial example test for others to follow as more rules are
added.

:warning: requires: https://github.com/alphagov/govuk-aws/pull/1051