### PR TITLE
Remove check for email frequency preselection

### DIFF
--- a/features/email_sign_up.feature
+++ b/features/email_sign_up.feature
@@ -13,7 +13,6 @@ Feature: Email signup
     Then I should see "Create subscription"
     When I click on the button "Create subscription"
     Then I should see "How often do you want to get updates?"
-    And the "immediately" option should be preselected by default
     When I choose radio button "Once a week" and click on "Next"
     And I input "simulate-delivered@notifications.service.gov.uk" and click subscribe
     Then I should see "You’ve subscribed successfully"
@@ -27,7 +26,6 @@ Feature: Email signup
     Then I should see "What you’ll get"
     When I click on the button "Sign up now"
     Then I should see "How often do you want to get updates?"
-    And the "immediately" option should be preselected by default
 
   @normal
   Scenario: Starting from the news and communications finder
@@ -36,7 +34,6 @@ Feature: Email signup
     Then I should see "Email alert subscription"
     When I click on the button "Create subscription"
     Then I should see "How often do you want to get updates?"
-    And the "immediately" option should be preselected by default
 
   @normal
   Scenario: Starting from the statistics finder
@@ -45,7 +42,6 @@ Feature: Email signup
     Then I should see "Create subscription"
     And I choose the checkbox "Statistics (published)" and click on "Create subscription"
     Then I should see "How often do you want to get updates?"
-    And the "immediately" option should be preselected by default
 
   @normal
   Scenario: Starting from a taxon page
@@ -56,7 +52,6 @@ Feature: Email signup
     When I choose radio button "Teaching and leadership" and click on "Select"
     And I click on the button "Sign up now"
     Then I should see "How often do you want to get updates?"
-    And the "immediately" option should be preselected by default
 
   @normal
   Scenario: Starting from a topic page
@@ -65,7 +60,6 @@ Feature: Email signup
     When I click on the link "Subscribe to email alerts"
     And I click on the button "Create subscription"
     Then I should see "How often do you want to get updates?"
-    And the "immediately" option should be preselected by default
 
   @normal
   Scenario: Starting from a finder (specialist-publisher)
@@ -74,7 +68,6 @@ Feature: Email signup
     When I click on the link "Get email alerts"
     And I choose the checkbox "Markets" and click on "Create subscription"
     Then I should see "How often do you want to get updates?"
-    And the "immediately" option should be preselected by default
 
   @normal
   Scenario: Starting from the business finder
@@ -83,4 +76,3 @@ Feature: Email signup
     When I click on the link "Get email alerts"
     And I choose the checkbox "Personal data" and click on "Create subscription"
     Then I should see "How often do you want to get updates?"
-    And the "daily" option should be preselected by default

--- a/features/step_definitions/email_sign_up_steps.rb
+++ b/features/step_definitions/email_sign_up_steps.rb
@@ -20,8 +20,3 @@ end
 When /^I click on the button "(.*?)"$/ do |button_text|
   click_button button_text
 end
-
-And /^the "(.+)" option should be preselected by default$/ do |frequency|
-  # 'visible: false' because the radio buttons are 'hidden' in order to style them
-  expect(page).to have_css("input[name='frequency'][value='#{frequency}'][checked]", visible: false)
-end


### PR DESCRIPTION
Trello: https://trello.com/c/KYrvoZmz/306-double-opt-in-stop-preselecting-the-frequency-when-subscribing
Relates to: https://github.com/alphagov/email-alert-frontend/pull/624/commits

In https://github.com/alphagov/email-alert-frontend/pull/624/commits we are stopping the preselection of email frequency when users sign up for new subscriptions. We can therefore remove the tests associated with this functionality.