### PR TITLE
Remove path defaults for internal URLs

### DIFF
--- a/features/support/base_urls.rb
+++ b/features/support/base_urls.rb
@@ -21,5 +21,5 @@ def application_external_url(app_name)
 end
 
 def application_internal_url(app_name)
-  "#{Plek.new.find(app_name)}#{DEFAULT_PATHS.fetch(app_name,'')}"
+  "#{Plek.new.find(app_name)}"
 end


### PR DESCRIPTION
This is confusing and unnecessary for internal URLs. Ideally we
should drop the defaults for external URLs as well (because it's
so surprising), but that would require more extensive changes to
features that are relying on the defaults.