### PR TITLE
Reenable search keyword test step

### DIFF
--- a/features/finder_frontend.feature
+++ b/features/finder_frontend.feature
@@ -54,6 +54,7 @@ Feature: Finder Frontend
     When I visit the "<finder>" finder without keywords
     And I fill in the keyword field with <keyword>
     Then There should be no alert
+    And I should see the string <keyword>
 
   Examples:
     | keyword                     | finder                  |


### PR DESCRIPTION
Revert of #626 where we temporarily disabled the step as we were running an AB test.

[Trello card](https://trello.com/c/1nHm6AeM/603-revert-keyword-facet-tags-a-b-test)