### PR TITLE
Update SmartAnswer to new URL

### DIFF
--- a/features/smartanswers.feature
+++ b/features/smartanswers.feature
@@ -15,7 +15,7 @@ Feature: Smart Answers
       | /calculate-employee-redundancy-pay/y        | What date was your employee made redundant?          |
       | /calculate-married-couples-allowance/y      | Were you or your partner born before 6 April 1935?   |
       | /marriage-abroad/y                          | Where do you want to get married?                    |
-      | /pay-leave-for-parents/y                    | Will the mother care for the child with a partner?   |
+      | /maternity-paternity-pay-leave/y            | Will the mother care for the child with a partner?   |
       | /register-a-death/y                         | Where did the death happen?                          |
       | /vat-payment-deadlines/y                    | When does your VAT accounting period end?            |
 


### PR DESCRIPTION
The `pay-leave-for-parents` SmartAnswer was renamed to `maternity-paternity-pay-leave` in
https://github.com/alphagov/smart-answers/pull/4765

A redirect is in place so Smokey will continue to pass until this change is deployed.

[trello](https://trello.com/c/65jLhWvK/2019-to-deploy-16-june-update-questions-and-outcomes-in-pay-leave-for-parents-to-remove-shared-parental-leave-information)