### PR TITLE
Make sure page view tracking events are sent on the homepage

### DIFF
--- a/features/frontend.feature
+++ b/features/frontend.feature
@@ -26,6 +26,11 @@ Feature: Frontend
     Then I should get a "Content-Type" header of "text/html; charset=utf-8"
 
   @normal
+  Scenario: Check homepage sends an event to Google Analytics
+    When I visit "/"
+    Then the page view should be tracked
+
+  @normal
   Scenario: Check 404 page content type and charset
     When I visit a non-existent page
     Then I should get a "Content-Type" header of "text/html; charset=utf-8"

--- a/features/step_definitions/analytics.rb
+++ b/features/step_definitions/analytics.rb
@@ -16,10 +16,20 @@ Then /^the "(.*)" event for result (.*) is reported$/ do |event, n|
   expect(proxy_has_request_with_body_containing sought).to be(true)
 end
 
+Then /^the page view should be tracked$/ do
+  sought = "t=pageview"
+  wait_until { proxy_has_request_with_body_containing sought }
+  expect(proxy_has_request_with_body_containing sought).to be(true)
+end
+
 def proxy_has_request_with_body_containing(sought)
-  $proxy.har.entries.any? do |e|
-    if e.request.body_size.positive?
-      e.request.post_data.text.include?(sought)
+  $proxy.har.entries.any? do |entry|
+    request = entry.request
+
+    return true if request.url.include?(sought)
+
+    if request.body_size.positive?
+      return true if request.post_data.text.include?(sought)
     end
   end
 end

--- a/features/step_definitions/analytics.rb
+++ b/features/step_definitions/analytics.rb
@@ -1,0 +1,25 @@
+Then /^search analytics for "(.*)" are reported$/ do |term|
+  sought = "dp=#{CGI::escape("/search/all?keywords=#{term.sub(' ', '+')}")}"
+  wait_until { proxy_has_request_with_body_containing sought }
+  expect(proxy_has_request_with_body_containing sought).to be(true)
+end
+
+Then /^the "(.*)" event is reported$/ do |event|
+  sought = "ec=#{event}"
+  wait_until { proxy_has_request_with_body_containing sought }
+  expect(proxy_has_request_with_body_containing sought).to be(true)
+end
+
+Then /^the "(.*)" event for result (.*) is reported$/ do |event, n|
+  sought = "ec=#{event}&ea=#{n}"
+  wait_until { proxy_has_request_with_body_containing sought }
+  expect(proxy_has_request_with_body_containing sought).to be(true)
+end
+
+def proxy_has_request_with_body_containing(sought)
+  $proxy.har.entries.any? do |e|
+    if e.request.body_size.positive?
+      e.request.post_data.text.include?(sought)
+    end
+  end
+end

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -32,29 +32,3 @@ And /^the search results should be unique$/ do
   end
   expect(results.uniq.count).to eq(results.count)
 end
-
-Then /^search analytics for "(.*)" are reported$/ do |term|
-  sought = "dp=#{CGI::escape("/search/all?keywords=#{term.sub(' ', '+')}")}"
-  wait_until { proxy_has_request_with_body_containing sought }
-  expect(proxy_has_request_with_body_containing sought).to be(true)
-end
-
-Then /^the "(.*)" event is reported$/ do |event|
-  sought = "ec=#{event}"
-  wait_until { proxy_has_request_with_body_containing sought }
-  expect(proxy_has_request_with_body_containing sought).to be(true)
-end
-
-Then /^the "(.*)" event for result (.*) is reported$/ do |event, n|
-  sought = "ec=#{event}&ea=#{n}"
-  wait_until { proxy_has_request_with_body_containing sought }
-  expect(proxy_has_request_with_body_containing sought).to be(true)
-end
-
-def proxy_has_request_with_body_containing(sought)
-  $proxy.har.entries.any? do |e|
-    if e.request.body_size.positive?
-      e.request.post_data.text.include?(sought)
-    end
-  end
-end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -54,6 +54,9 @@ end
 proxy.blacklist(/^https:\/\/www\.youtube\.com/i, 200)
 proxy.blacklist(/^https:\/\/s\.ytimg\.com/i, 200)
 
+# To avoid sending events to Google Analytics
+proxy.blacklist(/^https:\/\/www\.google\-analytics\.com/i, 200)
+
 # Licensify admin doesn't have favicon.ico so block requests to prevent errors
 proxy.blacklist(/^https:\/\/licensify-admin(.*)\.publishing\.service\.gov\.uk\/favicon\.ico$/i, 200)
 


### PR DESCRIPTION
This adds a test to ensure that visiting the homepage triggers a Google Analytics `t=pageview` event.

I've also blacklisted requests to Google Analytics to prevent the request from affecting our real results.

[Trello Card](https://trello.com/c/tpj7DUOs/1187-add-smokey-test-to-check-were-communicating-with-google-analytics)