### PR TITLE
Mark the Bouncer benchmarking to just run in AWS

### DIFF
--- a/features/benchmarking.feature
+++ b/features/benchmarking.feature
@@ -1,7 +1,7 @@
 Feature: Benchmarking
   Tests to check the loading times for various pages on GOV.UK.
 
-  @high @benchmarking @local-network
+  @high @benchmarking @local-network @aws
   Scenario: Check Bouncer application is up
     Given I am testing "bouncer" internally
     And I am benchmarking


### PR DESCRIPTION
As it tries to connect to Bouncer internally, which only works in AWS.