### PR TITLE
Re-enable malicious code test for finder-frontend

### DIFF
--- a/features/finder_frontend.feature
+++ b/features/finder_frontend.feature
@@ -49,7 +49,6 @@ Feature: Finder Frontend
     Then I should see filtered documents
     And I should see an open facet titled "Case type" with non-blank values
 
-  @notintegration @notstaging @notproduction
   Scenario Outline: Check malicious code does not execute
     When I visit the "<finder>" finder with keywords <keyword>
     Then There should be no alert


### PR DESCRIPTION
Previously this test was disabled [1] over a month ago due to being
flakey. We believed that there was an issue with CORs and google
analytics which led to a card being created to investigate. Since then
I've tried re-enabling the test to replicate the flakeyness for
integration and staging which proved to be unsuccessful, as out of 30
runs, there were no failures. This commit re-enables the test as there
doesn't seem to be an issue anymore.

[1]: https://github.com/alphagov/smokey/pull/755

I've recorded all the builds as a comment on the [Trello card](https://trello.com/c/5hdexmoU/2292-investigate-fix-failing-smokey-test-for-finder-frontend-timebox-2-days).

## Testing

**You should manually test your PR before merging.**

This app doesn't have CI setup, and it would be misleading to do so:
the behaviour of the tests changes depending on the environment they
are run in. You should manually test in applicable environments,
until you are confident your change is not a breaking one.

Example steps to test in Integration:

- Click "Configure" for the [Smokey job][]
- Change the "Branch specifier" to the name of your branch
- Run a new build of the Smokey project and check the results

## Deployment

**You need to manually deploy your PR after merging.**

Steps to deploy a change:

- Run the [Smokey deploy job][] to deploy the [continuous Smokey loop][]
- Repeat this in Staging and Production

> The manual [Smokey job][] will pick up changes on `master` automatically. You only need to do a manual deployment for the [continuous Smokey loop][].

[Smokey job]: https://deploy.integration.publishing.service.gov.uk/job/Smokey/
[continuous Smokey loop]: https://github.com/alphagov/govuk-puppet/blob/master/modules/monitoring/templates/smokey-loop.conf
[Smokey deploy job]: https://deploy.integration.publishing.service.gov.uk/job/Smokey_Deploy/
