### PR TITLE
Remove default path for smartanswers URLs

### DIFF
--- a/features/support/base_urls.rb
+++ b/features/support/base_urls.rb
@@ -9,7 +9,6 @@ DEFAULT_PATHS = {
   'licensing' => '/apply-for-a-license',
   'maslow' => '/needs',
   'publisher' => '/admin',
-  'smartanswers' => '/calculate-your-maternity-pay',
   'specialist-publisher' => '/cma-cases',
   'travel-advice-publisher' => '/admin',
   'whitehall' => '/government/how-government-works',


### PR DESCRIPTION
This was quite surprising, and fortunately unnecessary for this app.

Error:

Unable to fetch 'https://smartanswers.integration.govuk-internal.digital/calculate-your-maternity-pay/healthcheck?cache_bust=0.4472543812700581'