### PR TITLE
Update tests for retiring stats finder

### DIFF
--- a/features/benchmarking.feature
+++ b/features/benchmarking.feature
@@ -43,9 +43,9 @@ Feature: Benchmarking
     Then the elapsed time should be less than 2 seconds
 
   @normal @benchmarking
-  Scenario: Check the statistics announcements page loads quickly
+  Scenario: Check the research and statistics page loads quickly
     Given I am benchmarking
     And I am testing through the full stack
     And I force a varnish cache miss
-    When I visit "/government/statistics/announcements"
+    When I visit "/search/research-and-statistics"
     Then the elapsed time should be less than 2 seconds

--- a/features/email_sign_up.feature
+++ b/features/email_sign_up.feature
@@ -39,13 +39,13 @@ Feature: Email signup
     And the "immediately" option should be preselected by default
 
   @normal
-  Scenario: Starting from a whitehall finder
-    When I visit "/government/statistics"
-    And I click on the link "email"
+  Scenario: Starting from the statistics finder
+    When I visit "/search/research-and-statistics"
+    And I click on the link "Get email alerts"
     Then I should see "Create subscription"
-    When I click on the button "Create subscription"
+    And I choose the checkbox "Statistics (published)" and click on "Create subscription"
     Then I should see "How often do you want to get updates?"
-    And the "immediately" option should be preselected by default
+    And the "As soon as they happen" option should be preselected by default
 
   @normal
   Scenario: Starting from a taxon page

--- a/features/gov_uk.feature
+++ b/features/gov_uk.feature
@@ -24,13 +24,13 @@ Feature: Core GOV.UK behaviour
   Scenario: Check entirely upper case slugs redirect to lowercase
     Given I am testing through the full stack
     And I force a varnish cache miss
-    When I visit "/GOVERNMENT/STATISTICS" without following redirects
+    When I visit "/GOVERNMENT/ORGANISATIONS" without following redirects
     Then I should get a 301 status code
-    And I should be at a location path of "/government/statistics"
+    And I should be at a location path of "/government/organisations"
 
   @normal
   Scenario: Check partially upper case slugs do not redirect
     Given I am testing through the full stack
     And I force a varnish cache miss
-    When I visit "/government/statisTICS" without following redirects
+    When I visit "/government/organisaTIONS" without following redirects
     Then I should see "Page not found"


### PR DESCRIPTION
The Whitehall statistics finder is soon to be redirected to the newer
https://gov.uk/search/research-and-statistics finder. I've updated tests
that will fail when that redirect goes in.

There is one remaining test that should be updated (the Whitehall tests for
announcements and statistics atom feeds).  This test will continue to pass
once the redirects are deployed, but should be tweaked to ensure that the
redirects are actually working.

https://trello.com/c/BE2ooOcY/934-redirect-whitehall-statistics-finder-to-finder-frontend