### PR TITLE
Add replatforming tag to Signon and Publisher scenarios

### DIFF
--- a/features/publisher.feature
+++ b/features/publisher.feature
@@ -1,4 +1,4 @@
-@app-publisher
+@app-publisher @replatforming
 Feature: (Mainstream) Publisher
 
   @local-network

--- a/features/publishing_tools.feature
+++ b/features/publishing_tools.feature
@@ -71,7 +71,7 @@ Feature: Publishing Tools
     And I should see "Sign out"
     And I should see "All needs"
 
-  @app-publisher
+  @app-publisher @replatforming
   Scenario: Can log in to publisher
     When I go to the "publisher" landing page
     And I try to login as a user

--- a/features/signon.feature
+++ b/features/signon.feature
@@ -1,3 +1,4 @@
+@app-signon @replatforming
 Feature: Signon
   Tests for signon, the GOV.UK single sign-on service.
 


### PR DESCRIPTION
This will include the scenarios for Signon and Publisher in the set of smoke tests that are run against apps in ECS.

I've also added the tag app-signon to the signon suite so we can run those separately.