### PR TITLE
Remove Brexit email signups smoke test

### DIFF
--- a/features/brexit_check.feature
+++ b/features/brexit_check.feature
@@ -13,12 +13,3 @@ Feature: Get Ready for Brexit Check
     Then I should see the results page
     And I should see confirmation of my answers
     And I should see answers applicable to me
-
-  Scenario: Check that the Brexit checker can be subscribed to
-    When I visit "/transition-check/questions"
-    And I answer the nationality question
-    And I skip all other questions
-    And I click Subscribe link
-    And I do not want a GOV.UK account
-    And I click on the button "Subscribe"
-    Then I should enter the email subscription workflow

--- a/features/step_definitions/brexit_check_steps.rb
+++ b/features/step_definitions/brexit_check_steps.rb
@@ -31,18 +31,3 @@ end
 Then "I should see answers applicable to me" do
   expect(page).to have_content("Check if you need to apply for a new residence status")
 end
-
-When "I click Subscribe link" do
-  click_link "Subscribe to email updates about changes that may affect you and get a link to your results"
-end
-
-When "I do not want a GOV.UK account" do
-  click_link "Subscribe to get email updates"
-rescue Capybara::ElementNotFound
-  # link is only visible if accounts feature flag is turned on
-end
-
-Then "I should enter the email subscription workflow" do
-  path = "/email/subscriptions/new?topic_id=brexit-checklist-living-eu-nationality-uk"
-  page.has_current_path?(path)
-end


### PR DESCRIPTION
We don't show those links any more, because we're retiring the checker at the end of this month.

