### PR TITLE
Turn off broken test

### DIFF
--- a/features/finder_frontend.feature
+++ b/features/finder_frontend.feature
@@ -49,6 +49,7 @@ Feature: Finder Frontend
     Then I should see filtered documents
     And I should see an open facet titled "Case type" with non-blank values
 
+  @notintegration @notstaging @notproduction
   Scenario Outline: Check malicious code does not execute
     When I visit the "<finder>" finder with keywords <keyword>
     Then There should be no alert


### PR DESCRIPTION
We currently have a problem with this test related to CORs and google
analytics so it is adding no value and blocking deployment. A fix is
needed but false fails are of no use to anybody so this turns of that specific test
for now.

Example fail: https://deploy.blue.production.govuk.digital/job/smokey/5990/console

## Testing

**You should manually test your PR before merging.**

This app doesn't have CI setup, and it would be misleading to do so:
the behaviour of the tests changes depending on the environment they
are run in. You should manually test in applicable environments,
until you are confident your change is not a breaking one.

Example steps to test in Integration:

- Click "Configure" for the [Smokey job][]
- Change the "Branch specifier" to the name of your branch
- Run a new build of the Smokey project and check the results

## Deployment

**You need to manually deploy your PR after merging.**

Steps to deploy a change:

- Run the [Smokey deploy job][] to deploy the [continuous Smokey loop][]
- Repeat this in Staging and Production

> The manual [Smokey job][] will pick up changes on `master` automatically. You only need to do a manual deployment for the [continuous Smokey loop][].

[Smokey job]: https://deploy.integration.publishing.service.gov.uk/job/Smokey/
[continuous Smokey loop]: https://github.com/alphagov/govuk-puppet/blob/master/modules/monitoring/templates/smokey-loop.conf
[Smokey deploy job]: https://deploy.integration.publishing.service.gov.uk/job/Smokey_Deploy/
