### PR TITLE
Fix invalid selector

### DIFF
--- a/features/step_definitions/datagovuk_steps.rb
+++ b/features/step_definitions/datagovuk_steps.rb
@@ -17,7 +17,7 @@ When /^I save the dataset count$/ do
 end
 
 Then /^I should see a similar dataset count$/ do
-  count_span = page.first(".dgu-results__summary span.govuk-!-font-weight-bold")
+  count_span = page.first(".dgu-results__summary")
   count = count_span.text.gsub(/[^\d^\.]/, '').to_i
 
   # to account for a delay in the sync between CKAN and Find, we only check


### PR DESCRIPTION
Selenium can't use the selector with the bang as chrome will reject it
as an invalid selector. It turns out we don't need to use this selector
to get the span and can retrieve the number from the parent element.

## Testing

**You should manually test your PR before merging.**

This app doesn't have CI setup, and it would be misleading to do so:
the behaviour of the tests changes depending on the environment they
are run in. You should manually test in applicable environments,
until you are confident your change is not a breaking one.

Example steps to test in Integration:

- Click "Configure" for the [Smokey job][]
- Change the "Branch specifier" to the name of your branch
- Run a new build of the Smokey project and check the results

## Deployment

**You need to manually deploy your PR after merging.**

Steps to deploy a change:

- Run the [Smokey deploy job][] to deploy the [continuous Smokey loop][]
- Repeat this in Staging and Production

> The manual [Smokey job][] will pick up changes on `master` automatically. You only need to do a manual deployment for the [continuous Smokey loop][].

[Smokey job]: https://deploy.integration.publishing.service.gov.uk/job/Smokey/
[continuous Smokey loop]: https://github.com/alphagov/govuk-puppet/blob/master/modules/monitoring/templates/smokey-loop.conf
[Smokey deploy job]: https://deploy.integration.publishing.service.gov.uk/job/Smokey_Deploy/
