### PR TITLE
Update header link CSS selector

### DIFF
--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -235,7 +235,7 @@ When /^I try to post to "(.*)" with "(.*)" without following redirects$/ do |pat
 end
 
 Then /^the logo should link to the homepage$/ do
-  logo = Nokogiri::HTML.parse(page.body).at_css('#logo')
+  logo = Nokogiri::HTML.parse(page.body).at_css('.govuk-header__link')
   expect(logo.attributes['href'].value).to eq(ENV['GOVUK_WEBSITE_ROOT'])
 end
 


### PR DESCRIPTION
Smokey was failing with the release of the new gem_layout because this layout's homepage link in the header doesn't have the id `#logo`.

To fix this the selector has been changed to `.govuk-header__link` which is present in both `core_layout` and `gem_layout`.
<!-- ## Testing

**You should manually test your PR before merging.**

This app doesn't have CI setup, and it would be misleading to do so:
the behaviour of the tests changes depending on the environment they
are run in. You should manually test in applicable environments,
until you are confident your change is not a breaking one.

Example steps to test in Integration:

- Click "Configure" for the [Smokey job][]
- Change the "Branch specifier" to the name of your branch
- Run a new build of the Smokey project and check the results

## Deployment

**You need to manually deploy your PR after merging.**

Steps to deploy a change:

- Run the [Smokey deploy job][] to deploy the [continuous Smokey loop][]
- Repeat this in Staging and Production

> The manual [Smokey job][] will pick up changes on `main` automatically. You only need to do a manual deployment for the [continuous Smokey loop][].

[Smokey job]: https://deploy.integration.publishing.service.gov.uk/job/Smokey/
[continuous Smokey loop]: https://github.com/alphagov/govuk-puppet/blob/master/modules/monitoring/templates/smokey-loop.conf
[Smokey deploy job]: https://deploy.integration.publishing.service.gov.uk/job/Smokey_Deploy/

-->
