### PR TITLE
Add tag to run licensing tests independently

### DIFF
--- a/features/licensing.feature
+++ b/features/licensing.feature
@@ -1,3 +1,4 @@
+@app-licensing
 Feature: Licensing
   Tests for the Licensify app.
 


### PR DESCRIPTION
I want to be able to tell smokey to run just the tests that cover Licensing (🤢):

https://deploy.integration.publishing.service.gov.uk/job/Smokey/27314/console

At the moment I can't, because they don't have a tag.
