### PR TITLE
Fix government-frontend test by normalising paths

### DIFF
--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -228,10 +228,10 @@ end
 Then /^I should be at a location path of "(.*)"$/ do |location_path|
   if @response
     uri = URI(@response['location'])
-    expect(uri.path).to eq(location_path)
+    expect(normalise_path(uri.path)).to eq(location_path)
   else
     uri = URI(page.current_url)
-    expect(uri.path).to eq(location_path)
+    expect(normalise_path(uri.path)).to eq(location_path)
   end
 end
 
@@ -331,4 +331,9 @@ def get_status_code
   $proxy.new_har
   yield
   $proxy.har.entries.first.response.status
+end
+
+def normalise_path(path_str)
+  return path_str if path_str == "/"
+  path_str.chomp('/') # strip trailing slash
 end


### PR DESCRIPTION
The test at government_frontend.feature:78 relies on trailing slashes ("/")
being removed. This currently is done by Fastly VCL at
https://github.com/alphagov/govuk-cdn-config/blob/413abc509daea829d2eb8e125de711819b4d7409/vcl_templates/www.vcl.erb#L265

However, in cases where the Fastly CDN isn't fronting the site, we want
this test to still pass, so normalising the path by removing trailing slashes
here will make this more robust.

Tested:

```
ENVIRONMENT=production bundle exec cucumber features/government_frontend.feature:78

ENVIRONMENT=integration AUTH_USERNAME=<insert_username> AUTH_PASSWORD=<insert_pass> GOVUK_WEBSITE_ROOT="https://www-origin.eks.integration.govuk.digital/"  bundle exec cucumber features/government_frontend.feature:78
```

## Testing

**You should manually test your PR before merging.**

This app doesn't have CI setup, and it would be misleading to do so:
the behaviour of the tests changes depending on the environment they
are run in. You should manually test in applicable environments,
until you are confident your change is not a breaking one.

Example steps to test in Integration:

- Click "Configure" for the [Smokey job][]
- Change the "Branch specifier" to the name of your branch
- Run a new build of the Smokey project and check the results

## Deployment

**You need to manually deploy your PR after merging.**

Steps to deploy a change:

- Run the [Smokey deploy job][] to deploy the [continuous Smokey loop][]
- Repeat this in Staging and Production

> The manual [Smokey job][] will pick up changes on `main` automatically. You only need to do a manual deployment for the [continuous Smokey loop][].

[Smokey job]: https://deploy.integration.publishing.service.gov.uk/job/Smokey/
[continuous Smokey loop]: https://github.com/alphagov/govuk-puppet/blob/master/modules/monitoring/templates/smokey-loop.conf
[Smokey deploy job]: https://deploy.integration.publishing.service.gov.uk/job/Smokey_Deploy/
