### PR TITLE
data.gov.uk: add test of CKAN action api's search ability

### DIFF
--- a/features/data_gov_uk.feature
+++ b/features/data_gov_uk.feature
@@ -31,6 +31,13 @@ Feature: Data.gov.uk
     When I request "/"
     Then I should see "Data publisher"
 
+  @high
+  Scenario: Check CKAN action api's search works
+    Given I am testing "ckan"
+    When I request "/api/action/package_search?q=data"
+    Then I should get a 200 status code
+    And JSON is returned
+
   @high @notintegration @notstaging @nottraining
   Scenario: Check datasets sync between CKAN and Find
     Given I am testing "https://ckan.publishing.service.gov.uk"


### PR DESCRIPTION
https://trello.com/c/MjU2qdeI/228-enable-smoke-tests-on-staging

This should hopefully detect whether ckan's solr is up & running too.