### PR TITLE
Remove email signup steps for double opt-in

### DIFF
--- a/features/email_sign_up.feature
+++ b/features/email_sign_up.feature
@@ -13,9 +13,6 @@ Feature: Email signup
     Then I should see "Create subscription"
     When I click on the button "Create subscription"
     Then I should see "How often do you want to get updates?"
-    When I choose radio button "Once a week" and click on "Next"
-    And I input "simulate-delivered@notifications.service.gov.uk" and click subscribe
-    Then I should see "You’ve subscribed successfully"
 
   @normal
   Scenario: Starting from an organisation home page

--- a/features/step_definitions/email_sign_up_steps.rb
+++ b/features/step_definitions/email_sign_up_steps.rb
@@ -3,11 +3,6 @@ When /^I choose radio button "(.*?)" and click on "(.*?)"$/ do |option, button_t
   step "I click on the button \"#{button_text}\""
 end
 
-When /^I input "(.*)" and click subscribe$/ do |email|
-  fill_in('address', with: email)
-  step "I click on the button \"Subscribe\""
-end
-
 When /^I click on the link "(.*?)"$/ do |link_text|
   click_link link_text, match: :first
 end


### PR DESCRIPTION
https://trello.com/c/2Rjx8ib3/307-double-opt-in-simplify-smokey-tests-for-email-subscriptions

This removes a couple of steps from one of the email signup scenarios,
which went beyond the 'signup' journey and through the 'subscribe'
journey, which will shortly change with the introduction of double
op-in. The interaction between double opt-in and a received email means
we can't preserve an E2E smokey test for subscriptions, but we're
comfortable this is covered by the of specs in the respective repos.