### PR TITLE
Mark search analytics test as @pending

### DIFF
--- a/features/search.feature
+++ b/features/search.feature
@@ -6,7 +6,7 @@ Feature: Search
     Given I am testing through the full stack
     And I force a varnish cache miss for search
 
-  @high
+  @pending
   Scenario Outline: Check search results and analytics
     When I search for "<keywords>"
     Then I should see some search results


### PR DESCRIPTION
This is now failing following the change to cookie consent.  I think
we still want this test, so rather than remove it outright I've
disabled it until we make smokey accept cookies.