### PR TITLE
Add publishing smoke test

### DIFF
--- a/features/publisher.feature
+++ b/features/publisher.feature
@@ -7,3 +7,37 @@ Feature: (Mainstream) Publisher
     When I request "/healthcheck/ready"
     Then JSON is returned
     And I should see ""status":"ok""
+
+  @notproduction
+  Scenario: Can create a draft place
+    Given I have the smokey run identifier
+    When I try to login as a user
+    And I go to the "publisher" landing page
+    And I go to add an artefact
+    And I create a draft place
+    And I preview the draft place
+    Then I should see that the content has been published
+
+  @notproduction
+  Scenario: Can publish a draft place to live
+    Given I have the smokey run identifier
+    When I try to login as a user
+    And I go to the "publisher" landing page
+    And I search for the content in category "Drafts"
+    And I go to the content from the search results
+    And I request 2nd pair of eyes
+    And I skip the review
+    And I publish the draft
+    And I view the published content on live
+    Then I should see that the content has been published
+
+  @notproduction
+  Scenario: Can unpublish a live place
+    Given I have the smokey run identifier
+    When I try to login as a user
+    And I go to the "publisher" landing page
+    And I search for the content in category "Published"
+    And I go to the content from the search results
+    And I go to the "Unpublish" section
+    And I unpublish the edition
+    Then I should see that the content has been unpublished

--- a/features/step_definitions/publisher_steps.rb
+++ b/features/step_definitions/publisher_steps.rb
@@ -1,0 +1,117 @@
+module Status
+  OK = 200
+  NOT_FOUND = 404
+  GONE = 410
+end
+
+When "I go to add an artefact" do
+  click_on "Add artefact"
+  expect(page).to have_content("New artefact")
+end
+
+When "I create a draft place" do
+  fill_in "Title", with: publication_title
+  fill_in "Slug", with: parameterize(publication_title)
+  select "Place", from: "Format"
+  click_button "Save and go to item"
+end
+
+When "I preview the draft place" do
+  click_on "Preview"
+
+  wait_until do
+    status = get_status_code do
+      visit page.current_url
+    end
+
+    status != Status::NOT_FOUND
+  end
+end
+
+When "I should see that the content has been published" do
+  expect(page).to have_content(publication_title)
+  expect(page.current_path).to eq(publication_path)
+  expect(page).to_not have_content("GOV.UK Publisher")
+end
+
+When /I search for the content in category "([^"]*)"/ do |status|
+  select "Nobody", from: "Assignee"
+  fill_in "Keyword", with: publication_title
+  select "Place", from: "Format"
+  click_button "Filter publications"
+  click_link status
+end
+
+When "I go to the content from the search results" do
+  click_link publication_title
+end
+
+When "I request 2nd pair of eyes" do
+  click_on "2nd pair of eyes"
+  click_on "Send to 2nd pair of eyes"
+end
+
+When "I skip the review" do
+  click_on "Skip review"
+
+  within "#skip_review_form" do
+    click_on "Skip review"
+  end
+
+  wait_until { find('span[title="Status"]').text == "Ready" }
+end
+
+When "I publish the draft" do
+  click_on "Publish"
+  click_on "Send to publish"
+end
+
+When "I view the published content on live" do
+  click_on "View this on the GOV.UK website"
+
+  wait_until do
+    status = get_status_code do
+      visit_path publication_url
+    end
+
+    status != Status::NOT_FOUND
+  end
+end
+
+When /I go to the "([^"]*)" section/ do |section|
+  click_link section
+end
+
+When "I unpublish the edition" do
+  accept_alert do
+    click_button "Unpublish"
+  end
+end
+
+When "I should see that the content has been unpublished" do
+  expect(page).to have_content("Content unpublished")
+
+  wait_until do
+    status = get_status_code do
+      visit_path publication_url
+    end
+
+    status == Status::GONE
+  end
+end
+
+def parameterize(str)
+  str.downcase.gsub(/\s/,'-')
+end
+
+def publication_title
+  @publication_title ||= "Smokey test draft place #{$smokey_run_id}"
+end
+
+def publication_path
+  @publication_path ||= "/#{parameterize(publication_title)}"
+end
+
+def publication_url
+  @publication_url ||= "#{ENV['GOVUK_WEBSITE_ROOT']}#{publication_path}"
+end

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -39,6 +39,10 @@ Given /^I am an authenticated API client$/ do
   @authenticated_as_client = true
 end
 
+Given /^I have the smokey run identifier$/ do
+  $smokey_run_id ||= SecureRandom.hex
+end
+
 And /^I consent to cookies$/ do
   visit_path "/"
   click_button "Accept"
@@ -316,4 +320,10 @@ def cache_hits_value(response)
   else
     raise "Couldn't find X-Cache-Hits header in response"
   end
+end
+
+def get_status_code
+  $proxy.new_har
+  yield
+  $proxy.har.entries.first.response.status
 end


### PR DESCRIPTION
This PR adds a smoke test for Publisher which creates a new draft `Place` and ensures it is then visible on the draft stack, before then proceeding to delete the draft.

This test will not run on existing production and will not run on the new replatformed production when it's ready, as it has been given the tag `@notproduction` (where the Smokey run for each environment by Concourse will exclude tags matching `@not<environment>`).

Trello: https://trello.com/c/9QipS0X0