### PR TITLE
Fix feature tests for draft pages

### DIFF
--- a/features/draft_environment.feature
+++ b/features/draft_environment.feature
@@ -15,7 +15,7 @@ Feature: Draft environment
   @normal @draft
   Scenario: Check visiting a page served by government-frontend
     When I try to login as a user
-    When I attempt to visit "government/case-studies/epic-cic"
+    When I attempt to visit "government/case-studies/example-case-studies-eu-citizens-rights-in-the-uk"
     Then I should see "Case study"
     And the page should contain the draft watermark
 

--- a/features/step_definitions/draft_environment_steps.rb
+++ b/features/step_definitions/draft_environment_steps.rb
@@ -1,5 +1,5 @@
 When /^I attempt to go to a case study$/ do
-  visit_path "government/case-studies/loopwheels-delivering-a-smoother-ride-for-wheelchair-users"
+  visit_path "government/case-studies/example-case-studies-eu-citizens-rights-in-the-uk"
 end
 
 When /^I attempt to visit "(.*?)"$/ do |path|
@@ -25,7 +25,7 @@ When /^I log in using valid credentials$/ do
 end
 
 Then /^I should be on the case study page$/ do
-  expect(page.current_path).to eq("/government/case-studies/loopwheels-delivering-a-smoother-ride-for-wheelchair-users")
+  expect(page.current_path).to eq("/government/case-studies/example-case-studies-eu-citizens-rights-in-the-uk")
   expect(page).to have_content('Case study')
 end
 


### PR DESCRIPTION
The previous commit changed the candidate page for draft stack
but didn't include updating the spec file itself and is pointing
to a newly published page that does not yet exist on integration.