### PR TITLE
Update email alert feature test

### DIFF
--- a/features/email_sign_up.feature
+++ b/features/email_sign_up.feature
@@ -43,7 +43,6 @@ Feature: Email signup
     When I visit "/search/research-and-statistics"
     And I click on the link "Get email alerts"
     Then I should see "Create subscription"
-    And I choose the checkbox "Statistics (published)" and click on "Create subscription"
     Then I should see "How often do you want to get updates?"
     And the "immediately" option should be preselected by default
 


### PR DESCRIPTION
In line with https://github.com/alphagov/finder-frontend/pull/1515
users will no longer see a checkbox to select email alert types.