### PR TITLE
Fix test for homepage

### DIFF
--- a/features/step_definitions/whitehall_steps.rb
+++ b/features/step_definitions/whitehall_steps.rb
@@ -1,6 +1,6 @@
-Then /^I should see the departments and policies section on the homepage$/ do
+Then /^I should see the Government activity section on the homepage$/ do
   visit_path "/"
-  assert page.first('#departments-and-policy')
+  assert page.first('.homepage-section__government-activity')
 end
 
 When(/^I request an attachment$/) do

--- a/features/whitehall.feature
+++ b/features/whitehall.feature
@@ -8,7 +8,7 @@ Feature: Whitehall
     And I force a varnish cache miss
 
   Scenario: Check the government publishing section on GOV.UK homepage
-    Then I should see the departments and policies section on the homepage
+    Then I should see the Government activity section on the homepage
 
   Scenario: Check feeds are available for documents
     Then I should be able to visit:


### PR DESCRIPTION
A redesign of the homepage shipped and removed the ID. We should try to avoid adding IDs just for tests if possible.

[Proof that this ran against the `new-homepage` branch and passed](https://deploy.integration.publishing.service.gov.uk/job/Smokey/35864/console).

## Testing

**You should manually test your PR before merging.**

This app doesn't have CI setup, and it would be misleading to do so:
the behaviour of the tests changes depending on the environment they
are run in. You should manually test in applicable environments,
until you are confident your change is not a breaking one.

Example steps to test in Integration:

- Click "Configure" for the [Smokey job][]
- Change the "Branch specifier" to the name of your branch
- Run a new build of the Smokey project and check the results

## Deployment

**You need to manually deploy your PR after merging.**

Steps to deploy a change:

- Run the [Smokey deploy job][] to deploy the [continuous Smokey loop][]
- Repeat this in Staging and Production

> The manual [Smokey job][] will pick up changes on `main` automatically. You only need to do a manual deployment for the [continuous Smokey loop][].

[Smokey job]: https://deploy.integration.publishing.service.gov.uk/job/Smokey/
[continuous Smokey loop]: https://github.com/alphagov/govuk-puppet/blob/master/modules/monitoring/templates/smokey-loop.conf
[Smokey deploy job]: https://deploy.integration.publishing.service.gov.uk/job/Smokey_Deploy/
