### PR TITLE
Fix WAF smoke test

### DIFF
--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -1,7 +1,7 @@
-default: -t "not @benchmarking" -t "not @pending" -t "not @local-network" -t "not @notintegration"
-test: -t "not @pending" -t "not @nottest"
-integration: -t "not @pending" -t "not @notintegration"
-staging: -t "not @pending" -t "not @notstaging"
-production: -t "not @pending" -t "not @notproduction"
-staging_aws: -t "not @pending" -t "not @notstaging"
-production_aws: -t "not @pending" -t "not @notproduction"
+default: -t "not @benchmarking" -t "not @pending" -t "not @local-network" -t "not @notintegration" --publish-quiet
+test: -t "not @pending" -t "not @nottest" --publish-quiet
+integration: -t "not @pending" -t "not @notintegration" --publish-quiet
+staging: -t "not @pending" -t "not @notstaging" --publish-quiet
+production: -t "not @pending" -t "not @notproduction" --publish-quiet
+staging_aws: -t "not @pending" -t "not @notstaging" --publish-quiet
+production_aws: -t "not @pending" -t "not @notproduction" --publish-quiet

--- a/features/waf.feature
+++ b/features/waf.feature
@@ -8,5 +8,5 @@ Feature: WAF
 
   Scenario: Check that the X-Always-Block rule is in place
     Given I set header X-Always-Block to true
-    When I send a GET request to "/"
+    When I send a GET request to "/robots.txt"
     Then I should get a 403 status code


### PR DESCRIPTION
We're now ignoring paths in the cache key for the
homepage. The WAF is behind Fastly so the requests
from this smoke test to the homepage won't actually
make it to the WAF.

The fix is to point the smoke test at another path.

Test it locally:

```
ENVIRONMENT=production_aws bundle exec cucumber \
--profile production_aws --strict-undefined features/waf.feature
```