### PR TITLE
Add youtube-nocookie to the proxy blacklist

### DIFF
--- a/features/draft_environment.feature
+++ b/features/draft_environment.feature
@@ -15,7 +15,7 @@ Feature: Draft environment
   @normal @draft
   Scenario: Check visiting a page served by government-frontend
     When I try to login as a user
-    When I attempt to visit "government/case-studies/example-case-studies-eu-citizens-rights-in-the-uk"
+    When I attempt to visit "government/case-studies/epic-cic"
     Then I should see "Case study"
     And the page should contain the draft watermark
 

--- a/features/step_definitions/draft_environment_steps.rb
+++ b/features/step_definitions/draft_environment_steps.rb
@@ -1,5 +1,5 @@
 When /^I attempt to go to a case study$/ do
-  visit_path "government/case-studies/example-case-studies-eu-citizens-rights-in-the-uk"
+  visit_path "government/case-studies/libraries-unlimited"
 end
 
 When /^I attempt to visit "(.*?)"$/ do |path|
@@ -25,7 +25,7 @@ When /^I log in using valid credentials$/ do
 end
 
 Then /^I should be on the case study page$/ do
-  expect(page.current_path).to eq("/government/case-studies/example-case-studies-eu-citizens-rights-in-the-uk")
+  expect(page.current_path).to eq("/government/case-studies/libraries-unlimited")
   expect(page).to have_content('Case study')
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -52,6 +52,7 @@ end
 
 # Blacklist YouTube to prevent cross-site errors
 proxy.blacklist(/^https:\/\/www\.youtube\.com/i, 200)
+proxy.blacklist(/^https:\/\/www\.youtube\-nocookie\.com/i, 200)
 proxy.blacklist(/^https:\/\/s\.ytimg\.com/i, 200)
 
 # Licensify admin doesn't have favicon.ico so block requests to prevent errors


### PR DESCRIPTION
I think this should solve the YouTube problem we were seeing before as all requests to that address should result in a 200 successful response.

This allows us to revert 4480e78 and go back to using the old case study which had an embedded YouTube video.