### PR TITLE
Use separate env vars for account basic auth credentials

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -58,8 +58,8 @@ if ENV["AUTH_USERNAME"] && ENV["AUTH_PASSWORD"]
   )
   proxy.basic_authentication(
     "www.account.staging.publishing.service.gov.uk",
-    ENV["AUTH_USERNAME"],
-    ENV["AUTH_PASSWORD"],
+    ENV["ACCOUNT_AUTH_USERNAME"],
+    ENV["ACCOUNT_AUTH_PASSWORD"],
   )
 end
 


### PR DESCRIPTION
See also https://github.com/alphagov/govuk-puppet/pull/11157

[Successful smokey run on staging](https://deploy.blue.staging.govuk.digital/job/Smokey/12424/console)