### PR TITLE
Change "Get email alerts" to "Get emails"

### DIFF
--- a/features/finder_frontend.feature
+++ b/features/finder_frontend.feature
@@ -64,19 +64,19 @@ Feature: Finder Frontend
 
   Scenario: Email signup from the news and communications finder
     When I visit "/search/news-and-communications"
-    And I click on the link "Get email alerts"
+    And I click on the link "Get emails"
     And I click on the button "Continue"
     Then I should see "How often do you want to get emails?"
 
   Scenario: Email signup from the statistics finder
     When I visit "/search/research-and-statistics"
-    And I click on the link "Get email alerts"
+    And I click on the link "Get emails"
     And I choose the checkbox "Statistics (published)" and click on "Continue"
     Then I should see "How often do you want to get emails?"
 
   Scenario: Email signup from a finder (specialist-publisher)
     When I visit "/cma-cases"
-    When I click on the link "Get email alerts"
+    When I click on the link "Get emails"
     And I choose the checkbox "Markets" and click on "Continue"
     Then I should see "How often do you want to get emails?"
 

--- a/features/foreign_travel_advice.feature
+++ b/features/foreign_travel_advice.feature
@@ -27,6 +27,6 @@ Feature: Foreign Travel Advice
 
   Scenario: Email signup from foreign travel advice
     When I visit "/foreign-travel-advice/turkey"
-    And I click on the link "Get email alerts"
+    And I click on the link "Get emails"
     And I click on the button "Continue"
     Then I should see "How often do you want to get emails?"


### PR DESCRIPTION
This has been changed in govuk_publishing_components.

See:

- https://deploy.integration.publishing.service.gov.uk/job/Smokey/25069/console
- https://www-origin.integration.publishing.service.gov.uk/search/news-and-communications
- https://www-origin.integration.publishing.service.gov.uk/foreign-travel-advice/turkey
- https://github.com/alphagov/govuk_publishing_components/commit/36953fd979db6c144ba0fd0245ed414066fc88b0