### PR TITLE
Fix for failing Smokey test

### DIFF
--- a/features/step_definitions/feedback_steps.rb
+++ b/features/step_definitions/feedback_steps.rb
@@ -1,6 +1,6 @@
 When /^I input malicious code in the (.*) field$/ do |field|
   page.execute_script('$("form").attr("novalidate", "novalidate")')
-  find(".email").set("<script>alert(document.cookie)</script>")
+  find_by_id("email").set("<script>alert(document.cookie)</script>")
   click_button("Send message")
 end
 


### PR DESCRIPTION
I believe as part of a general modernisation of the use of govuk_frontend
we're seeing a test fail in Smokey due to being unable to find a certain
css field. This PR changes the means in which we retrieve the object in
question from the now non-existent css id to the id as found in the page
source.