### PR TITLE
Use different apostrophe for link text

### DIFF
--- a/features/step_definitions/brexit_check_steps.rb
+++ b/features/step_definitions/brexit_check_steps.rb
@@ -1,6 +1,6 @@
 When "I start the checker" do
   visit_path "/transition"
-  click_link "Check what's changing"
+  click_link "Check what’s changing"
 end
 
 When "I answer the nationality question" do


### PR DESCRIPTION
The job is still failing so hopefully this is the reason why. Following on from https://github.com/alphagov/smokey/pull/697

```
 Unable to find link "Check what's changing" (Capybara::ElementNotFound)
      ./features/step_definitions/brexit_check_steps.rb:3:in `"I start the checker"''
```

Failing job: https://deploy.blue.production.govuk.digital/job/smokey/4093/console