### PR TITLE
Update transition related tests

### DIFF
--- a/features/email_sign_up.feature
+++ b/features/email_sign_up.feature
@@ -66,10 +66,3 @@ Feature: Email signup
     And I choose the checkbox "Markets" and click on "Create subscription"
     Then I should see "How often do you want to get updates?"
 
-  @normal
-  Scenario: Starting from the business finder
-    When I visit "/find-eu-exit-guidance-business"
-    Then I should see "Get email alerts"
-    When I click on the link "Get email alerts"
-    And I choose the checkbox "Personal data" and click on "Create subscription"
-    Then I should see "How often do you want to get updates?"

--- a/features/step_definitions/brexit_check_steps.rb
+++ b/features/step_definitions/brexit_check_steps.rb
@@ -20,7 +20,7 @@ When "I skip all other questions" do
 end
 
 Then "I should see the results page" do
-  expect(page).to have_content("Get ready for a no-deal Brexit: Your results")
+  expect(page).to have_content("How to get ready for new rules in 2021: Your results")
 end
 
 Then "I should see confirmation of my answers" do


### PR DESCRIPTION
We have updated some copy and removed the checker previously at `/find-eu-exit-guidance-business`, so these tests can be updated