### PR TITLE
Suppress JS error for YouTube embed

### DIFF
--- a/features/step_definitions/draft_environment_steps.rb
+++ b/features/step_definitions/draft_environment_steps.rb
@@ -1,5 +1,5 @@
 When /^I attempt to go to a case study$/ do
-  visit_path "government/case-studies/libraries-unlimited"
+  visit_path "government/case-studies/loopwheels-delivering-a-smoother-ride-for-wheelchair-users"
 end
 
 When /^I attempt to visit "(.*?)"$/ do |path|
@@ -25,7 +25,7 @@ When /^I log in using valid credentials$/ do
 end
 
 Then /^I should be on the case study page$/ do
-  expect(page.current_path).to eq("/government/case-studies/libraries-unlimited")
+  expect(page.current_path).to eq("/government/case-studies/loopwheels-delivering-a-smoother-ride-for-wheelchair-users")
   expect(page).to have_content('Case study')
 end
 


### PR DESCRIPTION
There is a long standing bug [1] in the YouTube embed via their API.

The page will still work for users, as will the video, but the
Javascript error is causing Smokey to break. We have tried various
suggested mitigations and fixes but none have worked.

As the test is only really testing the draft stack and not videos,
switching out the test page for one without a Youtube video seems a
sensible change.

[1] https://issuetracker.google.com/issues/35174286