### PR TITLE
Use click_button for show more search options

### DIFF
--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -3,7 +3,7 @@ When /^I search for "(.*)"$/ do |term|
 end
 
 When /^I expand the search options$/ do
-  click_link "+ Show more search options"
+  click_button "+ Show more search options"
 end
 
 When /^I go to the next page$/ do


### PR DESCRIPTION
Following [this change in Finder Frontend to use a button element rather than a link](https://github.com/alphagov/finder-frontend/pull/1542), the Smokey tests have been failing because it still expects the toggle to be a link:

```Unable to find link "+ Show more search options" (Capybara::ElementNotFound)```

This updates the test to click on a button element rather than a link.