### PR TITLE
Remove `webdrivers` gem dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,6 @@ updates:
     versions:
     - 3.35.1
     - 3.35.3
-  - dependency-name: webdrivers
-    versions:
-    - 4.5.0
   - dependency-name: minitest
     versions:
     - 5.14.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,21 +8,17 @@ RUN mkdir $APP_HOME
 
 ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE 1
 
-# Install Google Chrome
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
-RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
-RUN apt-get update && apt-get install -y google-chrome-stable && apt-get clean
+# Install Chromium and ChromiumDriver
+RUN apt-get update -qq && apt-get install -y chromium chromium-driver && apt-get clean
 
 WORKDIR $APP_HOME
 ADD Gemfile* $APP_HOME/
 ADD .ruby-version $APP_HOME/
 RUN bundle install
-ADD Rakefile $APP_HOME
-RUN bundle exec rake webdrivers:chromedriver:update
 
 ADD . $APP_HOME
 
-# Allow root user to run Chrome in Docker
+# Allow root user to run Chromium in Docker
 ENV NO_SANDBOX 1
 
 # Remove Cucumber advert

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,6 @@ gem "rake", "~> 13.0"
 gem "rest-client", "~> 2"
 gem "rspec", "~> 3"
 gem "selenium-webdriver", "~> 3"
-gem "webdrivers", "~> 4.6"
 
 group :development do
   gem "pry-byebug", "~> 3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,10 +147,6 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.7)
-    webdrivers (4.6.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (>= 3.0, < 4.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.4.2)
@@ -173,7 +169,6 @@ DEPENDENCIES
   rest-client (~> 2)
   rspec (~> 3)
   selenium-webdriver (~> 3)
-  webdrivers (~> 4.6)
 
 BUNDLED WITH
    2.1.4

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,0 @@
-require 'webdrivers'
-load 'webdrivers/Rakefile'

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -7,7 +7,6 @@ require 'ptools'
 require 'plek'
 require 'selenium-webdriver'
 require 'uri'
-require 'webdrivers'
 
 # Set up environment
 case ENV["ENVIRONMENT"]


### PR DESCRIPTION
The `webdrivers` gem is no longer required because supported GOV.UK runtime environments now supply a ChromeDriver for use by Selenium – e.g. govuk-docker and Jenkins CI workers.

Smokey also runs as a containerised application in the new EKS hosting environment that's currently being built. For that, I've updated the Dockerfile in this repository to install Chromium and a compatible ChromeDriver from the default package repo. That way, we'll be guaranteed to have a compatible browser and webdriver installed, and it should be possible for developers to run it on an M1 MacBook because Chromium supports both AMD64 and ARM64.

## Testing

✅ This has been tested in integration.

Output of the test run can be seen here:
https://deploy.integration.publishing.service.gov.uk/job/Smokey/38547/

## Deployment

**You need to manually deploy your PR after merging.**

Steps to deploy a change:

- Run the [Smokey deploy job][] to deploy the [continuous Smokey loop][]
- Repeat this in Staging and Production

> The manual [Smokey job][] will pick up changes on `main` automatically. You only need to do a manual deployment for the [continuous Smokey loop][].

[Smokey job]: https://deploy.integration.publishing.service.gov.uk/job/Smokey/
[continuous Smokey loop]: https://github.com/alphagov/govuk-puppet/blob/master/modules/monitoring/templates/smokey-loop.conf
[Smokey deploy job]: https://deploy.integration.publishing.service.gov.uk/job/Smokey_Deploy/
