### PR TITLE
Change email singup test to use first link on page

### DIFF
--- a/features/step_definitions/email_sign_up_steps.rb
+++ b/features/step_definitions/email_sign_up_steps.rb
@@ -9,7 +9,7 @@ When /^I input "(.*)" and click subscribe$/ do |email|
 end
 
 When /^I click on the link "(.*?)"$/ do |link_text|
-  click_link link_text
+  click_link link_text, match: :first
 end
 
 When /^I choose the checkbox "(.*)" and click on "(.*)"$/ do |option, button_text|


### PR DESCRIPTION
Making this change as some tests were out of date, and were unable to pick between multiple occurrences of the same link - now they'll use the first one they find.