### PR TITLE
Add basic auth headers to DGU test

### DIFF
--- a/features/data_gov_uk.feature
+++ b/features/data_gov_uk.feature
@@ -1,5 +1,8 @@
 Feature: Data.gov.uk
   Tests for "Find open data" and CKAN on data.gov.uk
+  
+  Background:
+    Given I am testing through the full stack
 
   @high @notintegration @notstaging @nottraining
   Scenario: Check home page loads correctly


### PR DESCRIPTION
## What

Smokey tests for DGU are failing on Integration as the Integration website needs basic auth, so adding the basic auth headers should fix them. 