### PR TITLE
Disable account-api login test in integration

### DIFF
--- a/features/account_api.feature
+++ b/features/account_api.feature
@@ -7,7 +7,7 @@ Feature: Account API
     Then JSON is returned
     And I should see ""status":"ok""
 
-  @app-frontend @app-collections @app-finder-frontend
+  @notintegration @app-frontend @app-collections @app-finder-frontend
   Scenario Outline: Signing in
     Given I am testing through the full stack
     And I force a varnish cache miss


### PR DESCRIPTION
We're testing out the Digital Identity auth service in integration,
and we don't have a test user for that yet.

---

[Trello card](https://trello.com/c/ZvDGaba4/958-use-di-auth-in-integration-give-feedback-on-their-documentation)
