### PR TITLE
Update data_gov_uk feature to enable CKAN tests

### DIFF
--- a/features/data_gov_uk.feature
+++ b/features/data_gov_uk.feature
@@ -25,20 +25,20 @@ Feature: Data.gov.uk
     When I request "/dataset/lidar-composite-dtm-2017-1m.rdf"
     Then I should get a 200 status code
 
-  @notintegration @notstaging @notproduction
+  @notintegration @notstaging
   Scenario: Check CKAN loads correctly
     Given I am testing "ckan"
     When I request "/"
     Then I should see "Data publisher"
 
-  @notintegration @notstaging @notproduction
+  @notintegration @notstaging
   Scenario: Check CKAN action api's search works
     Given I am testing "ckan"
     When I request "/api/action/package_search?q=data"
     Then I should get a 200 status code
     And JSON is returned
 
-  @notintegration @notstaging @notproduction
+  @notintegration @notstaging
   Scenario: Check datasets sync between CKAN and Find
     Given I am testing "https://ckan.publishing.service.gov.uk"
     When I search for all datasets


### PR DESCRIPTION
## What

Enable CKAN smoke tests after upgrade complete.

## Reference 

https://trello.com/c/lkdK9QM2/71-do-the-postgres-upgrade-for-ckan