### PR TITLE
Remove redundant healthcheck scenarios

### DIFF
--- a/features/account_api.feature
+++ b/features/account_api.feature
@@ -1,12 +1,5 @@
 @app-account-api
 Feature: Account API
-  @local-network
-  Scenario: Healthcheck
-    Given I am testing "account-api" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""
-
   @notintegration @app-frontend @app-collections @app-finder-frontend
   Scenario Outline: Signing in
     Given I am testing through the full stack

--- a/features/asset_manager.feature
+++ b/features/asset_manager.feature
@@ -1,7 +1,0 @@
-@app-asset-manager @local-network
-Feature: Asset Manager
-  Scenario: Healthcheck
-    Given I am testing "asset-manager" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/authenticating_proxy.feature
+++ b/features/authenticating_proxy.feature
@@ -1,9 +1,0 @@
-@app-authenticating-proxy
-Feature: Authenticating Proxy
-
-  @local-network
-  Scenario: Healthcheck
-    Given I am testing "draft-origin"
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/bouncer.feature
+++ b/features/bouncer.feature
@@ -1,7 +1,0 @@
-@app-bouncer @local-network
-Feature: Bouncer
-  Scenario: Healthcheck
-    Given I am testing "bouncer" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/collections.feature
+++ b/features/collections.feature
@@ -65,10 +65,3 @@ Feature: Collections
     When I click on the link "Get emails for this topic"
     And I click on the button "Continue"
     Then I should see "How often do you want to get emails?"
-
-  @local-network
-  Scenario: Healthcheck
-    Given I am testing "collections" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/collections_publisher.feature
+++ b/features/collections_publisher.feature
@@ -1,7 +1,0 @@
-@app-collections-publisher @local-network
-Feature: Collections Publisher
-  Scenario: Healthcheck
-    Given I am testing "collections-publisher" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/contacts_admin.feature
+++ b/features/contacts_admin.feature
@@ -1,7 +1,0 @@
-@app-contacts-admin @local-network
-Feature: Contacts Admin
-  Scenario: Healthcheck
-    Given I am testing "contacts-admin" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/content_data_admin.feature
+++ b/features/content_data_admin.feature
@@ -3,12 +3,6 @@ Feature: Content Data Admin
   Tests for the Content Data Admin application, which provides
   publishers with data about the content they manage
 
-  Scenario: Healthcheck
-    Given I am testing "content-data" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""
-
   Scenario: Can access the Content Data Admin index page
     When I go to the "content-data-admin" landing page
     And I try to login as a user

--- a/features/content_data_api.feature
+++ b/features/content_data_api.feature
@@ -1,7 +1,0 @@
-@app-content-data-api @local-network
-Feature: Content Data API
-  Scenario: Healthcheck
-    Given I am testing "content-data-api" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/content_publisher.feature
+++ b/features/content_publisher.feature
@@ -1,7 +1,0 @@
-@app-content-publisher @local-network
-Feature: Content Publisher
-  Scenario: Healthcheck
-    Given I am testing "content-publisher" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/content_store.feature
+++ b/features/content_store.feature
@@ -1,7 +1,0 @@
-@app-content-store @local-network
-Feature: Content Store
-  Scenario: Healthcheck
-    Given I am testing "content-store" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/content_tagger.feature
+++ b/features/content_tagger.feature
@@ -1,7 +1,0 @@
-@app-content-tagger @local-network
-Feature: Content Tagger
-  Scenario: Healthcheck
-    Given I am testing "content-tagger" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/email_alert_api.feature
+++ b/features/email_alert_api.feature
@@ -1,7 +1,0 @@
-@app-email-alert-api @local-network
-Feature: Email Alert API
-  Scenario: Healthcheck
-    Given I am testing "email-alert-api" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/email_alert_frontend.feature
+++ b/features/email_alert_frontend.feature
@@ -1,7 +1,0 @@
-@app-email-alert-frontend @local-network
-Feature: Email Alert Frontend
-  Scenario: Healthcheck
-    Given I am testing "email-alert-frontend" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/feedback.feature
+++ b/features/feedback.feature
@@ -4,13 +4,6 @@ Feature: Feedback
     Given I am testing through the full stack
     And I force a varnish cache miss
 
