### PR TITLE
Re eable smokey tests

### DIFF
--- a/features/frontend.feature
+++ b/features/frontend.feature
@@ -5,12 +5,10 @@ Feature: Frontend
     Given I am testing through the full stack
     And I force a varnish cache miss
 
-  @notreplatforming
   Scenario: Check robots.txt
     When I request "/robots.txt"
     Then I should see "User-agent:"
 
-  @notreplatforming
   Scenario: Check transactions load
     When I visit "/apply-renew-passport"
     Then I should see "UK passport"
@@ -28,12 +26,10 @@ Feature: Frontend
     When I visit "/"
     Then the page view should be tracked
 
-  @notreplatforming
   Scenario: Check 404 page content type and charset
     When I visit a non-existent page
     Then I should get a "Content-Type" header of "text/html; charset=utf-8"
 
-  @notreplatforming
   Scenario: Check licences load
     When I visit "/busking-licence"
     Then I should see "Busking licence"
@@ -41,14 +37,12 @@ Feature: Frontend
     When I try to post to "/busking-licence" with "postcode=E20+2ST"
     Then I should see "Busking licence"
 
-  @notreplatforming
   Scenario: Check local transactions load
     When I visit "/pay-council-tax"
     Then I should see "Pay your Council Tax"
     When I try to post to "/pay-council-tax" with "postcode=WC2B+6SE"
     Then I should see "Camden"
 
-  @notreplatforming
   Scenario: Check electoral pages load
     When I visit "/contact-electoral-registration-office"
     Then I should see "Electoral Registration Office"
@@ -57,14 +51,12 @@ Feature: Frontend
     When I visit "/contact-electoral-registration-office?postcode=WV148TU"
     Then I should see "Choose your address"
 
-  @notreplatforming
   Scenario: Check "find my nearest" returns results
     When I visit "/ukonline-centre-internet-access-computer-training"
     And I should see "Online Centres Network"
     When I try to post to "/ukonline-centre-internet-access-computer-training" with "postcode=WC2B+6NH"
     Then I should see "Holborn Library"
 
-  @notreplatforming
   Scenario: Check redirects work
     When I visit "/workplacepensions"
     Then I should be at a location path of "/workplace-pensions"

--- a/features/licensing.feature
+++ b/features/licensing.feature
@@ -13,6 +13,7 @@ Feature: Licensing
       | /apply-for-a-licence/test-licence/westminster/apply-1/form        |
       | /apply-for-a-licence/forms/bury/test-licence/9999-7-1,0-1         |
 
+  @notreplatforming
   Scenario: Check signing in to licensify-admin
      When I try to login as a user
       And I login to Licensify


### PR DESCRIPTION
- re-enable some smokey tests for frontend in EKS now that the frontend should be fulling working there.
- disable the test for licensify-admin in EKS since licensify is remaining in EC2 for now.
