### PR TITLE
Update heading for specialist finders

### DIFF
--- a/features/step_definitions/finder_frontend_steps.rb
+++ b/features/step_definitions/finder_frontend_steps.rb
@@ -8,7 +8,7 @@ Then(/^I should see filtered documents$/) do
 end
 
 And /^I should see an? (open|closed) facet titled "(.*?)" with non-blank values$/ do |open_closed, title|
-  facet = page.find('.app-c-option-select') { |elem| elem.find('.js-container-head').has_text?(title)}
+  facet = page.find('.app-c-option-select') { |elem| elem.find('.js-container-button').has_text?(title)}
 
   if open_closed == "open"
     expect(facet[:class].split(" ")).not_to include("js-closed")


### PR DESCRIPTION
This resolves the failing test due to changes in https://github.com/alphagov/finder-frontend/pull/1713.