-  @app-feedback @local-network
-  Scenario: Healthcheck
-    Given I am testing "feedback" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""
-
   Scenario: Check the "Contact GOV.UK" page loads correctly
     When I visit "/contact/govuk"
     Then I should see "Contact GOV.UK"

--- a/features/finder_frontend.feature
+++ b/features/finder_frontend.feature
@@ -7,13 +7,6 @@ Feature: Finder Frontend
     And I consent to cookies
     And I force a varnish cache miss
 
-  @local-network
-  Scenario: Healthcheck
-    Given I am testing "finder-frontend" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""
-
   Scenario: Check people page loads correctly
     When I visit "/government/people"
     Then I should see "All ministers and senior officials on GOV.UK"

--- a/features/frontend.feature
+++ b/features/frontend.feature
@@ -75,10 +75,3 @@ Feature: Frontend
   Scenario: Check bank holidays JSON format is consistent
     When I request "/bank-holidays.json"
     Then JSON is returned
-
-  @local-network @aws @notreplatforming
-  Scenario: Healthcheck
-    Given I am testing "frontend" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/government_frontend.feature
+++ b/features/government_frontend.feature
@@ -64,10 +64,3 @@ Feature: Government Frontend
     When I visit "/log-in-file-self-assessment-tax-return/sign-in/prove-identity"
     When I choose "Register for Self Assessment"
     Then I should be redirected to "/register-for-self-assessment"
-
-  @local-network
-  Scenario: Healthcheck
-    Given I am testing "government-frontend" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/hmrc_manuals_api.feature
+++ b/features/hmrc_manuals_api.feature
@@ -1,7 +1,0 @@
-@app-hmrc-manuals-api @local-network
-Feature: HMRC Manuals API
-  Scenario: Healthcheck
-    Given I am testing "hmrc-manuals-api" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/imminence.feature
+++ b/features/imminence.feature
@@ -1,7 +1,0 @@
-@app-imminence @local-network
-Feature: Imminence
-  Scenario: Healthcheck
-    Given I am testing "imminence" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/info_frontend.feature
+++ b/features/info_frontend.feature
@@ -8,10 +8,3 @@ Feature: Info Frontend
   Scenario: Check the info page for the benefits mainstream browse page
     When I visit "/info/browse/benefits"
     Then I should see "Benefits"
-
-  @local-network
-  Scenario: Healthcheck
-    Given I am testing "info-frontend" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/licence_finder.feature
+++ b/features/licence_finder.feature
@@ -18,10 +18,3 @@ Feature: Licence Finder
   Scenario: Check licence finder returns licences
     When I visit "/licence-finder/licences?activities=149&location=wales&sectors=59"
     Then I should see "A premises licence is for carrying out 'licensable activities' at a particular venue"
-
-  @local-network
-  Scenario: Healthcheck
-    Given I am testing "licencefinder" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/link_checker_api.feature
+++ b/features/link_checker_api.feature
@@ -1,7 +1,0 @@
-@app-link-checker-api @local-network
-Feature: Link Checker API
-  Scenario: Healthcheck
-    Given I am testing "link-checker-api" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/local_links_manager.feature
+++ b/features/local_links_manager.feature
@@ -1,7 +1,0 @@
-@app-local-links-manager @local-network
-Feature: Local Links Manager
-  Scenario: Healthcheck
-    Given I am testing "local-links-manager" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/manuals_frontend.feature
+++ b/features/manuals_frontend.feature
@@ -10,10 +10,3 @@ Feature: Manuals Frontend
       | Path                                       |
       | /guidance/content-design/planning-content  |
       | /hmrc-internal-manuals/pensions-tax-manual |
