### PR TITLE
Update the brexit checker route to transition-checker

### DIFF
--- a/features/brexit_check.feature
+++ b/features/brexit_check.feature
@@ -16,7 +16,7 @@ Feature: Get Ready for Brexit Check
 
   @high
   Scenario: Check that the Brexit checker can be subscribed to
-    When I visit "/get-ready-brexit-check/questions"
+    When I visit "/transition-check/questions"
     And I answer the nationality question
     And I skip all other questions
     And I click Subscribe link

--- a/features/step_definitions/brexit_check_steps.rb
+++ b/features/step_definitions/brexit_check_steps.rb
@@ -14,7 +14,7 @@ When "I answer the where do you live question" do
 end
 
 When "I skip all other questions" do
-  while page.has_current_path?('/get-ready-brexit-check/questions', ignore_query: true)
+  while page.has_current_path?('/transition-check/questions', ignore_query: true)
     click_button "Continue"
   end
 end


### PR DESCRIPTION
We recently reslugged the brexit checker. This commit reflects that

trello: https://trello.com/c/LllJV5JJ/409-reslug-the-brexit-checker
