### PR TITLE
Fail the test run if there are undefined step

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -8,6 +8,7 @@ export RESTCLIENT_LOG="log/smokey-rest-client.log"
 export ENVIRONMENT=${TARGET_PLATFORM}
 
 FLAGS=(--profile "${TARGET_PLATFORM}")
+FLAGS+=(--strict-undefined)
 FLAGS+=(-t "not @benchmarking")
 
 if [ -n "${TARGET_APPLICATION}" ]; then


### PR DESCRIPTION
This should only happen if the test code has been written incorrectly;
not setting this means the tests pass when they shouldn't.

Tripped me up when doing [1].

[1]: https://github.com/alphagov/smokey/pull/688