### PR TITLE
Set Chrome user agent to Smokey Test / Ruby

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -80,6 +80,7 @@ Capybara.register_driver :headless_chrome do |app|
   options.add_argument("--headless")
   options.add_argument("--disable-gpu")
   options.add_argument("--disable-xss-auditor")
+  options.add_argument("--user-agent=Smokey\ Test\ \/\ Ruby")
 
   Capybara::Selenium::Driver.new(
     app,


### PR DESCRIPTION
Our PAs find it tricky to omit Smokey traffic from our analytics.  This is more important than it used to be because of our reduced analytics traffic.

This sets the Chromedriver user agent to be the same as the [user agent used by RestClient](https://github.com/alphagov/smokey/blob/master/features/support/http_requests.rb#L72) for some of the other Smokey requests.

https://trello.com/c/BC2lVBbw/1372-use-a-smokey-specific-user-agent-or-other-identifier