### PR TITLE
Fix ambiguous search result error

### DIFF
--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -11,8 +11,7 @@ When /^I go to the next page$/ do
 end
 
 When /^I click result (.*)$/ do |num|
-  result = page.all(".finder-results li a")[num.to_i - 1]
-  click_link result.text
+  all(".finder-results li a.gem-c-document-list__item-link")[num.to_i - 1].click
 end
 
 Then /^I should see some search results$/ do


### PR DESCRIPTION
As we show parts in search results now, this step can fail if a part
has the same title as a normal result, as capybara doesn't know which
to click.

So the solution is to call `click` on the right element directly,
keeping it to proper results (not parts) by adding the class: parts
are a .gem-c-document-list-child__link, and so don't match.