### PR TITLE
Add test for licence postcode lookup

### DIFF
--- a/features/licence_finder.feature
+++ b/features/licence_finder.feature
@@ -19,3 +19,11 @@ Feature: Licence Finder
   Scenario: Check licence finder returns licences
     When I visit "/licence-finder/licences?activities=149&location=wales&sectors=59"
     Then I should see "A premises licence is for carrying out 'licensable activities' at a particular venue"
+
+  @normal
+  Scenario: Check licence postcode lookup
+    When I visit "/temporary-events-notice"
+    Then I should see "Temporary Events Notice"
+     And I should see an input field for postcode
+    When I try to post to "/temporary-events-notice" with "postcode=SW1A+2AA"
+    Then I should see "Westminster City Council"


### PR DESCRIPTION
This came out as an incident review action.

It tests the following page:
<img width="745" alt="Screenshot 2020-02-10 at 11 32 51" src="https://user-images.githubusercontent.com/19667619/74146498-1df8b580-4bf9-11ea-947f-a33ec684f7e6.png">

<img width="698" alt="Screenshot 2020-02-10 at 11 33 49" src="https://user-images.githubusercontent.com/19667619/74146582-48e30980-4bf9-11ea-8522-c25874b54be4.png">


Trello card: https://trello.com/c/hTX3K6RQ/1740-2-add-a-smokey-test-for-applying-for-a-licence-with-a-postcode