### PR TITLE
Fix Brexit path

### DIFF
--- a/features/step_definitions/brexit_check_steps.rb
+++ b/features/step_definitions/brexit_check_steps.rb
@@ -1,5 +1,5 @@
 When "I start the checker" do
-  visit_path "/transition"
+  visit_path "/brexit"
   click_link "Brexit checker: start now"
 end
 


### PR DESCRIPTION
We're renaming /transition back to /brexit today.
