### PR TITLE
Fix sign up link text

### DIFF
--- a/features/email_sign_up.feature
+++ b/features/email_sign_up.feature
@@ -53,7 +53,7 @@ Feature: Email signup
     When I visit "/topic/transport/motorways-major-roads"
     Then I should see "Subscribe to email alerts"
     When I click on the link "Subscribe to email alerts"
-    And I click on the button "Create subscription"
+    And I click on the button "Sign up"
     Then I should see "How often do you want to receive emails?"
 
   @normal


### PR DESCRIPTION
This is similar to https://github.com/alphagov/smokey/pull/659 but for a transport taxon. I'm not sure why we've only had to change it now.

https://www.gov.uk/email-signup?topic=/topic/transport/motorways-major-roads is the page we get to with the "Sign up" button.