### PR TITLE
Add test environment

### DIFF
--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -1,4 +1,5 @@
 default: -t "not @benchmarking" -t "not @pending" -t "not @local-network" -t "not @notintegration"
+test: -t "not @pending" -t "not @nottest" -t "not @notaws"
 integration: -t "not @pending" -t "not @notintegration" -t "not @notaws"
 staging: -t "not @pending" -t "not @notstaging" -t "not @aws"
 production: -t "not @pending" -t "not @notproduction" -t "not @aws"

--- a/features/frontend.feature
+++ b/features/frontend.feature
@@ -1,4 +1,4 @@
-@aws
+@aws @replatforming
 Feature: Frontend
 
   Background:
@@ -9,6 +9,7 @@ Feature: Frontend
     When I request "/robots.txt"
     Then I should see "User-agent:"
 
+  @notreplatforming
   Scenario: Check transactions load
     When I visit "/apply-renew-passport"
     Then I should see "UK passport"
@@ -30,6 +31,7 @@ Feature: Frontend
     When I visit a non-existent page
     Then I should get a "Content-Type" header of "text/html; charset=utf-8"
 
+  @notreplatforming
   Scenario: Check licences load
     When I visit "/busking-licence"
     Then I should see "Busking licence"
@@ -37,18 +39,21 @@ Feature: Frontend
     When I try to post to "/busking-licence" with "postcode=E20+2ST"
     Then I should see "Busking licence"
 
+  @notreplatforming
   Scenario: Check local transactions load
     When I visit "/pay-council-tax"
     Then I should see "Pay your Council Tax"
     When I try to post to "/pay-council-tax" with "postcode=WC2B+6SE"
     Then I should see "Camden"
 
+  @notreplatforming
   Scenario: Check "find my nearest" returns results
     When I visit "/ukonline-centre-internet-access-computer-training"
     And I should see "Online Centres Network"
     When I try to post to "/ukonline-centre-internet-access-computer-training" with "postcode=WC2B+6NH"
     Then I should see "Holborn Library"
 
+  @notreplatforming
   Scenario: Check redirects work
     When I visit "/workplacepensions"
     Then I should be at a location path of "/workplace-pensions"

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -10,6 +10,9 @@ require 'webdrivers'
 
 # Set up environment
 case ENV["ENVIRONMENT"]
+when "test"
+  ENV["GOVUK_APP_DOMAIN"] ||= "test.publishing.service.gov.uk"
+  ENV["GOVUK_WEBSITE_ROOT"] ||= "https://www.test.publishing.service.gov.uk"
 when "integration"
   ENV["GOVUK_APP_DOMAIN"] ||= "integration.publishing.service.gov.uk"
   ENV["GOVUK_WEBSITE_ROOT"] ||= "https://www.integration.publishing.service.gov.uk"


### PR DESCRIPTION
This allows us to run smokey against the test AWS environment. The following test passes:

```
AUTH_USERNAME=x AUTH_PASSWORD=y ENVIRONMENT=test bundle exec cucumber --profile test --strict-undefined -t @replatforming -t "not @notreplatforming"
```

This is required by the replatforming team, as we're trying to get smokey running in & against ECS.