### PR TITLE
Add "smokey" to cache-bust string

### DIFF
--- a/features/support/visiting_pages.rb
+++ b/features/support/visiting_pages.rb
@@ -2,8 +2,8 @@ require 'base64'
 
 def visit_path(path)
   if path.match(%r[\?])
-    visit "#{path}&cachebust=#{rand.to_s}"
+    visit "#{path}&smokey_cachebust=#{rand.to_s}"
   else
-    visit "#{path}?cachebust=#{rand.to_s}"
+    visit "#{path}?smokey_cachebust=#{rand.to_s}"
   end
 end


### PR DESCRIPTION
This will make requests made via Smokey easier to spot in logs that may not report on user-agent