### PR TITLE
Check for "get emails for this topic" on taxon pages

### DIFF
--- a/features/collections.feature
+++ b/features/collections.feature
@@ -52,8 +52,8 @@ Feature: Collections
 
   Scenario: Email signup from a taxon page
     When I visit "/education"
-    Then I should see "Get emails about this topic"
-    When I click on the link "Get emails about this topic"
+    Then I should see "Get emails for this topic"
+    When I click on the link "Get emails for this topic"
     Then I should see "What do you want to get emails about?"
     When I choose radio button "Teaching and leadership" and click on "Continue"
     And I click on the button "Continue"


### PR DESCRIPTION
Taxon pages used to say "get emails about this topic", which was
inconsistent with topic pages, and that inconsistency has been
resolved.

---

Successful run: https://deploy.integration.publishing.service.gov.uk/job/Smokey/30286/console