### PR TITLE
Fix hyphen typo in 'app-smart-answers' tag

### DIFF
--- a/features/smartanswers.feature
+++ b/features/smartanswers.feature
@@ -1,4 +1,4 @@
-@aws @app-smart-answers
+@aws @app-smartanswers
 Feature: Smart Answers
 
   Background:


### PR DESCRIPTION
https://trello.com/c/VdbPVqto/154-support-running-only-smokey-tests-that-are-relevant-to-an-app

This tag needs to match the TARGET_APPLICATION parameter used by
the 'Deploy_App_Downstream' job. Normally this would equal the
repo name, but Smart Answers has a historical inconsistency.