### PR TITLE
Refactor info frontend smokey tests

### DIFF
--- a/features/info_frontend.feature
+++ b/features/info_frontend.feature
@@ -5,7 +5,7 @@ Feature: Info Frontend
     Given I am testing through the full stack
     And I force a varnish cache miss
 
-  Scenario: Check the info page for the benefits mainstream browse page
-    When I visit "/info/browse/benefits"
-    Then I should see "Benefits"
-     And I should see "Unique pageviews"
+  Scenario: Check the info page for a GOV.UK page
+    When I visit "/info/complain-company"
+    Then I should see "Complain about a limited company"
+     And I should see "Why is this page on GOV.UK?"


### PR DESCRIPTION
We've retired the GOV.UK registers, therefore info pages can no longer
display metrics. This removes that dependency in the Smokey test.