### PR TITLE
Add Healthcheck feature test for content-data-api

### DIFF
--- a/features/content_data_api.feature
+++ b/features/content_data_api.feature
@@ -1,0 +1,7 @@
+@app-content-data-api @local-network
+Feature: Content Data API
+  Scenario: Healthcheck
+    Given I am testing "content-data-api" internally
+    When I request "/healthcheck"
+    Then JSON is returned
+    And I should see ""status":"ok""


### PR DESCRIPTION
This PR adds a feature test for the content-data-api Healthcheck.

This is a pre-requisite for enabling continuous deployment for content-data-api.

Smokey test run: https://deploy.integration.publishing.service.gov.uk/job/Smokey/25167/console
(1 unrelated test failure)

Co-authored-by: Rebecca Pearce rebecca.pearce@digital.cabinet-office.gov.uk