### PR TITLE
Remove redundant basic auth feature

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,6 @@ STOPSIGNAL SIGINT
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 # Users of the image are expected to override the default CMD and set env vars
-# ENVIRONMENT, AUTH_USERNAME, AUTH_PASSWORD, and a profile flag.
+# ENVIRONMENT and a profile flag.
 
 CMD ["bundle", "exec", "cucumber", "--strict-undefined", "-t 'not @benchmarking'"]

--- a/README.md
+++ b/README.md
@@ -25,19 +25,17 @@ The tests require additional configuration to run successfully on a local machin
 ENVIRONMENT=integration \
 SIGNON_EMAIL="<email-address>" \
 SIGNON_PASSWORD="<password>" \
-AUTH_USERNAME="<username>" \
-AUTH_PASSWORD="<password>" \
 bundle exec cucumber
 ```
 
 You can use the following environment variables to configure the tests:
 
 * `ENVIRONMENT`: used to set environment variables for [Plek](https://github.com/alphagov/plek)
-* `AUTH_USERNAME`: the HTTP Basic auth username (required for Integration)
-* `AUTH_PASSWORD`: the HTTP Basic auth password (required for Integration)
 * `SIGNON_EMAIL`: email address of a user with a Signon account in the environment the tests are being run in
 * `SIGNON_PASSWORD`: password of a user with a Signon account in the environment the tests are being run in
 * `RATE_LIMIT_TOKEN`: a token used to bypass the default rate limiting
+
+**Note: you will need to be connected to the VPN to test against Integration or Staging.**
 
 ## Layout
 

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -25,7 +25,6 @@ Given /^I am testing through the full stack$/ do
   Capybara.app_host = @host
   @bypass_varnish = false
   @bypass_varnish_for_search = false
-  @authenticated = true
 end
 
 Given /^I force a varnish cache miss$/ do
@@ -34,10 +33,6 @@ end
 
 Given /^I force a varnish cache miss for search$/ do
   @bypass_varnish_for_search = true
-end
-
-Given /^I am not an authenticated user$/ do
-  @authenticated = false
 end
 
 Given /^I am an authenticated API client$/ do

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -46,12 +46,8 @@ if ENV["RATE_LIMIT_TOKEN"]
   proxy.header({ "Rate-Limit-Token" => ENV["RATE_LIMIT_TOKEN"] })
 end
 
-if ENV["AUTH_USERNAME"] && ENV["AUTH_PASSWORD"]
-  proxy.basic_authentication(
-    URI.parse(ENV["GOVUK_WEBSITE_ROOT"]).host,
-    ENV["AUTH_USERNAME"],
-    ENV["AUTH_PASSWORD"],
-  )
+
+if ENV["ACCOUNT_AUTH_USERNAME"] && ENV["ACCOUNT_AUTH_PASSWORD"]
   proxy.basic_authentication(
     "www.account.staging.publishing.service.gov.uk",
     ENV["ACCOUNT_AUTH_USERNAME"],


### PR DESCRIPTION
https://trello.com/c/DL5omRGP/230-smokey-needs-java-and-a-glitchy-proxy-server-to-run-tests

This isn't necessary since we switched to testing via the CDN [^1].
Integration Fastly doesn't require basic auth on the VPN [^2].

Tested and works with [the Smokey Jenkins job in Integration](https://deploy.integration.publishing.service.gov.uk/job/Smokey/39351/console) ✅.
Tested and works with Smokey Loop in Integration ✅.
Tested locally and works on VPN ✅.

Worth noting that gov_uk.feature doesn't pass locally even with basic 
auth - it requires a VPN connection.

[^1]: https://github.com/alphagov/smokey/commit/2c10c7541c98ebe450cd058813e0792954f4e5cf#diff-3c1d97c5f1fa7ca90a4a96df18478ce19fe4d3a8dbaa3914ccc6ec6c43e81cbeR18
[^2]: https://github.com/alphagov/govuk-cdn-config/blob/master/vcl_templates/www.vcl.erb#L197