### PR TITLE
Update Smartanswers country step to new class selector

### DIFF
--- a/features/step_definitions/smartanswers_steps.rb
+++ b/features/step_definitions/smartanswers_steps.rb
@@ -1,6 +1,6 @@
 Then /^I should see a populated country select$/ do
   countries = Nokogiri::HTML.parse(@response.body)
-    .css(".question select option")
+    .css("#current-question select option")
 
   # Check that we have a sensible-looking number of countries, with
   # some flex for that number to change


### PR DESCRIPTION
The CSS classes on the country drop-down list was updated in
https://github.com/alphagov/smart-answers/pull/4324

This updates the relevant step to target the correct class.
