### PR TITLE
Don't show an unknown if there are no tests

### DIFF
--- a/nagios_check_cache.py
+++ b/nagios_check_cache.py
@@ -184,7 +184,7 @@ def main():
         status = "OK"
         exitcode = 0
     else:
-        log_result_and_exit(3, "UNKNOWN: No tests were run")
+        log_result_and_exit(0, "OK: But no %s tests for %s found" % (priority, feature_name))
 
     log_result_and_exit(exitcode, "%s: %s failed, %s skipped, %s passed; \n\n%s" % (
         status, feature_test_run.failed, feature_test_run.skipped, feature_test_run.passed, feature_test_run.log))


### PR DESCRIPTION
This partially reverts e12e983b46d483d9d595bdd704f5c7964fc678b0 to restore the previous behaviour of sending an OK status to Icinga when no tests were run (rather than an UNKNOWN which I had changed it to). This is because when no tests are run it means the feature has no tests at the priority, not that there is a problem.

[Trello Card](https://trello.com/c/jpFVXZth/1146-make-icinga-generate-unknown-result-on-missing-feature-file)