### PR TITLE
Enable tests for replatformed applications

### DIFF
--- a/features/assets.feature
+++ b/features/assets.feature
@@ -1,3 +1,4 @@
+@replatforming @app-asset-manager
 Feature: Assets
   Tests for assets and asset-manager, including draft assets which are behind
   signon.

--- a/features/collections.feature
+++ b/features/collections.feature
@@ -1,4 +1,4 @@
-@app-collections
+@app-collections @replatforming
 Feature: Collections
 
   Background:

--- a/features/contacts.feature
+++ b/features/contacts.feature
@@ -1,4 +1,4 @@
-@aws
+@aws @replatforming @app-contacts
 Feature: Contacts
 
   Background:

--- a/features/csv_preview.feature
+++ b/features/csv_preview.feature
@@ -1,3 +1,4 @@
+@replatforming @app-whitehall
 Feature: CSV preview
   Tests to check CSV previews in whitehall.
 

--- a/features/feedback.feature
+++ b/features/feedback.feature
@@ -1,3 +1,4 @@
+@replatforming @app-feedback
 Feature: Feedback
 
   Background:

--- a/features/finder_frontend.feature
+++ b/features/finder_frontend.feature
@@ -1,4 +1,4 @@
-@aws @app-finder-frontend
+@aws @app-finder-frontend @replatforming
 Feature: Finder Frontend
   These are pages that let you search within a set of similar looking documents.
 

--- a/features/foreign_travel_advice.feature
+++ b/features/foreign_travel_advice.feature
@@ -1,3 +1,4 @@
+@replatforming
 Feature: Foreign Travel Advice
 
   Background:

--- a/features/gov_uk.feature
+++ b/features/gov_uk.feature
@@ -1,3 +1,4 @@
+@replatforming
 Feature: Core GOV.UK behaviour
   Tests for core URL and link behaviour on GOV.UK.
 

--- a/features/government_frontend.feature
+++ b/features/government_frontend.feature
@@ -1,4 +1,4 @@
-@aws @app-government-frontend
+@aws @app-government-frontend @replatforming
 Feature: Government Frontend
 
   Background:

--- a/features/info_frontend.feature
+++ b/features/info_frontend.feature
@@ -1,4 +1,4 @@
-@app-info-frontend
+@app-info-frontend @replatforming
 Feature: Info Frontend
 
   Background:

--- a/features/licence_finder.feature
+++ b/features/licence_finder.feature
@@ -1,4 +1,4 @@
-@app-licencefinder
+@app-licencefinder @replatforming
 Feature: Licence Finder
 
   Background:

--- a/features/licensing.feature
+++ b/features/licensing.feature
@@ -1,4 +1,4 @@
-@app-licensing
+@app-licensing @replatforming
 Feature: Licensing
   Tests for the Licensify app.
 

--- a/features/manuals_frontend.feature
+++ b/features/manuals_frontend.feature
@@ -1,4 +1,4 @@
-@app-manuals-frontend
+@app-manuals-frontend @replatforming
 Feature: Manuals Frontend
 
   Background:

--- a/features/public_api.feature
+++ b/features/public_api.feature
@@ -1,3 +1,4 @@
+@replatforming
 Feature: Public API
 
   Background:

--- a/features/publisher.feature
+++ b/features/publisher.feature
@@ -1,4 +1,4 @@
-@app-publisher @replatforming
+@app-publisher
 Feature: (Mainstream) Publisher
 
   @notstaging @notproduction

--- a/features/router.feature
+++ b/features/router.feature
@@ -1,4 +1,4 @@
-@aws
+@aws @replatforming @app-router
 Feature: Router
 
   Background:

--- a/features/signon.feature
+++ b/features/signon.feature
@@ -1,4 +1,4 @@
-@app-signon @replatforming
+@app-signon
 Feature: Signon
   Tests for signon, the GOV.UK single sign-on service.
 

--- a/features/smartanswers.feature
+++ b/features/smartanswers.feature
@@ -1,4 +1,4 @@
-@aws @app-smartanswers
+@aws @app-smartanswers @replatforming
 Feature: Smart Answers
 
   Background:

--- a/features/whitehall.feature
+++ b/features/whitehall.feature
@@ -1,4 +1,4 @@
-@aws
+@aws @replatforming @app-whitehall
 Feature: Whitehall
   Tests for the whitehall application that powers some pages under
   www.gov.uk/government and www.gov.uk/world.


### PR DESCRIPTION
These tests should pass now that the apps are running in Kubernetes (`replatforming` tag). I removed this tag from some apps which we're not going to be running in a passing state for the next milestone of our project.

I've also added in the `app-<appname>` tag to some apps which were missing it.