### PR TITLE
Treat all scenarios with the same priority

### DIFF
--- a/docs/writing-tests.md
+++ b/docs/writing-tests.md
@@ -2,14 +2,7 @@
 
 ## Alerting in Icinga
 
-In order to alert on a failing scenario in Icinga, you need to:
-
-- Ensure the feature is [listed in the Puppet config](https://github.com/alphagov/govuk-puppet/blob/d7af16e96aed682facb5cf5bc3e3972510c64ca2/hieradata_aws/integration.yaml#L378)
-
-- Tag the scenario with a [priority "@<tag>"](https://github.com/alphagov/govuk-puppet/blob/4ec2949332079570be5493753bb84a983218a444/modules/icinga/manifests/check_feature.pp)
-
-  - `@urgent` tags will trigger will [trigger out-of-hours callouts](https://github.com/alphagov/govuk-puppet/blob/51d7f7b648e8fde5aae3adfb774ec3bca6325bd8/modules/monitoring/manifests/contacts.pp#L163)
-  - Other tags are purely to help us prioritise fixing things
+In order to alert on a failing scenario in Icinga, you need to ensure the feature is [listed in the Puppet config](https://github.com/alphagov/govuk-puppet/blob/d7af16e96aed682facb5cf5bc3e3972510c64ca2/hieradata_aws/integration.yaml#L378).
 
 ## Filtering by app
 

--- a/features/ab_testing.feature
+++ b/features/ab_testing.feature
@@ -10,12 +10,10 @@ Feature: A/B Testing
     And I consent to cookies
     And I am testing through the full stack
 
-  @low
   Scenario: Check we end up in all buckets
     When multiple new users visit "/help/ab-testing"
     Then we have shown them all versions of the A/B test
 
-  @low
   Scenario: Check that an A/B test works
     And I do not have any A/B testing cookies set
     When I visit "/help/ab-testing"

--- a/features/assets.feature
+++ b/features/assets.feature
@@ -2,38 +2,34 @@ Feature: Assets
   Tests for assets and asset-manager, including draft assets which are behind
   signon.
 
-  @high
   Scenario: Check assets are being served
     Given I am testing "assets"
     When I request "/__canary__"
     Then JSON is returned
 
-  @normal @local-network
+  @local-network
   Scenario: Check an asset can be loaded
     Given I am testing "asset-manager" internally
     And I am an authenticated API client
     When I request "/assets/513a0efbed915d425e000002"
     And I should see "120613_Albania_Travel_Advice_WEB_Ed2_jpeg.jpg"
 
-  @normal
   Scenario: Check an asset can be served
     Given I am testing "assets"
     When I request "/media/513a0efbed915d425e000002/120613_Albania_Travel_Advice_WEB_Ed2_jpeg.jpg"
     And I should get a content length of "212880"
 
-  @normal
   Scenario: Check assets with a docx extension are served correctly
     Given I am testing "assets"
     When I request "/media/59f70d5640f0b66bbc806ed3/questionnaire-for-accommodation-providers-online-hotel-booking.docx"
     Then I should get a "Content-Type" header of "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
 
-  @normal
   Scenario: Check assets with an xls extension are served correctly
     Given I am testing "assets"
     When I request "/media/580768d940f0b64fbe000022/Target_incomes_calculator.xls"
     Then I should get a "Content-Type" header of "application/vnd.ms-excel"
 
-  @normal @draft-assets
+  @draft-assets
   Scenario: Check draft assets require authentication
     When I visit "/media/123/filename.extension"
     Then I should be redirected to signon

--- a/features/benchmarking.feature
+++ b/features/benchmarking.feature
@@ -2,7 +2,7 @@
 Feature: Benchmarking
   Tests to check the loading times for various pages on GOV.UK.
 
-  @high @local-network @aws
+  @local-network @aws
   Scenario: Check Bouncer application is up
     Given I am testing "bouncer" internally
     And I am benchmarking
@@ -11,14 +11,14 @@ Feature: Benchmarking
     And I should get a "Location" header of "https://www.gov.uk/government/organisations/attorney-generals-office"
     And the elapsed time should be less than 2 seconds
 
-  @low @notintegration @nottraining @aws
+  @notintegration @nottraining @aws
   Scenario: Check the licence finder home page loads quickly
     Given I am benchmarking
     And I am testing through the full stack
     When I visit "/licence-finder"
     Then the elapsed time should be less than 2 seconds
 
-  @normal @notintegration @nottraining
+  @notintegration @nottraining
   Scenario: Check requesting a PDF takes a reasonable amount of time
     Given I am testing "licensing" internally
       And I am benchmarking
@@ -27,7 +27,6 @@ Feature: Benchmarking
     When I request "/apply-for-a-licence/forms/bury/test-licence/9999-7-1,0-1"
     Then the elapsed time should be less than 10 seconds
 
-  @normal
   Scenario: Check whitehall-frontend pages load quickly
     Given I am benchmarking
     And I am testing through the full stack
@@ -35,7 +34,6 @@ Feature: Benchmarking
     When I visit "/government/how-government-works"
     Then the elapsed time should be less than 2 seconds
 
-  @normal
   Scenario: Check the whitehall API loads quickly
     Given I am benchmarking
     And I am testing through the full stack
@@ -43,7 +41,7 @@ Feature: Benchmarking
     When I visit "/api/world-locations"
     Then the elapsed time should be less than 2 seconds
 
-  @normal @aws
+  @aws
   Scenario: Check the research and statistics page loads quickly
     Given I am benchmarking
     And I am testing through the full stack

--- a/features/brexit_check.feature
+++ b/features/brexit_check.feature
@@ -4,7 +4,6 @@ Feature: Get Ready for Brexit Check
     Given I am testing through the full stack
     And I force a varnish cache miss
 
-  @high
   Scenario: Brexit checker shows results
     When I start the checker
     And I answer the nationality question
@@ -14,7 +13,6 @@ Feature: Get Ready for Brexit Check
     And I should see confirmation of my answers
     And I should see answers applicable to me
 
-  @high
   Scenario: Check that the Brexit checker can be subscribed to
     When I visit "/transition-check/questions"
     And I answer the nationality question

--- a/features/caching.feature
+++ b/features/caching.feature
@@ -5,19 +5,16 @@ Feature: Caching
   Background:
     Given I am testing through the full stack
 
-  @normal
   Scenario: Check council lookup
     When I try to post to "/find-local-council" with "postcode=WC2B+6SE" without following redirects
     Then I should not hit the cache
     Then I should see "camden"
 
-  @normal
   Scenario: Check licence lookup
     When I try to post to "/busking-licence" with "postcode=E20+2ST" without following redirects
     Then I should not hit the cache
     Then I should see "newham"
 
-  @low
   Scenario: Check homepage is served by Varnish
     When I request "/"
     Then I should hit the cache

--- a/features/calculators.feature
+++ b/features/calculators.feature
@@ -4,12 +4,10 @@ Feature: Calculators
     Given I am testing through the full stack
     And I force a varnish cache miss
 
-  @normal
   Scenario: Check the child benefit tax calculator start page
     When I visit "/child-benefit-tax-calculator"
     Then I should see "Child Benefit tax calculator"
 
-  @normal
   Scenario: Check the child benefit tax calculator
     When I visit "/child-benefit-tax-calculator/main"
     Then I should see "Child Benefit tax calculator"

--- a/features/collections.feature
+++ b/features/collections.feature
@@ -4,7 +4,6 @@ Feature: Collections
     Given I am testing through the full stack
     And I force a varnish cache miss
 
-  @normal
   Scenario Outline: Check example collection pages
     When I request "<Path>"
     Then I should see "<Expected string>"
@@ -22,29 +21,24 @@ Feature: Collections
       | /welfare                                         | Welfare                                                   |
       | /world/armenia                                   | UK help and services in Armenia                           |
 
-  @high
   Scenario: Check mainstream browse index page loads correctly
     When I visit "/browse"
     Then I should be able to navigate the browse pages
 
-  @normal
   Scenario: Check mainstream browse page loads with links
     When I visit "/browse/driving"
     And I should see "Teaching people to drive"
     When I click on the section "Teaching people to drive"
     Then I should see "Apply to become a driving instructor"
 
-  @normal
   Scenario: Check topic page loads correctly
     When I visit "/topic"
     Then I should be able to navigate the topic hierarchy
 
-  @normal
   Scenario: Check services and information page loads correctly
     When I visit "/government/organisations/hm-revenue-customs/services-information"
     Then I see links to pages per topic
 
-  @normal
   Scenario: Check government documents feed JSON format is consistent
     When I request "/government/feed"
     Then valid XML should be returned

--- a/features/contacts.feature
+++ b/features/contacts.feature
@@ -5,12 +5,10 @@ Feature: Contacts
     Given I am testing through the full stack
     And I force a varnish cache miss
 
-  @normal
   Scenario: Check the contacts finder
     When I visit "/government/organisations/hm-revenue-customs/contact"
     Then I should see "Contact HM Revenue &amp; Customs"
 
-  @normal
   Scenario: Check viewing a contact
     When I visit "/government/organisations/hm-revenue-customs/contact/child-benefit"
     Then I should see "Child Benefit"

--- a/features/content_data_admin.feature
+++ b/features/content_data_admin.feature
@@ -3,7 +3,6 @@ Feature: Content Data Admin
   Tests for the Content Data Admin application, which provides
   publishers with data about the content they manage
 
-  @normal
   Scenario: Can access the Content Data Admin index page
     When I go to the "content-data-admin" landing page
     And I try to login as a user
@@ -11,7 +10,6 @@ Feature: Content Data Admin
     Then I should see "Content Data"
     And I should see "Log out"
 
-  @normal
   Scenario: Can access a Content Data Admin metrics page
     When I try to login as a user
     And I visit "/metrics/government/organisations/government-digital-service" on the "content-data-admin" application

--- a/features/csv_preview.feature
+++ b/features/csv_preview.feature
@@ -5,7 +5,6 @@ Feature: CSV preview
     Given I am testing through the full stack
     And I force a varnish cache miss
 
-  @normal
   Scenario: Accessing a CSV preview
     When I visit "/government/uploads/system/uploads/attachment_data/file/214962/passport-impact-indicat.csv/preview"
     Then JavaScript should run without any errors

--- a/features/data_gov_uk.feature
+++ b/features/data_gov_uk.feature
@@ -1,44 +1,42 @@
 Feature: Data.gov.uk
   Tests for "Find open data" and CKAN on data.gov.uk
-  
+
   Background:
     Given I am testing through the full stack
 
-  @high @notintegration @notstaging @nottraining
+  @notintegration @notstaging @nottraining
   Scenario: Check home page loads correctly
     Given I am testing "https://data.gov.uk"
     And I force a varnish cache miss
     When I request "/"
     Then I should see "Find open data"
 
-  @high @notintegration @notstaging @nottraining
+  @notintegration @notstaging @nottraining
   Scenario: Check search works
     Given I am testing "https://data.gov.uk"
     And I force a varnish cache miss
     When I search for "data" in datasets
     Then I should see some dataset results
 
-  @normal @notintegration @notstaging @nottraining
+  @notintegration @notstaging @nottraining
   Scenario: Check RDF API loads
     Given I am testing "https://data.gov.uk"
     And I force a varnish cache miss
     When I request "/dataset/lidar-composite-dtm-2017-1m.rdf"
     Then I should get a 200 status code
 
-  @high
   Scenario: Check CKAN loads correctly
     Given I am testing "ckan"
     When I request "/"
     Then I should see "Data publisher"
 
-  @high
   Scenario: Check CKAN action api's search works
     Given I am testing "ckan"
     When I request "/api/action/package_search?q=data"
     Then I should get a 200 status code
     And JSON is returned
 
-  @high @notintegration @notstaging @nottraining
+  @notintegration @notstaging @nottraining
   Scenario: Check datasets sync between CKAN and Find
     Given I am testing "https://ckan.publishing.service.gov.uk"
     When I search for all datasets
@@ -48,7 +46,7 @@ Feature: Data.gov.uk
     When I search for "" in datasets
     Then I should see a similar dataset count
 
-  @high @notintegration @notstaging @nottraining
+  @notintegration @notstaging @nottraining
   Scenario: Check that we don't get any s3 CSP errors for organogram previews
     Given I am testing "https://data.gov.uk"
     When I preview an organogram

--- a/features/draft_environment.feature
+++ b/features/draft_environment.feature
@@ -4,7 +4,7 @@ Feature: Draft environment
   session. Access to the draft stack should be denied without a valid signon
   session.
 
-  @high @draft
+  @draft
   Scenario: Check visiting a draft page requires a signon session
     When I attempt to go to a case study
     Then I should be prompted to log in
@@ -12,21 +12,21 @@ Feature: Draft environment
     Then I should be on the case study page
     And the page should contain the draft watermark
 
-  @normal @draft
+  @draft
   Scenario: Check visiting a page served by government-frontend
     When I try to login as a user
     When I attempt to visit "government/case-studies/example-case-studies-eu-citizens-rights-in-the-uk"
     Then I should see "Case study"
     And the page should contain the draft watermark
 
-  @normal @draft
+  @draft
   Scenario: Check visiting a specialist document served by government-frontend
     When I try to login as a user
     And I attempt to visit a CMA case
     Then I should see "Competition and Markets Authority"
     And the page should contain the draft watermark
 
-  @normal @draft
+  @draft
   Scenario: Check visiting a manual served by manuals-frontend
     When I try to login as a user
     And I attempt to visit a manual

--- a/features/email_sign_up.feature
+++ b/features/email_sign_up.feature
@@ -6,7 +6,6 @@ Feature: Email signup
     Given I am testing through the full stack
     And I force a varnish cache miss
 
-  @high
   Scenario: Starting from foreign travel advice
     When I visit "/foreign-travel-advice/turkey"
     And I click on the link "Get email alerts"
@@ -14,7 +13,6 @@ Feature: Email signup
     When I click on the button "Create subscription"
     Then I should see "How often do you want to receive emails?"
 
-  @normal
   Scenario: Starting from an organisation home page
     When I visit "/government/organisations/department-for-education"
     And I click on the link "email"
@@ -22,7 +20,6 @@ Feature: Email signup
     When I click on the button "Sign up"
     Then I should see "How often do you want to receive emails?"
 
-  @normal
   Scenario: Starting from the news and communications finder
     When I visit "/search/news-and-communications"
     And I click on the link "Get email alerts"
@@ -30,7 +27,6 @@ Feature: Email signup
     When I click on the button "Create subscription"
     Then I should see "How often do you want to receive emails?"
 
-  @normal
   Scenario: Starting from the statistics finder
     When I visit "/search/research-and-statistics"
     And I click on the link "Get email alerts"
@@ -38,7 +34,6 @@ Feature: Email signup
     And I choose the checkbox "Statistics (published)" and click on "Create subscription"
     Then I should see "How often do you want to receive emails?"
 
-  @normal
   Scenario: Starting from a taxon page
     When I visit "/education"
     Then I should see "Sign up for updates to this topic page"
@@ -48,7 +43,6 @@ Feature: Email signup
     And I click on the button "Sign up"
     Then I should see "How often do you want to receive emails?"
 
-  @normal
   Scenario: Starting from a topic page
     When I visit "/topic/transport/motorways-major-roads"
     Then I should see "Subscribe to email alerts"
@@ -56,11 +50,9 @@ Feature: Email signup
     And I click on the button "Sign up"
     Then I should see "How often do you want to receive emails?"
 
-  @normal
   Scenario: Starting from a finder (specialist-publisher)
     When I visit "/cma-cases"
     Then I should see "Get email alerts"
     When I click on the link "Get email alerts"
     And I choose the checkbox "Markets" and click on "Create subscription"
     Then I should see "How often do you want to receive emails?"
-

--- a/features/feedback.feature
+++ b/features/feedback.feature
@@ -4,23 +4,19 @@ Feature: Feedback
     Given I am testing through the full stack
     And I force a varnish cache miss
 
-  @normal
   Scenario: Check the "Contact GOV.UK" page loads correctly
     When I visit "/contact/govuk"
     Then I should see "Contact GOV.UK"
 
-  @high
   Scenario: Check malicious code does not execute
     When I visit "/contact/govuk"
     And I input malicious code in the email field
     Then I see the code returned in the page
 
-  @normal
   Scenario: Check the FoI page loads correctly
     When I visit "/contact/foi"
     Then I should see "How to make a freedom of information (FOI) request"
 
-  @normal
   Scenario: Check "is this page useful?" email survey
     When I visit "/"
     And I click to say the page is not useful

--- a/features/finder_frontend.feature
+++ b/features/finder_frontend.feature
@@ -5,49 +5,41 @@ Feature: Finder Frontend
     Given I am testing through the full stack
     And I force a varnish cache miss
 
-  @normal
   Scenario: Check people page loads correctly
     When I visit "/government/people"
     Then I should see "All ministers and senior officials on GOV.UK"
     And I should see an input field to search
 
-  @normal
   Scenario: Check world organisations loads correctly
     When I visit "/world/organisations"
     Then I should see "Worldwide organisations"
     And I should see an input field to search
 
-  @normal
   Scenario: Check groups loads correctly
     When I visit "/government/groups"
     Then I should see "Groups"
     And I should see an input field to search
 
-  @normal
   Scenario: Check case studies loads correctly
     When I visit "/government/case-studies"
     Then I should see "Case studies: Real-life examples of government activity"
     And I should see an input field to search
 
-  @normal
   Scenario: Check contacts finder loads correctly
     When I visit "/government/organisations/hm-revenue-customs/contact"
     Then I should see "Contact HM Revenue &amp; Customs"
     And I should see an input field to search
 
-  @normal
   Scenario: Check statistical data sets loads correctly
     When I visit "/government/statistical-data-sets"
     Then I should see "Statistical data sets"
     And I should see an input field to search
 
-  @normal
   Scenario: Check specialist documents are searchable
     When I visit "/cma-cases?keywords=merger"
     Then I should see filtered documents
     And I should see an open facet titled "Case type" with non-blank values
 
-  @high
   Scenario Outline: Check malicious code does not execute
     When I visit the "<finder>" finder with keywords <keyword>
     Then There should be no alert

--- a/features/foreign_travel_advice.feature
+++ b/features/foreign_travel_advice.feature
@@ -4,27 +4,23 @@ Feature: Foreign Travel Advice
     Given I am testing through the full stack
     And I force a varnish cache miss
 
-  @normal
   Scenario: Check the index page loads correctly
     When I visit "/foreign-travel-advice"
     Then I should see "Foreign travel advice"
     And I should see "Afghanistan"
     And I should see "Luxembourg"
 
-  @normal
   Scenario: Check a country page loads correctly
     When I visit "/foreign-travel-advice/luxembourg"
     Then I should see "Luxembourg"
     And I should see "Summary"
 
-  @normal
   Scenario: Check feeds are available for both index and countries
     Then I should be able to visit:
       | Path                                   |
       | /foreign-travel-advice.atom            |
       | /foreign-travel-advice/luxembourg.atom |
 
-  @normal
   Scenario: Check country feed contains the correct website root
     When I visit "/foreign-travel-advice/ireland.atom"
     Then the XML ID is formed from the correct URL

--- a/features/frontend.feature
+++ b/features/frontend.feature
@@ -5,22 +5,18 @@ Feature: Frontend
     Given I am testing through the full stack
     And I force a varnish cache miss
 
-  @normal
   Scenario: Check robots.txt
     When I request "/robots.txt"
     Then I should see "User-agent:"
 
-  @normal
   Scenario: Check transactions load
     When I visit "/apply-renew-passport"
     Then I should see "UK passport"
 
-  @normal
   Scenario: Check help page loads correctly
     When I visit "/help"
     Then I should see "Help using GOV.UK"
 
-  @normal
   Scenario: Check homepage content type and charset
     When I request "/"
     Then I should get a "Content-Type" header of "text/html; charset=utf-8"
@@ -30,12 +26,10 @@ Feature: Frontend
     When I visit "/"
     Then the page view should be tracked
 
-  @normal
   Scenario: Check 404 page content type and charset
     When I visit a non-existent page
     Then I should get a "Content-Type" header of "text/html; charset=utf-8"
 
-  @normal
   Scenario: Check licences load
     When I visit "/busking-licence"
     Then I should see "Busking licence"
@@ -43,40 +37,34 @@ Feature: Frontend
     When I try to post to "/busking-licence" with "postcode=E20+2ST"
     Then I should see "Busking licence"
 
-  @normal
   Scenario: Check local transactions load
     When I visit "/pay-council-tax"
     Then I should see "Pay your Council Tax"
     When I try to post to "/pay-council-tax" with "postcode=WC2B+6SE"
     Then I should see "Camden"
 
-  @normal
   Scenario: Check "find my nearest" returns results
     When I visit "/ukonline-centre-internet-access-computer-training"
     And I should see "Online Centres Network"
     When I try to post to "/ukonline-centre-internet-access-computer-training" with "postcode=WC2B+6NH"
     Then I should see "Holborn Library"
 
-  @normal
   Scenario: Check redirects work
     When I visit "/workplacepensions"
     Then I should be at a location path of "/workplace-pensions"
 
-  @normal
   Scenario: Check calendars pages
     Then I should be able to visit:
       | Path                       |
       | /when-do-the-clocks-change |
       | /bank-holidays             |
 
-  @normal
   Scenario: Check alternative formats are available
     Then I should be able to visit:
       | Path                                           |
       | /when-do-the-clocks-change/united-kingdom.json |
       | /when-do-the-clocks-change/united-kingdom.ics  |
 
-  @normal
   Scenario: Check bank holidays JSON format is consistent
     When I request "/bank-holidays.json"
     Then JSON is returned

--- a/features/gov_uk.feature
+++ b/features/gov_uk.feature
@@ -1,26 +1,22 @@
 Feature: Core GOV.UK behaviour
   Tests for core URL and link behaviour on GOV.UK.
 
-  @high
   Scenario: Check paths with a trailing slash are redirected
     When I visit "https://www.gov.uk/browse/benefits/" without following redirects
     Then I should get a 301 status code
     And I should get a "Location" header of "//www.gov.uk/browse/benefits"
 
-  @high
   Scenario: Check paths with a trailing full stop are redirected
     When I visit "https://www.gov.uk/browse/benefits." without following redirects
     Then I should get a 301 status code
     And I should get a "Location" header of "//www.gov.uk/browse/benefits"
 
-  @normal
   Scenario: Check the crown logo links to GOV.UK homepage
     Given I am testing through the full stack
     And I force a varnish cache miss
     When I visit "/"
     Then the logo should link to the homepage
 
-  @normal
   Scenario: Check entirely upper case slugs redirect to lowercase
     Given I am testing through the full stack
     And I force a varnish cache miss
@@ -28,7 +24,6 @@ Feature: Core GOV.UK behaviour
     Then I should get a 301 status code
     And I should be at a location path of "/government/organisations"
 
-  @normal
   Scenario: Check partially upper case slugs do not redirect
     Given I am testing through the full stack
     And I force a varnish cache miss

--- a/features/gov_uk_redirect.feature
+++ b/features/gov_uk_redirect.feature
@@ -1,25 +1,20 @@
 Feature: Redirect of gov.uk to www.gov.uk
-
-  @high
   Scenario: Check redirect from bare domain to www.gov.uk is working for HTTP
     When I visit "http://gov.uk/" without following redirects
     Then I should get a 301 status code
     And I should get a "Location" header of "https://gov.uk/"
 
-  @high
   Scenario: Check redirect from bare domain to www.gov.uk is working for HTTPS and has HSTS enabled
     When I visit "https://gov.uk/" without following redirects
     Then I should get a 301 status code
     And I should get a "Location" header of "https://www.gov.uk/"
     And I should get a "Strict-Transport-Security" header of "max-age=63072000; preload"
 
-  @high
   Scenario: Check www.gov.uk redirect from HTTP to HTTPS is working
     When I visit "http://www.gov.uk/" without following redirects
     Then I should get a 301 status code
     And I should get a "Location" header of "https://www.gov.uk/"
 
-  @normal
   Scenario: Check redirect from service domain to GOV.UK has HSTS enabled
     When I visit "https://service.gov.uk/" without following redirects
     Then I should get a 302 status code

--- a/features/government_frontend.feature
+++ b/features/government_frontend.feature
@@ -5,7 +5,6 @@ Feature: Government Frontend
     Given I am testing through the full stack
     And I force a varnish cache miss
 
-    @normal
     Scenario Outline: Check example pages across formats
       When I request "<Path>"
       Then I should get a 200 status code
@@ -41,7 +40,6 @@ Feature: Government Frontend
         | /government/statistical-data-sets/effort-statistics-february-2017                                     |
         | /government/publications/development-scheme/practice-guide-72-development-schemes                     |
 
-  @normal
   Scenario: Check service sign-in offers both Government Gateway and GOV.UK Verify
     When I visit "/log-in-file-self-assessment-tax-return/sign-in/prove-identity"
     Then I should see "How do you want to sign in?"
@@ -62,7 +60,6 @@ Feature: Government Frontend
     When I choose "Sign in with GOV.UK Verify"
     Then I should be redirected to "https://www.signin.service.gov.uk/start"
 
-  @normal
   Scenario: Check service sign-in redirects correctly to registration page
     When I visit "/log-in-file-self-assessment-tax-return/sign-in/prove-identity"
     When I choose "Register for Self Assessment"

--- a/features/info_frontend.feature
+++ b/features/info_frontend.feature
@@ -4,7 +4,6 @@ Feature: Info Frontend
     Given I am testing through the full stack
     And I force a varnish cache miss
 
-  @normal
   Scenario: Check the info page for the benefits mainstream browse page
     When I visit "/info/browse/benefits"
     Then I should see "Benefits"

--- a/features/licence_finder.feature
+++ b/features/licence_finder.feature
@@ -4,7 +4,6 @@ Feature: Licence Finder
     Given I am testing through the full stack
     And I force a varnish cache miss
 
-  @normal
   Scenario: Check licence finder loads
     Then I should be able to visit:
       | Path                                                              |
@@ -15,12 +14,10 @@ Feature: Licence Finder
       | /licence-finder/location?sectors=59&activities=149                |
       | /licence-finder/licences?activities=149&location=wales&sectors=59 |
 
-  @normal
   Scenario: Check licence finder returns licences
     When I visit "/licence-finder/licences?activities=149&location=wales&sectors=59"
     Then I should see "A premises licence is for carrying out 'licensable activities' at a particular venue"
 
-  @normal
   Scenario: Check licence postcode lookup
     When I visit "/temporary-events-notice"
     Then I should see "Temporary Events Notice"

--- a/features/licensing.feature
+++ b/features/licensing.feature
@@ -1,7 +1,7 @@
 Feature: Licensing
   Tests for the Licensify app.
 
-  @normal @notintegration @nottraining
+  @notintegration @nottraining
   Scenario: Check licensing app is present
     Given I am testing "licensing" internally
       And I am testing through the full stack
@@ -12,7 +12,7 @@ Feature: Licensing
       | /apply-for-a-licence/test-licence/westminster/apply-1/form        |
       | /apply-for-a-licence/forms/bury/test-licence/9999-7-1,0-1         |
 
-  @normal @notintegration @nottraining
+  @notintegration @nottraining
   Scenario: Check signing in to licensify-admin
      When I try to login as a user
       And I login to Licensify

--- a/features/manuals_frontend.feature
+++ b/features/manuals_frontend.feature
@@ -4,7 +4,6 @@ Feature: Manuals Frontend
     Given I am testing through the full stack
     And I force a varnish cache miss
 
-  @normal
   Scenario: Check manuals load
     Then I should be able to visit:
       | Path                                       |

--- a/features/mirror.feature
+++ b/features/mirror.feature
@@ -1,30 +1,30 @@
 @aws @local-network
 Feature: Mirror
-    Tests for the GOV.UK mirrors that serve content if origin is unavailable.	
+    Tests for the GOV.UK mirrors that serve content if origin is unavailable.
 
-    @high @notintegration @notstaging @nottraining
+    @notintegration @notstaging @nottraining
     Scenario: Check Fastly probe request
       Given S3 mirrors
       Then I should get a 200 response from "/www.gov.uk/index.html" on the mirrors
 
-    @high @notintegration @notstaging @nottraining
+    @notintegration @notstaging @nottraining
     Scenario: Check homepage is served by all the mirrors
       Given S3 mirrors
       Then I should get a 200 response from "/www.gov.uk/index.html" on the mirrors
       And I should see "Welcome to GOV.UK"
 
-    @high @notintegration @notstaging @nottraining
+    @notintegration @notstaging @nottraining
     Scenario: Check a deep-linked page is served by all the mirrors
       Given S3 mirrors
       Then I should get a 200 response from "/www.gov.uk/book-theory-test.html" on the mirrors
       And I should see "Book your theory test"
 
-    @high @notintegration @notstaging @nottraining
+    @notintegration @notstaging @nottraining
     Scenario: Check a non-existent page returns a AccessDenied error from all the mirrors
       Given S3 mirrors
       Then I should get a 403 response from "/www.gov.uk/jasdu3jjasd" on the mirrors
 
-    @high @notintegration @notstaging @nottraining
+    @notintegration @notstaging @nottraining
     Scenario: Check that search returns an error on all the mirrors
       Given S3 mirrors
       Then I should get a 403 response from "/www.gov.uk/search" on the mirrors

--- a/features/performance_platform.feature
+++ b/features/performance_platform.feature
@@ -3,13 +3,13 @@ Feature: Performance Platform
   Background:
     Given I am testing through the full stack
 
-  @high @nottraining @notintegration @notstaging
+  @nottraining @notintegration @notstaging
   Scenario: Check the Performance Platform homepage loads correctly
     When I visit "/performance"
     Then I should see "Performance"
     And I should see "Find performance data of government services"
 
-  @normal @nottraining @notintegration @notstaging
+  @nottraining @notintegration @notstaging
   Scenario: Check a Performance Platform dashboard loads correctly
     When I visit "/performance/register-to-vote"
     Then I should see "Voter registration"

--- a/features/public_api.feature
+++ b/features/public_api.feature
@@ -3,42 +3,36 @@ Feature: Public API
   Background:
     Given I am testing through the full stack
 
-  @normal
   Scenario: Check the search API returns data
     Given I force a varnish cache miss for search
     When I request "/api/search.json"
     Then I should get a 200 status code
     And JSON is returned
 
-  @normal
   Scenario: Check the content store returns data
     Given I force a varnish cache miss
     When I request "/api/content/help"
     Then I should get a 200 status code
     And JSON is returned
 
-  @normal
   Scenario: Check the collections organisations API returns data
     Given I force a varnish cache miss
     When I request "/api/organisations"
     Then I should get a 200 status code
     And JSON is returned
 
-  @normal
   Scenario: Check the collections organisation API returns data
     Given I force a varnish cache miss
     When I request "/api/organisations/hm-revenue-customs"
     Then I should get a 200 status code
     And JSON is returned
 
-  @normal
   Scenario: Check the whitehall governments API returns data
     Given I force a varnish cache miss
     When I request "/api/governments"
     Then I should get a 200 status code
     And JSON is returned
 
-  @normal
   Scenario: Check the whitehall world locations API returns data
     Given I force a varnish cache miss
     When I request "/api/world-locations"

--- a/features/publishing_tools.feature
+++ b/features/publishing_tools.feature
@@ -1,4 +1,4 @@
-@app-publishing-api @aws @high
+@app-publishing-api @aws
 Feature: Publishing Tools
   Scenario: Can log in to collections-publisher
     When I go to the "collections-publisher" landing page

--- a/features/router.feature
+++ b/features/router.feature
@@ -5,13 +5,11 @@ Feature: Router
     Given I am testing through the full stack
     And I force a varnish cache miss
 
-  @high
   Scenario: Check the router loads home page
     Then I should be able to visit:
       | Path      |
       | /         |
 
-  @normal
   Scenario: Check department short URLs redirect correctly
     Then I should be redirected when I try to visit:
       | Path                      |

--- a/features/search.feature
+++ b/features/search.feature
@@ -7,7 +7,6 @@ Feature: Search
     And I consent to cookies
     And I force a varnish cache miss for search
 
-  @high
   Scenario Outline: Check search results and analytics
     When I search for "<keywords>"
     Then I should see some search results
@@ -30,13 +29,12 @@ Feature: Search
     When I search for "policy"
     Then I should see organisations in the organisation filter
 
-  @normal @notintegration @nottraining
+  @notintegration @nottraining
   Scenario: Check sitemap
     When I visit "/sitemap.xml"
     Then it should contain a link to at least one sitemap file
     And I should be able to get all the referenced sitemap files
 
-  @high
   Scenario: Check malicious code does not execute
     When I search for "<script>alert(document.cookie)</script>"
     Then I see the code returned in the page

--- a/features/service_manual.feature
+++ b/features/service_manual.feature
@@ -4,22 +4,18 @@ Feature: Service Manual
     Given I am testing through the full stack
     And I force a varnish cache miss
 
-  @normal
   Scenario: Check Service Manual loads correctly
     When I visit "/service-manual"
     Then I should see "Service Manual"
 
-  @normal
   Scenario: Check a topic page loads correctly
     When I visit "/service-manual/agile-delivery"
     Then I should see "Agile delivery"
 
-  @normal
   Scenario: Check a guide page loads correctly
     When I visit "/service-manual/agile-delivery/writing-user-stories"
     Then I should see "Writing user stories"
 
-  @normal
   Scenario: Check the service standard page loads correctly
     When I visit "/service-manual/service-standard"
     Then I should see "Service Standard"

--- a/features/signon.feature
+++ b/features/signon.feature
@@ -1,12 +1,10 @@
 Feature: Signon
   Tests for signon, the GOV.UK single sign-on service.
 
-  @high
   Scenario: Check logging in works
     When I try to login as a user
     Then I should see "Your applications"
 
-  @low
   Scenario: Check signon cookies are marked as secure
     When I go to the "signon" landing page
     Then I should receive a "_signonotron2_session" cookie which is "secure"

--- a/features/smartanswers.feature
+++ b/features/smartanswers.feature
@@ -11,7 +11,6 @@ Feature: Smart Answers
     When I request "/healthcheck"
     Then I should get a 200 status code
 
-  @normal
   Scenario Outline: Check selected smart answer start pages
     When I request "<Path>"
     Then I should see "<Expected string>"
@@ -26,7 +25,6 @@ Feature: Smart Answers
       | /register-a-death/y                         | Where did the death happen?                          |
       | /vat-payment-deadlines/y                    | When does your VAT accounting period end?            |
 
-  @normal
   Scenario: Check stepping through a smart answer
     Then I should be able to visit:
     | Path                                        |
@@ -35,7 +33,6 @@ Feature: Smart Answers
     | /vat-payment-deadlines/y/2000-01-31         |
     | /vat-payment-deadlines/y/2000-01-31/cheque  |
 
-  @normal
   Scenario: Check stepping through a smart answer that uses Imminence
     Then I should be able to visit:
     | Path                                              |
@@ -46,7 +43,6 @@ Feature: Smart Answers
     | /landlord-immigration-check/y/SW1A2AA/yes/yes     |
     | /landlord-immigration-check/y/SW1A2AA/yes/yes/yes |
 
-  @normal
   Scenario: Check stepping through a smart answer that uses the Worldwide API
     Then I should be able to visit:
     | Path                                                |
@@ -57,7 +53,6 @@ Feature: Smart Answers
     | /marriage-abroad/y/sweden/uk/partner_other          |
     | /marriage-abroad/y/sweden/uk/partner_other/same_sex |
 
-  @normal
   Scenario Outline: Check viewing countries in a select element
     When I request "<Path>"
     Then I should see a populated country select
@@ -73,7 +68,6 @@ Feature: Smart Answers
       | /register-a-death/y/overseas/afghanistan/another_country   |
       | /uk-benefits-abroad/y/going_abroad/child_benefit           |
 
-  @normal
   Scenario Outline: Check country names are correctly formatted
     When I request "<Path>"
     Then I should see "<Expected string>"
@@ -85,7 +79,6 @@ Feature: Smart Answers
       | /register-a-birth/y/cayman-islands                                           | regulations in the Cayman Islands                  |
       | /register-a-death/y/overseas/cayman-islands                                  | regulations in the Cayman Islands                  |
 
-  @normal
   Scenario Outline: Check country slugs are correctly validated
     When I request "<Path>"
     Then the slug should be <Valid>
@@ -101,7 +94,6 @@ Feature: Smart Answers
       | /help-if-you-are-arrested-abroad/y/afghanistan         | valid   |
       | /help-if-you-are-arrested-abroad/y/foo                 | invalid |
 
-  @normal
   Scenario Outline: Check country FCOs can be looked up
     When I request "<Path>"
     Then I should see "<Expected string>"
@@ -111,7 +103,6 @@ Feature: Smart Answers
       | /marriage-abroad/y/afghanistan/uk/partner_british/opposite_sex | Embassy of Afghanistan          |
       | /register-a-death/y/overseas/north-korea/same_country          | British Embassy Pyongyang       |
 
-  @normal
   Scenario Outline: Check postcode lookup
     When I request "<Path>"
     Then I should see "<Expected string>"
@@ -123,7 +114,6 @@ Feature: Smart Answers
       | /landlord-immigration-check/y/SW1A%202AA                                          | Is the person renting      |
       | /landlord-immigration-check/y/EH99%201SP                                          | check in England           |
 
-  @normal
   Scenario: Check personal information is excluded from analytics data
     When I visit "/marriage-abroad/y"
     Then I should see that postcodes are stripped from analytics data

--- a/features/transition.feature
+++ b/features/transition.feature
@@ -1,7 +1,6 @@
 Feature: Transition
   Tests for the transition management tools, including the transition app.
 
-  @high
   Scenario: Check logging in to the transition app works
     When I go to the "transition" landing page
       And I try to login as a user
@@ -9,7 +8,6 @@ Feature: Transition
     Then I should see "Sign out"
       And I should see "Organisations"
 
-  @high
   Scenario: Check the host list from API to configure CDN works
     When I request "/hosts.json" from the "transition" application
     Then I should get a 200 status code

--- a/features/waf.feature
+++ b/features/waf.feature
@@ -6,7 +6,6 @@ Feature: WAF
     Given I am testing through the full stack
     And I force a varnish cache miss
 
-  @high
   Scenario: Check that the X-Always-Block rule is in place
     Given I set header X-Always-Block to true
     When I send a GET request to "/"

--- a/features/whitehall.feature
+++ b/features/whitehall.feature
@@ -7,18 +7,15 @@ Feature: Whitehall
     Given I am testing through the full stack
     And I force a varnish cache miss
 
-  @normal
   Scenario: Check the government publishing section on GOV.UK homepage
     Then I should see the departments and policies section on the homepage
 
-  @normal
   Scenario: Check feeds are available for documents
     Then I should be able to visit:
       | Path                           |
       | /government/announcements.atom |
       | /government/statistics.atom  |
 
-  @normal
   Scenario Outline: Check whitehall pages load
     When I request "<Path>"
     Then I should get a 200 status code
@@ -31,7 +28,6 @@ Feature: Whitehall
       | /government/people/eric-pickles  |
       | /world                           |
 
-  @normal
   Scenario: Check whitehall assets are redirected to and served from the asset host
     When I request an attachment
     Then I should be redirected to the asset host

--- a/nagios_check_cache.py
+++ b/nagios_check_cache.py
@@ -92,13 +92,11 @@ class FeatureTestRun(object):
         result_details.add("\n")
 
     def set_status_for_scenarios_in_feature(self, feature, priority, result_details):
-        if 'elements' not in feature:
-            log_result_and_exit(0, "OK: Feature %s has no steps at any priority" % feature['id'])
+        if priority != '@normal':
+            return
+
         for scenario in feature['elements']:
-            if 'tags' in scenario:
-                for tag in scenario['tags']:
-                    if tag['name'] == priority:
-                        self.log_details_and_set_status_for_scenario(result_details, feature, priority, scenario)
+            self.log_details_and_set_status_for_scenario(result_details, feature, priority, scenario)
 
     def set_status_for_feature(self, feature_name, json_data, priority):
         feature_uri = 'features/' + feature_name + '.feature'


### PR DESCRIPTION
https://trello.com/c/aW59k3Tf/170-activate-continuous-deployment-for-the-publishing-api

**Deadline for discussion: 2020-07-08**

Related to: https://github.com/alphagov/smokey/pull/691

This changes the alerting behaviour for the results of the
Smokey loop so that are scenarios are considered 'normal'
priority, due to the lack of any consistent definition of
'high' and 'low' priorities, and the complete absence of
'urgent'. Please see the commits for more details.

Follow-up tasks:

- [ ] Remove [redundant code to support priorities](https://github.com/alphagov/smokey/blob/master/nagios_check_cache.py)
- [ ] Remove [redundant priority-based checks in Puppet](https://github.com/alphagov/govuk-puppet/blob/4ec2949332079570be5493753bb84a983218a444/modules/icinga/manifests/check_feature.pp)

## Before 🤷‍♂️ 

<img width="483" alt="Screenshot 2020-06-30 at 10 56 11" src="https://user-images.githubusercontent.com/9029009/86112854-69d0cc00-bac0-11ea-9e06-e29018aedc7a.png">


## After 🤷‍♂️ 

<img width="487" alt="Screenshot 2020-06-30 at 10 44 35" src="https://user-images.githubusercontent.com/9029009/86112866-6d645300-bac0-11ea-8767-b51671cafbb4.png">