### PR TITLE
Fix step in Get Involved test

### DIFF
--- a/features/step_definitions/get_involved_page_steps.rb
+++ b/features/step_definitions/get_involved_page_steps.rb
@@ -10,7 +10,7 @@ And /^it should be populated$/ do
 end
 
 When /^I click the next closing response link$/ do
-  within ".gem-c-inset-text > div > .govuk-link" do
+  within ".gem-c-inset-text" do
     click_link "Read and respond"
   end
 end
@@ -39,4 +39,3 @@ end
 And /^it should link to "(.*?)"$/ do |link|
   have_link(@linktext, :href => link)
 end
-


### PR DESCRIPTION
An unused div was removed from the Get Involved page in https://github.com/alphagov/government-frontend/pull/2296 in order to fix the `And it should be populated` step of this test.

However this now causes the `When I click the next closing response link` step to fail, as the div is no longer present.

Updating the test to match the government-frontend changes.

## Testing

**You should manually test your PR before merging.**

This app doesn't have CI setup, and it would be misleading to do so:
the behaviour of the tests changes depending on the environment they
are run in. You should manually test in applicable environments,
until you are confident your change is not a breaking one.

Example steps to test in Integration:

- Click "Configure" for the [Smokey job][]
- Change the "Branch specifier" to the name of your branch
- Run a new build of the Smokey project and check the results

## Deployment

**You need to manually deploy your PR after merging.**

Steps to deploy a change:

- Run the [Smokey deploy job][] to deploy the [continuous Smokey loop][]
- Repeat this in Staging and Production

> The manual [Smokey job][] will pick up changes on `main` automatically. You only need to do a manual deployment for the [continuous Smokey loop][].

[Smokey job]: https://deploy.integration.publishing.service.gov.uk/job/Smokey/
[continuous Smokey loop]: https://github.com/alphagov/govuk-puppet/blob/master/modules/monitoring/templates/smokey-loop.conf
[Smokey deploy job]: https://deploy.integration.publishing.service.gov.uk/job/Smokey_Deploy/
