### PR TITLE
Trial alerting on scenario failures in Sentry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem "rake", "~> 13.0"
 gem "rest-client", "~> 2"
 gem "rspec", "~> 3"
 gem "selenium-webdriver", "~> 3"
+gem "sentry-ruby"
 
 group :development do
   gem "pry-byebug", "~> 3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,6 +138,11 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    sentry-ruby (5.2.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      sentry-ruby-core (= 5.2.1)
+    sentry-ruby-core (5.2.1)
+      concurrent-ruby
     sys-uname (1.2.2)
       ffi (~> 1.1)
     thor (1.1.0)
@@ -169,6 +174,7 @@ DEPENDENCIES
   rest-client (~> 2)
   rspec (~> 3)
   selenium-webdriver (~> 3)
+  sentry-ruby
 
 BUNDLED WITH
    2.1.4

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,3 +1,5 @@
+require 'sentry-ruby'
+
 Before do
   # Clear the request log so that tests only see their requests.
   $proxy.new_har(capture_binary_content: true)
@@ -12,6 +14,36 @@ After do
       flush_and_check_errors
     rescue Capybara::Chromedriver::Logger::JsError => e
       puts "Detected JS error, but ignored it. #{e}"
+    end
+  end
+end
+
+After do |scenario|
+  Sentry.init do |config|
+    config.dsn = 'abc123'
+    config.send_modules = false # list of installed gems
+  end
+
+  if scenario.exception
+    Sentry.with_scope do |scope|
+      scope.set_tags(
+        'cucumber.scenario': scenario.name,
+        'cucumber.failing_step': scenario.test_steps[-1].text
+      )
+
+      message = <<~HERE
+        #{scenario.location.file}
+
+        \t#{scenario.test_steps.reject(&:hook?).map(&:text).join("\n\t")}
+
+        #{scenario.exception.to_s}
+      HERE
+
+      Sentry.capture_message(
+        message,
+        fingerprint: [scenario.location.file],
+        backtrace: scenario.exception.backtrace,
+      )
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/LnE7dZdj/257-survey-actions-for-smokey

Problem: we think Smokey is flakey but lack the data on what / why.
Flakiness was a common issue identified in the last dev tools survey.
We need to understand the flakiness if we want to reduce it.

Possible solutions:

- Metrics in Grafana*. This would help us understand what is failing
but not why, which isn't very useful overall.

- Logs in Kibana**. This would help us understand why a scenario is
failing but lacks good high level analysis tools.

- Sentry (this PR).

If we think of the Smokey Loop as another app - it does run like an
app - then Sentry is a potential option that combines the "what" and
the "why" data to help us understand what is flakey.

What would it look like in Sentry?
=========================

From running Smokey locally in a test Sentry project.

Issues page
<img width="1257" alt="Screenshot 2022-04-05 at 18 11 27" src="https://user-images.githubusercontent.com/9029009/161812598-d77b1044-5f15-493e-a273-7057e606db89.png">

Example issue
<img width="950" alt="Screenshot 2022-04-05 at 18 15 41" src="https://user-images.githubusercontent.com/9029009/161813310-7f2b3eb7-d182-4c75-88de-9bf1d720e3d2.png">

How to structure the events
===========================

Unlike a normal app, we probably don't want distinct events for every
scenario or type of error, as this makes the main incident page long
or harder to understand at a glance. Instead, I suggest we group each
error by feature by forcing this as the "fingerprint".

Despite the forced grouping, we can add some "tags" to each event to
support more fine-grained searches. This is useful if:

- Multiple scenarios have the same step and are failing for the same
reason.

- Multiple scenarios in the same feature are failing and we want to
isolate each one.

What is the next step for this?
===============================

- Decide if this is a direction we want to go (pros / cons).
- Double check if Sentry rate limiting is a concern.
- Setup a real project for Smokey in Sentry.
- Update Puppet to populate the SENTRY_DSN env var for Smokey Loop.
- Let events accumulate for a week to see (at last) what is flakey.

Notes about Grafana / Kibana
============================

*We do have metrics from Icinga about Smokey Loop failures [^1], but
the metric only updates when Icinga's state changes e.g. when alerts
go from "OK" to "CRITICAL". This is useful if a scenario is flapping
a lot, but not if it has a sustained failure.

**We do have logs in Kibana about Smokey Loop failures [^2], but the
logs come from syslog and aren't readable. It would be hard to make
a log that was readable but also indexed in such a way as to give a
high level picture - for monitoring.

Ideas and tweaks from PR discussion below
=================================

- Add GitHub link to the scenario.
- Ignore errors during [data sync period](https://github.com/alphagov/govuk_app_config/blob/87e445eccee5fba2449a170d5ba628e8a380fcb8/lib/govuk_app_config/govuk_error/configuration.rb#L11).

[^1]: https://grafana.integration.publishing.service.gov.uk/dashboard/file/icinga_alerts.json?orgId=1
[^2]: https://kibana.logit.io/s/d4dba58d-d7be-4bca-81e7-034e14b8b9ee/app/kibana#/discover?_g=()&_a=(columns:!(message),index:'*-*',interval:auto,query:(language:lucene,query:'failed%20AND%20skipped'),sort:!('@timestamp',desc))