### PR TITLE
Update search tests to allow cookies

### DIFF
--- a/features/search.feature
+++ b/features/search.feature
@@ -6,14 +6,12 @@ Feature: Search
     Given I am testing through the full stack
     And I force a varnish cache miss for search
 
-  @pending
+  @high
   Scenario Outline: Check search results and analytics
     When I search for "<keywords>"
     Then I should see some search results
     And the search results should be unique
     Then search analytics for "<keywords>" are reported
-    When I expand the search options
-    Then the "filterClicked" event is reported
     When I go to the next page
     Then the "contentsClicked" event is reported
     When I click result 1

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -1,5 +1,6 @@
 When /^I search for "(.*)"$/ do |term|
   visit_path "/search?q=#{term}"
+  click_button "Accept" # Pesky search cookie window needs to be told to go away
 end
 
 When /^I expand the search options$/ do


### PR DESCRIPTION
Two commits: The new cookie window was preventing any visits to the search page from
allowing any actual searching to take place. Small fix in place to allow us to bypass the window through accepting the cookies.

Also updated the relevant feature to remove some obsolete functionality.

Trello: https://trello.com/c/mWtEFWK9/1334-make-smokey-consent-to-search-cookies