### PR TITLE
Remove redundant "_aws" environments

### DIFF
--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -2,5 +2,3 @@ default: -t "not @benchmarking" -t "not @pending" -t "not @local-network" -t "no
 integration: -t "not @pending" -t "not @notintegration" --publish-quiet
 staging: -t "not @pending" -t "not @notstaging" --publish-quiet
 production: -t "not @pending" -t "not @notproduction" --publish-quiet
-staging_aws: -t "not @pending" -t "not @notstaging" --publish-quiet
-production_aws: -t "not @pending" -t "not @notproduction" --publish-quiet

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -13,14 +13,14 @@ case ENV["ENVIRONMENT"]
 when "integration"
   ENV["GOVUK_APP_DOMAIN"] ||= "integration.publishing.service.gov.uk"
   ENV["GOVUK_WEBSITE_ROOT"] ||= "https://www.integration.publishing.service.gov.uk"
-when "staging", "staging_aws"
+when "staging"
   ENV["GOVUK_APP_DOMAIN"] ||= "staging.publishing.service.gov.uk"
   ENV["GOVUK_WEBSITE_ROOT"] ||= "https://www.staging.publishing.service.gov.uk"
-when "production", "production_aws"
+when "production"
   ENV["GOVUK_APP_DOMAIN"] ||= "publishing.service.gov.uk"
   ENV["GOVUK_WEBSITE_ROOT"] ||= "https://www.gov.uk"
 else
-  raise "ENVIRONMENT should be one of integration, staging, staging_aws, production or production_aws"
+  raise "ENVIRONMENT should be one of integration, staging, production"
 end
 
 # Set up basic URLs


### PR DESCRIPTION
https://github.com/alphagov/govuk-puppet/pull/11603

Follow-on from: [^1].

[^1]: https://github.com/alphagov/govuk-puppet/pull/11603


## Testing

**You should manually test your PR before merging.**

This app doesn't have CI setup, and it would be misleading to do so:
the behaviour of the tests changes depending on the environment they
are run in. You should manually test in applicable environments,
until you are confident your change is not a breaking one.

Example steps to test in Integration:

- Click "Configure" for the [Smokey job][]
- Change the "Branch specifier" to the name of your branch
- Run a new build of the Smokey project and check the results

## Deployment

**You need to manually deploy your PR after merging.**

Steps to deploy a change:

- Run the [Smokey deploy job][] to deploy the [continuous Smokey loop][]
- Repeat this in Staging and Production

> The manual [Smokey job][] will pick up changes on `main` automatically. You only need to do a manual deployment for the [continuous Smokey loop][].

[Smokey job]: https://deploy.integration.publishing.service.gov.uk/job/Smokey/
[continuous Smokey loop]: https://github.com/alphagov/govuk-puppet/blob/master/modules/monitoring/templates/smokey-loop.conf
[Smokey deploy job]: https://deploy.integration.publishing.service.gov.uk/job/Smokey_Deploy/