### PR TITLE
Add sign-out check

### DIFF
--- a/features/support/account_dashboard.feature
+++ b/features/support/account_dashboard.feature
@@ -1,0 +1,9 @@
+@app-account-dashboard
+Feature: Account dashboard
+  Scenario: Check that the sign out links are available in the Accounts dashboard
+    Given I am testing through the full stack
+    And I force a varnish cache miss
+    When I visit "/account/home"
+    Then I should see "Sign in to your GOV.UK account"
+    When I sign in to my GOV.UK account
+    Then I should see "Sign out"

--- a/features/support/account_dashboard.feature
+++ b/features/support/account_dashboard.feature
@@ -1,5 +1,6 @@
 @app-account-dashboard
 Feature: Account dashboard
+  @notintegration
   Scenario: Check that the sign out links are available in the Accounts dashboard
     Given I am testing through the full stack
     And I force a varnish cache miss


### PR DESCRIPTION
To ensure any changes to menu headers on GOV.UK does not affect the sign-out links on GOV.UK Accounts.

## Build result

[This build on Staging passed](https://deploy.blue.staging.govuk.digital/job/Smokey/14275/console) (DI are currently testing on integration so the [account related smoke tests will fail there](https://github.com/alphagov/smokey/pull/853)).

## Deployment

**You need to manually deploy your PR after merging.**

Steps to deploy a change:

- Run the [Smokey deploy job][] to deploy the [continuous Smokey loop][]
- Repeat this in Staging and Production

> The manual [Smokey job][] will pick up changes on `main` automatically. You only need to do a manual deployment for the [continuous Smokey loop][].

[Smokey job]: https://deploy.integration.publishing.service.gov.uk/job/Smokey/
[continuous Smokey loop]: https://github.com/alphagov/govuk-puppet/blob/master/modules/monitoring/templates/smokey-loop.conf
[Smokey deploy job]: https://deploy.integration.publishing.service.gov.uk/job/Smokey_Deploy/