-
-  @local-network
-  Scenario: Healthcheck
-    Given I am testing "manuals-frontend" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/manuals_publisher.feature
+++ b/features/manuals_publisher.feature
@@ -1,7 +1,0 @@
-@app-manuals-publisher @local-network
-Feature: Manuals Publisher
-  Scenario: Healthcheck
-    Given I am testing "manuals-publisher" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/maslow.feature
+++ b/features/maslow.feature
@@ -1,7 +1,0 @@
-@app-maslow @local-network
-Feature: Maslow
-  Scenario: Healthcheck
-    Given I am testing "maslow" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/publisher.feature
+++ b/features/publisher.feature
@@ -1,13 +1,6 @@
 @app-publisher @replatforming
 Feature: (Mainstream) Publisher
 
-  @local-network
-  Scenario: Healthcheck
-    Given I am testing "publisher" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""
-
   @notstaging @notproduction
   Scenario: Can create a draft place
     Given I have the smokey run identifier

--- a/features/publishing_api.feature
+++ b/features/publishing_api.feature
@@ -1,7 +1,0 @@
-@app-publishing-api @local-network
-Feature: Publishing API
-  Scenario: Healthcheck
-    Given I am testing "publishing-api" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/release.feature
+++ b/features/release.feature
@@ -1,7 +1,0 @@
-@app-release @local-network
-Feature: Release
-  Scenario: Healthcheck
-    Given I am testing "release" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/router_api.feature
+++ b/features/router_api.feature
@@ -1,7 +1,0 @@
-@app-router-api @local-network
-Feature: Router API
-  Scenario: Healthcheck
-    Given I am testing "router-api" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/search_admin.feature
+++ b/features/search_admin.feature
@@ -1,7 +1,0 @@
-@app-search-admin @local-network
-Feature: Search Admin
-  Scenario: Healthcheck
-    Given I am testing "search-admin" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/search_api.feature
+++ b/features/search_api.feature
@@ -6,10 +6,3 @@ Feature: Search API
     When I visit "/sitemap.xml"
     Then it should contain a link to at least one sitemap file
     And I should be able to get all the referenced sitemap files
-
-  @local-network
-  Scenario: Healthcheck
-    Given I am testing "search-api" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/service_manual_frontend.feature
+++ b/features/service_manual_frontend.feature
@@ -1,7 +1,0 @@
-@app-service-manual-frontend @local-network
-Feature: Service Manual Frontend
-  Scenario: Healthcheck
-    Given I am testing "service-manual-frontend" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/service_manual_publisher.feature
+++ b/features/service_manual_publisher.feature
@@ -1,7 +1,0 @@
-@app-service-manual-publisher @local-network
-Feature: Service Manual Publisher
-  Scenario: Healthcheck
-    Given I am testing "service-manual-publisher" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/short_url_manager.feature
+++ b/features/short_url_manager.feature
@@ -1,7 +1,0 @@
-@app-short-url-manager @local-network
-Feature: Short URL manager
-  Scenario: Healthcheck
-    Given I am testing "short-url-manager" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/sidekiq_monitoring.feature
+++ b/features/sidekiq_monitoring.feature
@@ -1,7 +1,0 @@
-@app-sidekiq-monitoring @local-network
-Feature: Sidekiq Monitoring
-  Scenario: Healthcheck
-    Given I am testing "sidekiq-monitoring" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/signon.feature
+++ b/features/signon.feature
@@ -9,10 +9,3 @@ Feature: Signon
   Scenario: Check signon cookies are marked as secure
     When I go to the "signon" landing page
     Then I should receive a "_signonotron2_session" cookie which is "secure"
-
-  @local-network
-  Scenario: Healthcheck
-    Given I am testing "signon" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/smartanswers.feature
+++ b/features/smartanswers.feature
@@ -90,10 +90,3 @@ Feature: Smart Answers
   Scenario: Check personal information is excluded from analytics data
     When I visit "/marriage-abroad/y"
     Then I should see that postcodes are stripped from analytics data
