### PR TITLE
Make cookie consent global

### DIFF
--- a/features/ab_testing.feature
+++ b/features/ab_testing.feature
@@ -7,6 +7,7 @@ Feature: A/B Testing
 
   Background:
     Given there is an A/B test set up
+    And I consent to cookies
     And I am testing through the full stack
 
   @low

--- a/features/search.feature
+++ b/features/search.feature
@@ -4,6 +4,7 @@ Feature: Search
 
   Background:
     Given I am testing through the full stack
+    And I consent to cookies
     And I force a varnish cache miss for search
 
   @high

--- a/features/step_definitions/ab_testing_steps.rb
+++ b/features/step_definitions/ab_testing_steps.rb
@@ -8,11 +8,13 @@ Given(/^there is an A\/B test set up$/) do
 end
 
 Given(/^I do not have any A\/B testing cookies set$/) do
-  assert_equal(
-    [],
-    Capybara.current_session.driver.browser.manage.all_cookies,
-    "There should be no cookies set"
-  )
+  Capybara.current_session.driver.browser.manage.all_cookies.each do |cookie|
+    refute_equal(
+      "ABTest-Example",
+      cookie[:name],
+      "There should be no A/B cookies set"
+    )
+  end
 end
 
 Then(/^we have shown them all versions of the A\/B test$/) do

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -1,6 +1,5 @@
 When /^I search for "(.*)"$/ do |term|
   visit_path "/search?q=#{term}"
-  click_button "Accept" # Pesky search cookie window needs to be told to go away
 end
 
 When /^I expand the search options$/ do

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -39,6 +39,20 @@ Given /^I am an authenticated API client$/ do
   @authenticated_as_client = true
 end
 
+And /^I consent to cookies$/ do
+  visit_path "/"
+  click_button "Accept"
+
+  consent_cookie = Capybara
+    .current_session
+    .driver
+    .browser
+    .manage
+    .cookie_named("cookies_policy")
+
+  @consent_cookie_value = consent_cookie[:value]
+end
+
 When /^I go to the "([^"]*)" landing page$/ do |app_name|
   visit_path application_external_url(app_name)
 end

--- a/features/support/http_requests.rb
+++ b/features/support/http_requests.rb
@@ -63,6 +63,11 @@ def do_http_request(url, method = :get, options = {}, &block)
   }
   options = defaults.merge(options)
 
+  if @consent_cookie_value
+    cookies = options.fetch(:cookies, {}).merge("cookies_policy": @consent_cookie_value)
+    options = options.merge(cookies: cookies)
+  end
+
   headers = {
     'User-Agent' => 'Smokey Test / Ruby',
     'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',


### PR DESCRIPTION
The "And I consent to cookies" step adds the consent cookie to all
following requests, whether Capybara requests in the current
session (using "visit" etc) or raw HTTP requests (using
"do_http_request" etc).

Consent can be revoked by setting @consent_cookie_value to nil, but
there are no tests yet which give and then revoke consent.

Also change search tests to use this new way, and A/B test tests to
consent.