### PR TITLE
Change finder-frontend selector

### DIFF
--- a/features/step_definitions/finder_frontend_steps.rb
+++ b/features/step_definitions/finder_frontend_steps.rb
@@ -39,7 +39,7 @@ When /^I go to the next page$/ do
 end
 
 When /^I click result (.*)$/ do |num|
-  all(".finder-results li a.gem-c-document-list__item-link")[num.to_i - 1].click
+  all(".finder-results li a.gem-c-document-list__item-title")[num.to_i - 1].click
 end
 
 Then /^I should see some search results$/ do


### PR DESCRIPTION
In https://github.com/alphagov/govuk_publishing_components/pull/2211/files
the `gem-c-document-list__item-link` class was removed which led to this
test failing once v24.21.0 was released of the gem.

I've changed it to a class that remains that also doesn't risk the
ambiguity that led to a class being added in the first place [1].
However this seems rather fragile and could well break again in future.
I can't seem to find any better alternatives available or the ability
for finder-frontend to specify the selector.

[1]: https://github.com/alphagov/smokey/commit/93a07b6a6969357f79eaac7f36ea002317781e90
