### PR TITLE
Search options are always shown

### DIFF
--- a/features/search.feature
+++ b/features/search.feature
@@ -12,8 +12,6 @@ Feature: Search
     Then I should see some search results
     And the search results should be unique
     Then search analytics for "<keywords>" are reported
-    When I expand the search options
-    Then the "filterClicked" event is reported
     When I go to the next page
     Then the "contentsClicked" event is reported
     When I click result 1

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -2,10 +2,6 @@ When /^I search for "(.*)"$/ do |term|
   visit_path "/search?q=#{term}"
 end
 
-When /^I expand the search options$/ do
-  click_button "+ Show more search options"
-end
-
 When /^I go to the next page$/ do
   click_link "Next page"
 end


### PR DESCRIPTION
Removing a bit of the search test because we're not showing the "Show more search options" link at present.