### PR TITLE
Update a test dataset in the data.gov.uk feature

### DIFF
--- a/features/data_gov_uk.feature
+++ b/features/data_gov_uk.feature
@@ -22,7 +22,7 @@ Feature: Data.gov.uk
   Scenario: Check RDF API loads
     Given I am testing "https://data.gov.uk"
     And I force a varnish cache miss
-    When I request "/dataset/lidar-composite-dsm-1m1.rdf"
+    When I request "/dataset/lidar-composite-dtm-2017-1m.rdf"
     Then I should get a 200 status code
 
   @high


### PR DESCRIPTION
The dataset seems to have been renamed. I'm not sure if the test is
doing what it should be, as the response is a redirect to a HTML page
rather than some nice RDF, but that's maybe another issue.