### PR TITLE
Authenticating proxy healthcheck

### DIFF
--- a/features/authenticating_proxy.feature
+++ b/features/authenticating_proxy.feature
@@ -1,0 +1,8 @@
+@app-authenticating-proxy
+Feature: Authenticating Proxy
+
+  @local-network
+  Scenario: Healthcheck
+    Given I am testing "collections" internally
+    When I request "/healthcheck"
+    Then I should get a 200 status code

--- a/features/draft_environment.feature
+++ b/features/draft_environment.feature
@@ -1,3 +1,4 @@
+@app-authenticating-proxy
 Feature: Draft environment
   Tests for the draft environment, which is used to preview content before it is
   put live on GOV.UK. Accessing the draft environment requires a valid signon


### PR DESCRIPTION
This updates Smokey to add further tests for Authenticating Proxy so we can enable CD for it. See individual commits for more details.

Related to https://github.com/alphagov/authenticating-proxy/pull/238 and here is an example build: https://deploy.blue.staging.govuk.digital/job/Smokey/7561/console