-
-  @local-network
-  Scenario: Healthcheck
-    Given I am testing "smartanswers" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/specialist_publisher.feature
+++ b/features/specialist_publisher.feature
@@ -1,7 +1,0 @@
-@app-specialist-publisher @local-network
-Feature: Specialist Publisher
-  Scenario: Healthcheck
-    Given I am testing "specialist-publisher" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/static.feature
+++ b/features/static.feature
@@ -1,7 +1,0 @@
-@app-static @local-network
-Feature: Static
-  Scenario: Healthcheck
-    Given I am testing "static" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/support.feature
+++ b/features/support.feature
@@ -1,7 +1,0 @@
-@app-support @local-network
-Feature: Support
-  Scenario: Healthcheck
-    Given I am testing "support" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/support_api.feature
+++ b/features/support_api.feature
@@ -1,7 +1,0 @@
-@app-support-api @local-network
-Feature: Support API
-  Scenario: Healthcheck
-    Given I am testing "support-api" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/transition.feature
+++ b/features/transition.feature
@@ -12,10 +12,3 @@ Feature: Transition
     When I request "/hosts.json" from the "transition" application
     Then I should get a 200 status code
      And I should see "www.direct.gov.uk"
-
-  @local-network
-  Scenario: Healthcheck
-    Given I am testing "transition" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/travel_advice_publisher.feature
+++ b/features/travel_advice_publisher.feature
@@ -1,7 +1,0 @@
-@app-travel-advice-publisher @local-network
-Feature: Travel Advice Publisher
-  Scenario: Healthcheck
-    Given I am testing "travel-advice-publisher" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""

--- a/features/whitehall.feature
+++ b/features/whitehall.feature
@@ -32,10 +32,3 @@ Feature: Whitehall
     When I request an attachment
     Then I should be redirected to the asset host
     And the attachment should be served successfully
-
-  @local-network
-  Scenario: Healthcheck
-    Given I am testing "whitehall-admin" internally
-    When I request "/healthcheck/ready"
-    Then JSON is returned
-    And I should see ""status":"ok""


### PR DESCRIPTION
https://trello.com/c/USH1B9K1/243-investigate-drying-up-deployment-healthchecks-out-of-smokey

Depends on: https://github.com/alphagov/govuk-puppet/pull/11258

These were only added to ensure we do a healthcheck as part of the
CD pipeline, which now does this directly [1].

Some healthchecks were added for apps that are not yet continuously
deployed [2]. I've confirmed this was just done for consistency and
we're not losing anything by removing them.

[1]: https://github.com/alphagov/govuk-puppet/pull/11258
[2]: https://github.com/alphagov/smokey/commit/cef08db214b6c454285894919f337a65304724fe#diff-ba6ff6af9a0f039605b8e6aaa23149c71f78760837cdb786001a055408cb22e1


## Testing

**You should manually test your PR before merging.**

This app doesn't have CI setup, and it would be misleading to do so:
the behaviour of the tests changes depending on the environment they
are run in. You should manually test in applicable environments,
until you are confident your change is not a breaking one.

Example steps to test in Integration:

- Click "Configure" for the [Smokey job][]
- Change the "Branch specifier" to the name of your branch
- Run a new build of the Smokey project and check the results

## Deployment

**You need to manually deploy your PR after merging.**

Steps to deploy a change:

- Run the [Smokey deploy job][] to deploy the [continuous Smokey loop][]
- Repeat this in Staging and Production

> The manual [Smokey job][] will pick up changes on `main` automatically. You only need to do a manual deployment for the [continuous Smokey loop][].

[Smokey job]: https://deploy.integration.publishing.service.gov.uk/job/Smokey/
[continuous Smokey loop]: https://github.com/alphagov/govuk-puppet/blob/master/modules/monitoring/templates/smokey-loop.conf
[Smokey deploy job]: https://deploy.integration.publishing.service.gov.uk/job/Smokey_Deploy/