### PR TITLE
Add E2E scenario for travel advice publisher

### DIFF
--- a/features/foreign_travel_advice.feature
+++ b/features/foreign_travel_advice.feature
@@ -28,3 +28,13 @@ Feature: Foreign Travel Advice
   Scenario: Check country feed contains the correct website root
     When I visit "/foreign-travel-advice/ireland.atom"
     Then the XML ID is formed from the correct URL
+
+  @notproduction
+  Scenario: Publishing travel advice
+    When I go to the "travel-advice-publisher" landing page
+    And I try to login as a user
+    And I go to the "travel-advice-publisher" landing page
+    Then I should see "GOV.UK Travel Advice Publisher"
+    When I publish a new travel advice edition
+    And I visit "/foreign-travel-advice/afghanistan"
+    Then I should see the updated travel advice

--- a/features/step_definitions/foreign_travel_advice_steps.rb
+++ b/features/step_definitions/foreign_travel_advice_steps.rb
@@ -1,0 +1,12 @@
+When "I publish a new travel advice edition" do
+  step 'I click on the link "Afghanistan"'
+  step 'I click on the button "Create new edition"'
+  choose "edition_update_type_minor"
+  fill_in "edition_summary", with: "Smokey test"
+  step 'I click on the button "Save & Publish"'
+end
+
+Then "I should see the updated travel advice" do
+  step 'I visit "/foreign-travel-advice/afghanistan"'
+  step 'I should see "Smokey test"'
+end


### PR DESCRIPTION
https://trello.com/c/TUB9OGWD/152-prepare-and-run-a-beta-trial-of-continuous-deployment

This is a mergeable demo of how we could extend the coverage provided by 
Smokey tests to give us more confidence in changes to publishing apps.

    We want to avoid running this in production, as it would generate
    changes to the live site. Although each run of this scenario can
    generate data, the daily wipes of our non-production DBs should be
    sufficient to avoid any longterm build up.