### PR TITLE
Add scenario for when a page is not useful

### DIFF
--- a/features/feedback.feature
+++ b/features/feedback.feature
@@ -19,3 +19,11 @@ Feature: Feedback
   Scenario: Check the FoI page loads correctly
     When I visit "/contact/foi"
     Then I should see "How to make a freedom of information (FOI) request"
+
+  @normal
+  Scenario: Check "is this page useful?" email survey
+    When I visit "/"
+    And I click to say the page is not useful
+    And I submit the email survey signup form
+    Then I see a signup confirmation message
+    And a request is sent to the feedback app

--- a/features/step_definitions/feedback_steps.rb
+++ b/features/step_definitions/feedback_steps.rb
@@ -4,6 +4,35 @@ When /^I input malicious code in the (.*) field$/ do |field|
   click_button("Send message")
 end
 
+When /^I click to say the page is not useful$/ do
+  within(".gem-c-feedback") do
+    click_on("No")
+  end
+end
+
+When /^I submit the email survey signup form$/ do
+  within(".gem-c-feedback") do
+    fill_in "Email address", with: "name@example.com"
+    click_on "Send me the survey"
+  end
+end
+
+Then /^I see a signup confirmation message$/ do
+  expect(page).to have_content("Thank you for your feedback")
+end
+
 Then /^I see the code returned in the page$/ do
   expect(page).to have_selector("input[value='<script>alert(document.cookie)</script>']")
+end
+
+Then /^a request is sent to the feedback app$/ do
+  sought = "/contact/govuk/email-survey-signup"
+  wait_until { proxy_has_request_with_url_containing sought }
+  expect(proxy_has_request_with_url_containing sought).to be(true)
+end
+
+def proxy_has_request_with_url_containing(sought)
+  $proxy.har.entries.any? do |e|
+    e.request.url.include? sought
+  end
 end


### PR DESCRIPTION
https://github.com/alphagov/govuk_publishing_components/issues/997

This adds a scenario to check a user is able to successfully submit a
request to give feedback when they don't find a page is useful. While
this feature exists on most pages on GOV.UK, this check only visits the
homepage to superficially cover the behaviour.

Co-Author: @bilbof 