### PR TITLE
Stop CKAN alerts during upgrade to 2.9 (merge before upgrade started)

### DIFF
--- a/features/data_gov_uk.feature
+++ b/features/data_gov_uk.feature
@@ -25,11 +25,13 @@ Feature: Data.gov.uk
     When I request "/dataset/lidar-composite-dtm-2017-1m.rdf"
     Then I should get a 200 status code
 
+  @notintegration @notstaging @notproduction
   Scenario: Check CKAN loads correctly
     Given I am testing "ckan"
     When I request "/"
     Then I should see "Data publisher"
 
+  @notintegration @notstaging @notproduction
   Scenario: Check CKAN action api's search works
     Given I am testing "ckan"
     When I request "/api/action/package_search?q=data"


### PR DESCRIPTION
## What

Stop CKAN alerts during upgrade to 2.9, this should be done after the redirection to CKAN maintenance started and worker processes stopped - https://github.com/alphagov/govuk-puppet/pull/11203

## Reference 

https://trello.com/c/DZJFi8z5/2613-create-prs-to-prep-for-29-upgrade

## Testing

**You should manually test your PR before merging.**

This app doesn't have CI setup, and it would be misleading to do so:
the behaviour of the tests changes depending on the environment they
are run in. You should manually test in applicable environments,
until you are confident your change is not a breaking one.

Example steps to test in Integration:

- Click "Configure" for the [Smokey job][]
- Change the "Branch specifier" to the name of your branch
- Run a new build of the Smokey project and check the results

## Deployment

**You need to manually deploy your PR after merging.**

Steps to deploy a change:

- Run the [Smokey deploy job][] to deploy the [continuous Smokey loop][]
- Repeat this in Staging and Production

> The manual [Smokey job][] will pick up changes on `main` automatically. You only need to do a manual deployment for the [continuous Smokey loop][].

[Smokey job]: https://deploy.integration.publishing.service.gov.uk/job/Smokey/
[continuous Smokey loop]: https://github.com/alphagov/govuk-puppet/blob/master/modules/monitoring/templates/smokey-loop.conf
[Smokey deploy job]: https://deploy.integration.publishing.service.gov.uk/job/Smokey_Deploy/
