### PR TITLE
Add tests for signing in to the GOV.UK account

### DIFF
--- a/features/account_api.feature
+++ b/features/account_api.feature
@@ -1,7 +1,24 @@
-@app-account-api @local-network
+@app-account-api
 Feature: Account API
+  @local-network
   Scenario: Healthcheck
     Given I am testing "account-api" internally
     When I request "/healthcheck/ready"
     Then JSON is returned
     And I should see ""status":"ok""
+
+  @app-frontend @app-collections @app-finder-frontend
+  Scenario Outline: Signing in
+    Given I am testing through the full stack
+    And I force a varnish cache miss
+    When I visit "<Path>"
+    Then I should see "Sign in"
+    When I click on the link "Sign in"
+    Then I should see "Sign in to your GOV.UK account"
+    When I sign in to my GOV.UK account
+    Then I should see "Sign out"
+
+    Examples:
+      | Path                                                                      |
+      | /brexit                                                                   |
+      | /transition-check/results?c[]=living-uk&c[]=nationality-uk&c[]=working-uk |

--- a/features/step_definitions/account_steps.rb
+++ b/features/step_definitions/account_steps.rb
@@ -1,0 +1,7 @@
+When "I sign in to my GOV.UK account" do
+  assert ENV["GOVUK_ACCOUNT_EMAIL"] && ENV["GOVUK_ACCOUNT_PASSWORD"], "Please ensure that the GOV.UK account credentials are available in the environment"
+
+  fill_in "Email address", :with => ENV["GOVUK_ACCOUNT_EMAIL"]
+  fill_in "Password", :with => ENV["GOVUK_ACCOUNT_PASSWORD"]
+  click_button "Continue"
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -56,6 +56,11 @@ if ENV["AUTH_USERNAME"] && ENV["AUTH_PASSWORD"]
     ENV["AUTH_USERNAME"],
     ENV["AUTH_PASSWORD"],
   )
+  proxy.basic_authentication(
+    "www.account.staging.publishing.service.gov.uk",
+    ENV["AUTH_USERNAME"],
+    ENV["AUTH_PASSWORD"],
+  )
 end
 
 # Blacklist YouTube to prevent cross-site errors


### PR DESCRIPTION
We've had a few instances where the sign in journey has broken.  This
sort of thing is hard to catch when testing at the app level, as it
involves GOV.UK apps, an external auth service, and our CDN config.

We think that smoke tests which test the full journey from the
perspective of a user will help catch future breaking changes.

---

[Example successful Smokey run on integration](https://deploy.integration.publishing.service.gov.uk/job/Smokey/30935/console)

[Trello card](https://trello.com/c/a1mlNSkg/849-add-smoke-tests-for-signing-in-from-the-brexit-landing-page-the-checker-results-page)
