### PR TITLE
Fix test for Collections Publisher

### DIFF
--- a/features/publishing_tools.feature
+++ b/features/publishing_tools.feature
@@ -6,7 +6,7 @@ Feature: Publishing Tools
     And I try to login as a user
     And I go to the "collections-publisher" landing page
     Then I should see "Collections Publisher"
-    And I should see "Sign out"
+    And I should see "Log out"
     And I should see "Mainstream browse pages"
     And I should see "Add a mainstream browse page"
 


### PR DESCRIPTION
The test for Collections Publisher looks for the text 'Sign out' but [the application uses the word 'Log out'](https://github.com/alphagov/collections-publisher/blob/fd11a00e990750c94caf297b0ac9093b30caf086/app/views/layouts/admin_layout.html.erb#L39).