### PR TITLE
Suppress JS console errors in Licensify tests

### DIFF
--- a/features/licensing.feature
+++ b/features/licensing.feature
@@ -6,6 +6,7 @@ Feature: Licensing
     Given I am testing "licensing" internally
       And I am testing through the full stack
       And I force a varnish cache miss
+      And I don't care about JavaScript errors
     Then I should be able to visit:
       | Path                                                              |
       | /apply-for-a-licence/test-licence/westminster/apply-1             |

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -156,6 +156,10 @@ Then /^I should see that postcodes are stripped from analytics data$/ do
   end
 end
 
+And /^I don't care about JavaScript errors/ do
+  $fail_on_js_error = false
+end
+
 Then /^I should be able to visit:$/ do |table|
   table.hashes.each do |row|
     visit_path row['Path']

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,9 +1,22 @@
 Before do
   # Clear the request log so that tests only see their requests.
   $proxy.new_har(capture_binary_content: true)
+  $fail_on_js_error = true
 end
 
 After do
+  if $fail_on_js_error
+    flush_and_check_errors
+  else
+    begin
+      flush_and_check_errors
+    rescue Capybara::Chromedriver::Logger::JsError => e
+      puts "Detected JS error, but ignored it. #{e}"
+    end
+  end
+end
+
+def flush_and_check_errors
   # Do this manually rather than using `after_example!` so we can configure
   # the log destination to be $stderr rather than $stdout. This prevents
   # unformatted JavaScript errors from making their way into the Smokey loop's


### PR DESCRIPTION
We're currently unable to deploy changes to Licensify. Our
Smokey test suite is failing because we're seeing CSP errors
on Google Analytics requests in Licensify.

In order to get Smokey passing again - essential for continuous
deployment and for developer confidence - we've decided to
ignore the JS error for these tests. When we're able to
deploy Licensify again, we should already have fixed the CSP
issue here:
https://github.com/alphagov/licensify/pull/492

## Testing

**You should manually test your PR before merging.**

This app doesn't have CI setup, and it would be misleading to do so:
the behaviour of the tests changes depending on the environment they
are run in. You should manually test in applicable environments,
until you are confident your change is not a breaking one.

Example steps to test in Integration:

- Click "Configure" for the [Smokey job][]
- Change the "Branch specifier" to the name of your branch
- Run a new build of the Smokey project and check the results

## Deployment

**You need to manually deploy your PR after merging.**

Steps to deploy a change:

- Run the [Smokey deploy job][] to deploy the [continuous Smokey loop][]
- Repeat this in Staging and Production

> The manual [Smokey job][] will pick up changes on `master` automatically. You only need to do a manual deployment for the [continuous Smokey loop][].

[Smokey job]: https://deploy.integration.publishing.service.gov.uk/job/Smokey/
[continuous Smokey loop]: https://github.com/alphagov/govuk-puppet/blob/master/modules/monitoring/templates/smokey-loop.conf
[Smokey deploy job]: https://deploy.integration.publishing.service.gov.uk/job/Smokey_Deploy/
