### PR TITLE
Feedback component tests for each frontend app

### DIFF
--- a/features/feedback.feature
+++ b/features/feedback.feature
@@ -28,5 +28,83 @@ Feature: Feedback
     When I visit "/"
     And I click to say the page is not useful
     And I submit the email survey signup form
-    Then I see a signup confirmation message
+    Then I see the feedback confirmation message
     And a request is sent to the feedback app
+
+  Scenario: Check feedback component behaviour
+    When I visit "<url>"
+    And I confirm it is rendered by "<application>"
+    And I click to report a problem with the page
+    Then I see the report a problem form
+    When I close the open feedback form
+    And I click to say the page is not useful
+    Then I see the email survey signup form
+    When I close the open feedback form
+    And I click to say the page is useful
+    Then I see the feedback confirmation message
+
+    # Failing as of 30 June 2021
+    #
+    # @app-collections
+    # Examples:
+    #   | url                       | application |
+    #   | /government/organisations | collections |
+
+    @app-email-frontend
+    Examples:
+      | url                        | application          |
+      | /email/manage/authenticate | email-alert-frontend |
+
+    @app-feedback
+    Examples:
+      | url            | application |
+      | /contact/govuk | feedback    |
+
+    @app-finder-frontend
+    Examples:
+      | url                             | application     |
+      | /search/news-and-communications | finder-frontend |
+
+    # Failing as of 30 June 2021
+    #
+    # @app-frontend
+    # Examples:
+    #   | url | application |
+    #   | /   | frontend    |
+
+    @app-government-frontend
+    Examples:
+      | url               | application         |
+      | /help/about-govuk | government-frontend |
+
+    @app-info-frontend
+    Examples:
+      | url             | application   |
+      | /info/vat-rates | info-frontend |
+
+    @app-licencefinder
+    Examples:
+      | url                     | application   |
+      | /licence-finder/sectors | licencefinder |
+
+    @app-manuals-frontend
+    Examples:
+      | url                      | application      |
+      | /guidance/content-design | manuals-frontend |
+
+    @app-service-manual-frontend
+    Examples:
+      | url             | application             |
+      | /service-manual | service-manual-frontend |
+
+    # Failing as of 30 June 2021
+    #
+    # @app-smartanswers
+    # Examples:
+    #   | url              | application  |
+    #   | /marriage-abroad | smartanswers |
+
+    @app-whitehall
+    Examples:
+      | url    | application |
+      | /world | whitehall   |

--- a/features/step_definitions/feedback_steps.rb
+++ b/features/step_definitions/feedback_steps.rb
@@ -4,9 +4,50 @@ When /^I input malicious code in the (.*) field$/ do |field|
   click_button("Send message")
 end
 
+When /^I click to report a problem with the page$/ do
+  within(".gem-c-feedback") do
+    click_on("Report a problem with this page")
+  end
+end
+
+Then /^I see the report a problem form$/ do
+  within(".gem-c-feedback") do
+    expect(page).to have_content("Help us improve GOV.UK")
+    expect(page).to have_field("What went wrong?")
+
+    # Regression test for scenario where wrong URL is set
+    url_input = page.find("form[action='/contact/govuk/problem_reports'] input[name=url]", visible: false)
+    expect(url_input.value).to eq(page.current_url)
+  end
+end
+
+When /^I close the open feedback form$/ do
+  within(".gem-c-feedback") do
+    click_on("Close")
+  end
+end
+
 When /^I click to say the page is not useful$/ do
   within(".gem-c-feedback") do
     click_on("No")
+  end
+end
+
+When /^I click to say the page is useful$/ do
+  within(".gem-c-feedback") do
+    click_on("Yes")
+  end
+end
+
+Then /^I see the email survey signup form$/ do
+  within(".gem-c-feedback") do
+    expect(page).to have_content("Help us improve GOV.UK")
+    expect(page).to have_field("Email address")
+
+    # Regression test for scenario where wrong URL is set
+    url_input = page.find("form[action='/contact/govuk/email-survey-signup'] input[name='email_survey_signup[survey_source]']", visible: false)
+    full_path = URI(page.current_url).request_uri
+    expect(url_input.value).to eq(full_path)
   end
 end
 
@@ -17,7 +58,7 @@ When /^I submit the email survey signup form$/ do
   end
 end
 
-Then /^I see a signup confirmation message$/ do
+Then /^I see the feedback confirmation message$/ do
   expect(page).to have_content("Thank you for your feedback")
 end
 
@@ -27,7 +68,7 @@ end
 
 Then /^a request is sent to the feedback app$/ do
   sought = "/contact/govuk/email-survey-signup"
-  wait_until { proxy_has_request_with_url_containing sought }
+  wait_until { found = proxy_has_request_with_url_containing sought }
   expect(proxy_has_request_with_url_containing sought).to be(true)
 end
 

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -75,6 +75,11 @@ When /^I visit "(.*)"$/ do |path_or_url|
   visit_path path_or_url
 end
 
+Then /^I confirm it is rendered by "(.*)"$/ do |application|
+  meta = page.find("meta[name='govuk:rendering-application']", visible: false)
+  expect(meta[:content]).to eq(application)
+end
+
 When /^I visit the "([^"]+)" finder with keywords (.*)$/ do |finder, keywords|
   path = "/search/#{finder}?keywords=#{keywords}"
   visit_path path


### PR DESCRIPTION
This adds regression tests for the feedback component that is available
across GOV.UK frontend apps. At the time of writing this
component is currently broken in a number of applications and we've
found out that there wasn't tests available to catch the problem. A fix
is currently in progress for the problem [1] and these are being added
so that we can learn sooner if the problem re-occurs.

The feedback component has become particularly complex as it requires a
high degree of integration. The items involved are: the frontend
application, the feedback application, the slimmer gem, static application
and it's integration with govuk_publishing_components. This seems to leave
Smokey as the only tool that has a sufficient perspective to test this
component is integrated correctly. Because of this complexity I felt it
was necessary to test each application, as any one of those can
break while the component is still operational in other apps (this
is the case currently where this component is broken for 3 apps).

There was already a test that confirmed a user could submit a request
for the email survey from the homepage (frontend app). I
decided against extending this and instead wrote an additional
complimentary test. I chose this because: I thought it was worth testing
both the email survey and the report a problem functionality in a
consistent way; It looked like it'd be tricky to understand failures if
asserted on a post request; and I didn't want to bombard feedback with
lots of duplicate requests. I instead made this test into one that
exercises the routes feedback can take.

In order to exercise all the apps, and have them appropriately tagged, I had
to take this rather verbose approach of setting up lots of tagged
example tables. I'm not an expert on Gherkin by any means, so it could
be there's a simpler way to do this.

I've commented out the tests for applications that are currently failing
so that we can merge this in before to fix goes out. I'll plan to remove
the comments from them as the fix is deployed.

[1]: https://github.com/alphagov/slimmer/pull/271
