### PR TITLE
Run finder benchmarking tests in AWS only

### DIFF
--- a/features/benchmarking.feature
+++ b/features/benchmarking.feature
@@ -10,7 +10,7 @@ Feature: Benchmarking
     And I should get a "Location" header of "https://www.gov.uk/government/organisations/attorney-generals-office"
     And the elapsed time should be less than 2 seconds
 
-  @low @benchmarking @notintegration @nottraining
+  @low @benchmarking @notintegration @nottraining @aws
   Scenario: Check the licence finder home page loads quickly
     Given I am benchmarking
     And I am testing through the full stack
@@ -42,7 +42,7 @@ Feature: Benchmarking
     When I visit "/api/world-locations"
     Then the elapsed time should be less than 2 seconds
 
-  @normal @benchmarking
+  @normal @benchmarking @aws
   Scenario: Check the research and statistics page loads quickly
     Given I am benchmarking
     And I am testing through the full stack


### PR DESCRIPTION
We occasionally get a failure for these tests when they are run in carrenza, which we think is related to network latency.  We've checked the finder-frontend application logs and the maximum time to respond hasn't exceeded 1.6 secs for the research and statistics finder in this period.

These tests should be failing if the software is slow, not if there are problems with network connectivity.