### PR TITLE
Containerised smoke tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM ruby:2.7.2
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential \
+  libpq-dev libxml2-dev libxslt1-dev dumb-init default-jre
+
+ENV APP_HOME /smokey
+RUN mkdir $APP_HOME
+
+ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE 1
+
+# Install Google Chrome
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
+RUN apt-get update && apt-get install -y google-chrome-stable && apt-get clean
+
+WORKDIR $APP_HOME
+ADD Gemfile* $APP_HOME/
+ADD .ruby-version $APP_HOME/
+RUN bundle install
+ADD Rakefile $APP_HOME
+RUN bundle exec rake webdrivers:chromedriver:update
+
+ADD . $APP_HOME
+
+# Allow root user to run Chrome in Docker
+ENV NO_SANDBOX 1
+
+# Remove Cucumber advert
+ENV CUCUMBER_PUBLISH_QUIET true
+
+STOPSIGNAL SIGINT
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+
+# Users of the image are expected to override the default CMD and set env vars
+# ENVIRONMENT, AUTH_USERNAME, AUTH_PASSWORD, and a profile flag.
+
+CMD ["bundle", "exec", "cucumber", "--strict-undefined", "-t 'not @benchmarking'"]

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "minitest", "~> 5"
 gem "nokogiri", "~> 1"
 gem "plek", "~> 4"
 gem 'ptools'
+gem "rake", "~> 13.0"
 gem "rest-client", "~> 2"
 gem "rspec", "~> 3"
 gem "selenium-webdriver", "~> 3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,7 @@ GEM
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
+    rake (13.0.3)
     regexp_parser (1.8.2)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
@@ -164,6 +165,7 @@ DEPENDENCIES
   plek (~> 4)
   pry-byebug (~> 3)
   ptools
+  rake (~> 13.0)
   rest-client (~> 2)
   rspec (~> 3)
   selenium-webdriver (~> 3)

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,2 @@
+require 'webdrivers'
+load 'webdrivers/Rakefile'

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -33,7 +33,12 @@ Capybara.app_host = ENV["GOVUK_WEBSITE_ROOT"]
 # Set up proxy server (used to manipulate HTTP headers etc since Selenium doesn't
 # support this) on a random port between 3222 and 3229
 proxy_port = (3222..3229).to_a.sample
-server = BrowserMob::Proxy::Server.new("./bin/browserup-proxy", port: proxy_port)
+server = BrowserMob::Proxy::Server.new(
+  "./bin/browserup-proxy",
+  port: proxy_port,
+  log: ENV.fetch("ENABLE_BROWSERMOB_LOGS", false),
+  timeout: 20
+)
 server.start
 proxy = server.create_proxy
 
@@ -76,6 +81,7 @@ Capybara.register_driver :headless_chrome do |app|
   options.add_argument("--disable-gpu")
   options.add_argument("--disable-xss-auditor")
   options.add_argument("--user-agent=Smokey\ Test\ \/\ Ruby")
+  options.add_argument("--no-sandbox") if ENV.key?("NO_SANDBOX")
 
   Capybara::Selenium::Driver.new(
     app,


### PR DESCRIPTION
This enables us to run the smoke tests from a container.

No build pipeline is set up for this yet. You'll need to manually build the container image with `docker build . -t smokey` then run the smoke tests like below.

Test environment (replatforming subset):

```
docker run -it -e AUTH_USERNAME=<user> -e AUTH_PASSWORD=<pass> -e ENVIRONMENT=test smokey bundle exec cucumber --profile test --strict-undefined -t 'not @benchmarking' -t @replatforming -t "not @notreplatforming"
```

Staging environment (smartanswers subset):

```
docker run -it -e AUTH_USERNAME=<user> -e AUTH_PASSWORD=<pass> -e ENVIRONMENT=staging_aws smokey bundle exec cucumber --profile staging_aws --strict-undefined -t 'not @benchmarking' -t @app-smartanswers
```

NB. Other environment variables are required (see [puppet for the list](https://github.com/alphagov/govuk-puppet/blob/84689ae2c36bbc7740da6a8d70c7f4e04d0e2357/modules/govuk/manifests/apps/smokey.pp)).

Changes to the test config:

- The additional timeout is required as I found the browsermob proxy would occasionally take over 10 seconds to start.
- The flag `--no-sandbox` was required in order to run Chrome as the root user in Docker. This is a shame but not a great risk given we're just making requests to our own site.
- Added environment variable flag `ENABLE_BROWSERMOB_LOGS` to make it easier to debug the image without needing to rebuild it.

The smoke tests expect to be run within our infrastructure (e.g. some tests make calls to non-public endpoints, such as publishing-api). We should mark those tests for removal, so we can run a subset of tests for CI for this repo (from concourse).