### PR TITLE
Disable signing in test

### DIFF
--- a/features/account_api.feature
+++ b/features/account_api.feature
@@ -1,6 +1,6 @@
 @app-account-api
 Feature: Account API
-  @notintegration @app-frontend @app-collections @app-finder-frontend
+  @notintegration @notstaging @notproduction @app-frontend @app-collections @app-finder-frontend
   Scenario Outline: Signing in
     Given I am testing through the full stack
     And I force a varnish cache miss


### PR DESCRIPTION
We're disabling this test until we have credentials for a smoke test
user from Digital Identity, which we expect to have shortly after (but
not in time for) going live.

---

[Trello card](https://trello.com/c/oybk0a6f/1074-switch-over-production-to-use-di-auth)
