### PR TITLE
Change DGU steps to collect package count from frontend

### DIFF
--- a/features/data_gov_uk.feature
+++ b/features/data_gov_uk.feature
@@ -34,7 +34,7 @@ Feature: Data.gov.uk
   @high @notintegration @notstaging @nottraining
   Scenario: Check datasets sync between CKAN and Find
     Given I am testing "https://ckan.publishing.service.gov.uk"
-    When I request "/api/3/action/package_search"
+    When I search for all datasets
     And I save the dataset count
     Given I am testing "https://data.gov.uk"
     And I force a varnish cache miss

--- a/features/step_definitions/datagovuk_steps.rb
+++ b/features/step_definitions/datagovuk_steps.rb
@@ -7,9 +7,13 @@ Then /^I should see some dataset results$/ do
   expect(result_links.count).to be >= 1
 end
 
+When /^I search for all datasets$/ do
+  visit "#{@host}/dataset?q="
+end
+
 When /^I save the dataset count$/ do
-  json = JSON.parse(@response.body)
-  @package_count = json.fetch("result").fetch("count")
+  package_count_form = page.first(".search-form h2")
+  @package_count = package_count_form.text.gsub(/[^\d^\.]/, '').to_i
 end
 
 Then /^I should see a similar dataset count$/ do


### PR DESCRIPTION
A previously tested endpoint is no longer exposed in the API.
An alternative method can be used to obtain the same information from the frontend.