### PR TITLE
Fix not actually checking app healthchecks

### DIFF
--- a/features/authenticating_proxy.feature
+++ b/features/authenticating_proxy.feature
@@ -5,4 +5,5 @@ Feature: Authenticating Proxy
   Scenario: Healthcheck
     Given I am testing "collections" internally
     When I request "/healthcheck"
-    Then I should get a 200 status code
+    Then JSON is returned
+    And I should see ""status":"ok""

--- a/features/collections.feature
+++ b/features/collections.feature
@@ -71,4 +71,5 @@ Feature: Collections
   Scenario: Healthcheck
     Given I am testing "collections" internally
     When I request "/healthcheck"
-    Then I should get a 200 status code
+    Then JSON is returned
+    And I should see ""status":"ok""

--- a/features/finder_frontend.feature
+++ b/features/finder_frontend.feature
@@ -11,7 +11,8 @@ Feature: Finder Frontend
   Scenario: Healthcheck
     Given I am testing "finder-frontend" internally
     When I request "/healthcheck"
-    Then I should get a 200 status code
+    Then JSON is returned
+    And I should see ""status":"ok""
 
   Scenario: Check people page loads correctly
     When I visit "/government/people"

--- a/features/finder_frontend.feature
+++ b/features/finder_frontend.feature
@@ -10,7 +10,7 @@ Feature: Finder Frontend
   @local-network
   Scenario: Healthcheck
     Given I am testing "finder-frontend" internally
-    When I request "/healthcheck"
+    When I request "/healthcheck.json"
     Then JSON is returned
     And I should see ""status":"ok""
 

--- a/features/government_frontend.feature
+++ b/features/government_frontend.feature
@@ -69,4 +69,5 @@ Feature: Government Frontend
   Scenario: Healthcheck
     Given I am testing "government-frontend" internally
     When I request "/healthcheck"
-    Then I should get a 200 status code
+    Then JSON is returned
+    And I should see ""status":"ok""

--- a/features/publisher.feature
+++ b/features/publisher.feature
@@ -5,4 +5,5 @@ Feature: (Mainstream) Publisher
   Scenario: Healthcheck
     Given I am testing "publisher" internally
     When I request "/healthcheck"
-    Then I should get a 200 status code
+    Then JSON is returned
+    And I should see ""status":"ok""

--- a/features/publishing_api.feature
+++ b/features/publishing_api.feature
@@ -3,4 +3,5 @@ Feature: Publishing API
   Scenario: Healthcheck
     Given I am testing "publishing-api" internally
     When I request "/healthcheck"
-    Then I should get a 200 status code
+    Then JSON is returned
+    And I should see ""status":"ok""

--- a/features/smartanswers.feature
+++ b/features/smartanswers.feature
@@ -5,13 +5,6 @@ Feature: Smart Answers
     Given I am testing through the full stack
     And I force a varnish cache miss
 
-  @local-network
-  Scenario: Healthcheck
-    Given I am testing "smartanswers" internally
-    When I request "/healthcheck"
-    Then JSON is returned
-    And I should see ""status":"ok""
-
   Scenario Outline: Check selected smart answer start pages
     When I request "<Path>"
     Then I should see "<Expected string>"

--- a/features/smartanswers.feature
+++ b/features/smartanswers.feature
@@ -9,7 +9,8 @@ Feature: Smart Answers
   Scenario: Healthcheck
     Given I am testing "smartanswers" internally
     When I request "/healthcheck"
-    Then I should get a 200 status code
+    Then JSON is returned
+    And I should see ""status":"ok""
 
   Scenario Outline: Check selected smart answer start pages
     When I request "<Path>"

--- a/features/travel_advice_publisher.feature
+++ b/features/travel_advice_publisher.feature
@@ -3,4 +3,5 @@ Feature: Travel Advice Publisher
   Scenario: Healthcheck
     Given I am testing "travel-advice-publisher" internally
     When I request "/healthcheck"
-    Then I should get a 200 status code
+    Then JSON is returned
+    And I should see ""status":"ok""


### PR DESCRIPTION
https://trello.com/c/ILpSOFhq/201-enable-cd-for-quick-win-and-possible-quick-win-apps

Previously in scenarios requesting the /healthcheck endpoint we only
verified the response code was 200, but this will always be the case
even if the app is unhealthy. This adjusts the /healthcheck scenarios
to actually verify the endpoint reports an "OK" status.


## Testing

**You should manually test your PR before merging.**

This app doesn't have CI setup, and it would be misleading to do so:
the behaviour of the tests changes depending on the environment they
are run in. You should manually test in applicable environments,
until you are confident your change is not a breaking one.

Example steps to test in Integration:

- Click "Configure" for the [Smokey job][]
- Change the "Branch specifier" to the name of your branch
- Run a new build of the Smokey project and check the results

## Deployment

**You need to manually deploy your PR after merging.**

Steps to deploy a change:

- Run the [Smokey deploy job][] to deploy the [continuous Smokey loop][]
- Repeat this in Staging and Production

> The manual [Smokey job][] will pick up changes on `master` automatically. You only need to do a manual deployment for the [continuous Smokey loop][].

[Smokey job]: https://deploy.integration.publishing.service.gov.uk/job/Smokey/
[continuous Smokey loop]: https://github.com/alphagov/govuk-puppet/blob/master/modules/monitoring/templates/smokey-loop.conf
[Smokey deploy job]: https://deploy.integration.publishing.service.gov.uk/job/Smokey_Deploy/