### PR TITLE
Change SmartAnswer example for Imminence test

### DIFF
--- a/features/smartanswers.feature
+++ b/features/smartanswers.feature
@@ -27,16 +27,6 @@ Feature: Smart Answers
     | /vat-payment-deadlines/y/2000-01-31         |
     | /vat-payment-deadlines/y/2000-01-31/cheque  |
 
-  Scenario: Check stepping through a smart answer that uses Imminence
-    Then I should be able to visit:
-    | Path                                              |
-    | /landlord-immigration-check                       |
-    | /landlord-immigration-check/y                     |
-    | /landlord-immigration-check/y/SW1A2AA             |
-    | /landlord-immigration-check/y/SW1A2AA/yes         |
-    | /landlord-immigration-check/y/SW1A2AA/yes/yes     |
-    | /landlord-immigration-check/y/SW1A2AA/yes/yes/yes |
-
   Scenario: Check stepping through a smart answer that uses the Worldwide API
     Then I should be able to visit:
     | Path                                                |
@@ -105,8 +95,6 @@ Feature: Smart Answers
       | Path                                                                              | Expected string            |
       | /benefit-cap-calculator/y/yes/no/none/bereavement/1000.0/1000.0/single/SW1A%202AA | Greater London benefit cap |
       | /benefit-cap-calculator/y/yes/no/none/bereavement/1000.0/1000.0/single/EH99%201SP | Outside London benefit cap |
-      | /landlord-immigration-check/y/SW1A%202AA                                          | Is the person renting      |
-      | /landlord-immigration-check/y/EH99%201SP                                          | check in England           |
 
   Scenario: Check personal information is excluded from analytics data
     When I visit "/marriage-abroad/y"


### PR DESCRIPTION
The "check-landlord-immigration" smart answer is no longer suitable for testing Imminence, so this swaps it for one that is.

There is now only one SmartAnswer that uses Imminence, the BenefitCapCalculator.

This commit removes a Scenario for stepping through an Imminence-enabled smart answer because:
* the benefit cap calculator only uses a post-code in the final step
* it is possible for the steps to fail validation but to still return a 200,
making this test unreliable

Instead we can now rely on the existing "Check postcode lookup" Scenario which actually asserts that the Imminence call has succeeded by checking page text.

[trello](https://trello.com/c/4mogKZrw/2584-temporarily-take-down-check-if-someone-can-rent-your-residential-property-remove-the-start-page-button-replace-the-start-page-te)
