### PR TITLE
Mark test as 'notreplatforming' so it won't run in ECS

### DIFF
--- a/features/frontend.feature
+++ b/features/frontend.feature
@@ -74,7 +74,7 @@ Feature: Frontend
     When I request "/bank-holidays.json"
     Then JSON is returned
 
-  @local-network @aws
+  @local-network @aws @notreplatforming
   Scenario: Healthcheck
     Given I am testing "frontend" internally
     When I request "/healthcheck"

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -23,7 +23,7 @@ when "production", "production_aws"
   ENV["GOVUK_APP_DOMAIN"] ||= "publishing.service.gov.uk"
   ENV["GOVUK_WEBSITE_ROOT"] ||= "https://www.gov.uk"
 else
-  raise "ENVIRONMENT should be one of integration, staging, staging_aws, production or production_aws"
+  raise "ENVIRONMENT should be one of test, integration, staging, staging_aws, production or production_aws"
 end
 
 # Set up basic URLs


### PR DESCRIPTION
Smokey currently doesn't have access to frontend in ECS, so marking this as `notreplatforming` will get tests passing against ECS again.

We'll probably remove this particular test once we have moved to ECS, since ECS or App Mesh will check the healthcheck endpoints directly.