### PR TITLE
Update the brexit checker test

### DIFF
--- a/features/step_definitions/brexit_check_steps.rb
+++ b/features/step_definitions/brexit_check_steps.rb
@@ -1,6 +1,6 @@
 When "I start the checker" do
-  visit_path "/get-ready-brexit-check"
-  click_link "Start now"
+  visit_path "/transition"
+  click_link "Check what's changing"
 end
 
 When "I answer the nationality question" do


### PR DESCRIPTION
The start page has now been redirected to the /transition page now, so we should start from there instead.