### PR TITLE
Fix missing tag to skip benchmarking scenarios

### DIFF
--- a/features/benchmarking.feature
+++ b/features/benchmarking.feature
@@ -1,7 +1,8 @@
+@benchmarking
 Feature: Benchmarking
   Tests to check the loading times for various pages on GOV.UK.
 
-  @high @benchmarking @local-network @aws
+  @high @local-network @aws
   Scenario: Check Bouncer application is up
     Given I am testing "bouncer" internally
     And I am benchmarking
@@ -10,14 +11,14 @@ Feature: Benchmarking
     And I should get a "Location" header of "https://www.gov.uk/government/organisations/attorney-generals-office"
     And the elapsed time should be less than 2 seconds
 
-  @low @benchmarking @notintegration @nottraining @aws
+  @low @notintegration @nottraining @aws
   Scenario: Check the licence finder home page loads quickly
     Given I am benchmarking
     And I am testing through the full stack
     When I visit "/licence-finder"
     Then the elapsed time should be less than 2 seconds
 
-  @normal @benchmarking @notintegration @nottraining
+  @normal @notintegration @nottraining
   Scenario: Check requesting a PDF takes a reasonable amount of time
     Given I am testing "licensing" internally
       And I am benchmarking
@@ -26,7 +27,7 @@ Feature: Benchmarking
     When I request "/apply-for-a-licence/forms/bury/test-licence/9999-7-1,0-1"
     Then the elapsed time should be less than 10 seconds
 
-  @normal @benchmarking
+  @normal
   Scenario: Check whitehall-frontend pages load quickly
     Given I am benchmarking
     And I am testing through the full stack
@@ -34,7 +35,7 @@ Feature: Benchmarking
     When I visit "/government/how-government-works"
     Then the elapsed time should be less than 2 seconds
 
-  @normal @benchmarking
+  @normal
   Scenario: Check the whitehall API loads quickly
     Given I am benchmarking
     And I am testing through the full stack
@@ -42,7 +43,7 @@ Feature: Benchmarking
     When I visit "/api/world-locations"
     Then the elapsed time should be less than 2 seconds
 
-  @normal @benchmarking @aws
+  @normal @aws
   Scenario: Check the research and statistics page loads quickly
     Given I am benchmarking
     And I am testing through the full stack

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -x
 
@@ -7,10 +7,11 @@ bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
 export RESTCLIENT_LOG="log/smokey-rest-client.log"
 export ENVIRONMENT=${TARGET_PLATFORM}
 
-FLAGS="--profile ${TARGET_PLATFORM}"
+FLAGS=(--profile "${TARGET_PLATFORM}")
+FLAGS+=(-t "not @benchmarking")
 
 if [ -n "${TARGET_APPLICATION}" ]; then
-  FLAGS="${FLAGS} -t @app-${TARGET_APPLICATION}"
+  FLAGS+=(-t "@app-${TARGET_APPLICATION}")
 fi
 
-govuk_setenv smokey bundle exec cucumber $FLAGS
+govuk_setenv smokey bundle exec cucumber "${FLAGS[@]}"


### PR DESCRIPTION
https://trello.com/c/VdbPVqto/154-support-running-only-smokey-tests-that-are-relevant-to-an-app

These should only be run by the "test_json_output" script.

Accidentally removed in: 4d73195