### PR TITLE
Dataset count is now in h1 element not h2

### DIFF
--- a/features/data_gov_uk.feature
+++ b/features/data_gov_uk.feature
@@ -38,6 +38,7 @@ Feature: Data.gov.uk
     Then I should get a 200 status code
     And JSON is returned
 
+  @notintegration @notstaging
   Scenario: Check datasets sync between CKAN and Find
     Given I am testing "https://ckan.publishing.service.gov.uk"
     When I search for all datasets

--- a/features/step_definitions/datagovuk_steps.rb
+++ b/features/step_definitions/datagovuk_steps.rb
@@ -12,7 +12,7 @@ When /^I search for all datasets$/ do
 end
 
 When /^I save the dataset count$/ do
-  package_count_form = page.first(".search-form h2")
+  package_count_form = page.first(".search-form h1")
   @package_count = package_count_form.text.gsub(/[^\d^\.]/, '').to_i
 end
 


### PR DESCRIPTION
## What

Dataset count is in `h1` element not `h2`.

Error reported -

> expected to find css ".search-form h2" at least 1 time but there were no matches (Capybara::ExpectationNotMet)
      ./features/step_definitions/datagovuk_steps.rb:15:in `/^I save the dataset count$/'

## Testing

**You should manually test your PR before merging.**

This app doesn't have CI setup, and it would be misleading to do so:
the behaviour of the tests changes depending on the environment they
are run in. You should manually test in applicable environments,
until you are confident your change is not a breaking one.

Example steps to test in Integration:

- Click "Configure" for the [Smokey job][]
- Change the "Branch specifier" to the name of your branch
- Run a new build of the Smokey project and check the results

## Deployment

**You need to manually deploy your PR after merging.**

Steps to deploy a change:

- Run the [Smokey deploy job][] to deploy the [continuous Smokey loop][]
- Repeat this in Staging and Production

> The manual [Smokey job][] will pick up changes on `main` automatically. You only need to do a manual deployment for the [continuous Smokey loop][].

[Smokey job]: https://deploy.integration.publishing.service.gov.uk/job/Smokey/
[continuous Smokey loop]: https://github.com/alphagov/govuk-puppet/blob/master/modules/monitoring/templates/smokey-loop.conf
[Smokey deploy job]: https://deploy.integration.publishing.service.gov.uk/job/Smokey_Deploy/
