### PR TITLE
Fix Feedback test

### DIFF
--- a/features/feedback.feature
+++ b/features/feedback.feature
@@ -53,11 +53,6 @@ Feature: Feedback
       | url                        | application          |
       | /email/manage/authenticate | email-alert-frontend |
 
-    @app-feedback
-    Examples:
-      | url            | application |
-      | /contact/govuk | feedback    |
-
     @app-finder-frontend
     Examples:
       | url                             | application     |


### PR DESCRIPTION
The [feedback component was removed](https://github.com/alphagov/feedback/commit/715aad1db1868a01774cc01f69c12e90bb4b1064#diff-f43fe075643e681b2c01c2f853bb0c4299d135b47fcbd4da96890d521c49e3eb) from the layout in the feedback app, so [this test won't ever pass](https://deploy.blue.production.govuk.digital/job/smokey/9044/console).

(You can check this on https://www.gov.uk/contact/govuk)

