### PR TITLE
Only run Publisher publishing tests in integration

### DIFF
--- a/features/publisher.feature
+++ b/features/publisher.feature
@@ -8,7 +8,7 @@ Feature: (Mainstream) Publisher
     Then JSON is returned
     And I should see ""status":"ok""
 
-  @notproduction
+  @notstaging @notproduction
   Scenario: Can create a draft place
     Given I have the smokey run identifier
     When I try to login as a user
@@ -18,7 +18,7 @@ Feature: (Mainstream) Publisher
     And I preview the draft place
     Then I should see that the content has been published
 
-  @notproduction
+  @notstaging @notproduction
   Scenario: Can publish a draft place to live
     Given I have the smokey run identifier
     When I try to login as a user
@@ -31,7 +31,7 @@ Feature: (Mainstream) Publisher
     And I view the published content on live
     Then I should see that the content has been published
 
-  @notproduction
+  @notstaging @notproduction
   Scenario: Can unpublish a live place
     Given I have the smokey run identifier
     When I try to login as a user


### PR DESCRIPTION
Smoke tests were recently added to test the end-to-end Publisher workflow - specifically creating, publishing and unpublishing content. In order to facilitate the publishing test, Smokey was granted the `skip_review` permission in integration and staging which then enables it to request 2i, skip review and publish immediately. Due to the daily Signon data sync from prod to staging however, manually added permissions do not persist in staging; as Smokey doesn't hold the `skip_review` permission in prod, this will also be the case in staging.

For now, the Replatforming team are deciding to only run this test in integration, where manually added permissions in Signon do persist as there is no daily Signon data sync that would otherwise overwrite this data. When we come to moving the new platform to staging, we will revisit this decision and consider doing the work to persist Smokey's `skip_review` permission for Publisher in staging.