### PR TITLE
Add test for redirect from postcode checker to national guidance

### DIFF
--- a/features/coronavirus_local_restrictions.feature
+++ b/features/coronavirus_local_restrictions.feature
@@ -1,0 +1,10 @@
+@app-collections
+Feature: Collections
+
+  Background:
+    Given I am testing through the full stack
+    And I force a varnish cache miss
+
+  Scenario: Postcode checker shows results
+    When I visit the postcode checker
+    Then I should be redirected to the national restrictions page

--- a/features/step_definitions/coronavirus_local_restrictions_steps.rb
+++ b/features/step_definitions/coronavirus_local_restrictions_steps.rb
@@ -1,0 +1,7 @@
+When "I visit the postcode checker" do
+  visit_path "/find-coronavirus-local-restrictions"
+end
+
+Then "I should be redirected to the national restrictions page" do
+  expect(current_path).to eql("/guidance/new-national-restrictions-from-5-november")
+end


### PR DESCRIPTION
The postcode checker has been hidden to the public. This tests that the redirect to the appropriate guidance is in place.

## Testing

**You should manually test your PR before merging.**

This app doesn't have CI setup, and it would be misleading to do so:
the behaviour of the tests changes depending on the environment they
are run in. You should manually test in applicable environments,
until you are confident your change is not a breaking one.

Example steps to test in Integration:

- Click "Configure" for the [Smokey job][]
- Change the "Branch specifier" to the name of your branch
- Run a new build of the Smokey project and check the results

## Deployment

**You need to manually deploy your PR after merging.**

Steps to deploy a change:

- Run the [Smokey deploy job][] to deploy the [continuous Smokey loop][]
- Repeat this in Staging and Production

> The manual [Smokey job][] will pick up changes on `master` automatically. You only need to do a manual deployment for the [continuous Smokey loop][].

[Smokey job]: https://deploy.integration.publishing.service.gov.uk/job/Smokey/
[continuous Smokey loop]: https://github.com/alphagov/govuk-puppet/blob/master/modules/monitoring/templates/smokey-loop.conf
[Smokey deploy job]: https://deploy.integration.publishing.service.gov.uk/job/Smokey_Deploy/
