### PR TITLE
Fix issues with WAF feature

### DIFF
--- a/features/step_definitions/waf_steps.rb
+++ b/features/step_definitions/waf_steps.rb
@@ -1,11 +1,10 @@
-
 Given /^I set header ([^\s]+) to ([^\s]+)/ do |header_name, header_value|
-	@headers ||= {}
-	@headers[header_name.to_sym] = header_value
+  @headers ||= {}
+  @headers[header_name.to_sym] = header_value
 end
 
 When /^I send a (\w+) request to "(.*?)"$/ do |method, path|
-	@response = do_http_request("#{@host}#{path}", method.downcase.to_sym, default_request_options.merge({:headers => @headers}))
+  @response = do_http_request("#{@host}#{path}", method.downcase.to_sym, default_request_options.merge({:headers => @headers}))
 end
 
 Then /^the response status should be "([^"]*)"$/ do |status|

--- a/features/step_definitions/waf_steps.rb
+++ b/features/step_definitions/waf_steps.rb
@@ -6,7 +6,3 @@ end
 When /^I send a (\w+) request to "(.*?)"$/ do |method, path|
   @response = do_http_request("#{@host}#{path}", method.downcase.to_sym, default_request_options.merge({:headers => @headers}))
 end
-
-Then /^the response status should be "([^"]*)"$/ do |status|
-  expect(@response.code).to eq(status)
-end

--- a/features/support/http_requests.rb
+++ b/features/support/http_requests.rb
@@ -107,7 +107,7 @@ def do_http_request(url, method = :get, options = {}, &block)
     method: method,
     user: user,
     password: password,
-	headers: headers.merge(options[:headers] || {}),
+    headers: headers.merge(options[:headers] || {}),
     timeout: 10,
     payload: options[:payload],
     verify_ssl: options[:verify_ssl],

--- a/features/waf.feature
+++ b/features/waf.feature
@@ -1,9 +1,9 @@
 @aws @local-network
 Feature: WAF
-    Tests to ensure expected WAF rules are in place
+  Tests to ensure expected WAF rules are in place
 
-    @high
-    Scenario: Check that the X-Always-Block rule is in place
-      Given I set header X-Always-Block to true
-      When I send a GET request to /
-      Then the response status should be 403
+  @high
+  Scenario: Check that the X-Always-Block rule is in place
+    Given I set header X-Always-Block to true
+    When I send a GET request to /
+    Then the response status should be 403

--- a/features/waf.feature
+++ b/features/waf.feature
@@ -2,6 +2,9 @@
 Feature: WAF
   Tests to ensure expected WAF rules are in place
 
+  Background:
+    Given I am testing through the full stack
+
   @high
   Scenario: Check that the X-Always-Block rule is in place
     Given I set header X-Always-Block to true

--- a/features/waf.feature
+++ b/features/waf.feature
@@ -9,4 +9,4 @@ Feature: WAF
   Scenario: Check that the X-Always-Block rule is in place
     Given I set header X-Always-Block to true
     When I send a GET request to "/"
-    Then the response status should be "403"
+    Then I should get a 403 status code

--- a/features/waf.feature
+++ b/features/waf.feature
@@ -5,5 +5,5 @@ Feature: WAF
   @high
   Scenario: Check that the X-Always-Block rule is in place
     Given I set header X-Always-Block to true
-    When I send a GET request to /
-    Then the response status should be 403
+    When I send a GET request to "/"
+    Then the response status should be "403"


### PR DESCRIPTION
The WAF feature is currently failing with "undefined" errors:

```
1 scenario (1 undefined)
3 steps (2 undefined, 1 passed)
0m20.382s

You can implement step definitions for undefined steps with these snippets:

When("I send a GET request to \/") do
  pending # Write code here that turns the phrase above into concrete actions
end

Then("the response status should be {int}") do |int|
  pending # Write code here that turns the phrase above into concrete actions
end
```

This should fix the undefined errors.