### PR TITLE
Swap Feedback feature's generic test e-mail address with Notify test address

### DIFF
--- a/features/step_definitions/feedback_steps.rb
+++ b/features/step_definitions/feedback_steps.rb
@@ -12,7 +12,7 @@ end
 
 When /^I submit the email survey signup form$/ do
   within(".gem-c-feedback") do
-    fill_in "Email address", with: "name@example.com"
+    fill_in "Email address", with: "simulate-delivered@notifications.service.gov.uk"
     click_on "Send me the survey"
   end
 end


### PR DESCRIPTION
When testing the "Is this page useful?" feature, the Feedback application submits an
e-mail address to the GOV.UK Notify service.

In Integration and Staging these Notify services are trial accounts with "allow lists". 
An e-mail address not on their guest list will result in an unsuccessful request.

This change will allow this test to simulate a successful submission to the
service.

https://docs.notifications.service.gov.uk/ruby.html#smoke-testing
