### PR TITLE
Try removing rate limit bypass token everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ You can use the following environment variables to configure the tests:
 * `ENVIRONMENT`: used to set environment variables for [Plek](https://github.com/alphagov/plek)
 * `SIGNON_EMAIL`: email address of a user with a Signon account in the environment the tests are being run in
 * `SIGNON_PASSWORD`: password of a user with a Signon account in the environment the tests are being run in
-* `RATE_LIMIT_TOKEN`: a token used to bypass the default rate limiting
 
 **Note: you will need to be connected to the VPN to test against Integration or Staging.**
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -42,11 +42,6 @@ proxy = server.create_proxy
 $proxy = proxy
 
 # Add request headers
-if ENV["RATE_LIMIT_TOKEN"]
-  proxy.header({ "Rate-Limit-Token" => ENV["RATE_LIMIT_TOKEN"] })
-end
-
-
 if ENV["ACCOUNT_AUTH_USERNAME"] && ENV["ACCOUNT_AUTH_PASSWORD"]
   proxy.basic_authentication(
     "www.account.staging.publishing.service.gov.uk",

--- a/features/support/http_requests.rb
+++ b/features/support/http_requests.rb
@@ -90,10 +90,6 @@ def do_http_request(url, method = :get, options = {}, &block)
   if options[:cookies]
     headers["Cookie"] = options[:cookies].map { |k, v| "#{k}=#{v}" }.join("; ")
   end
-  rate_limit_token = ENV['RATE_LIMIT_TOKEN']
-  if rate_limit_token
-    headers["Rate-Limit-Token"] = rate_limit_token
-  end
 
   request_options = {
     url: url,


### PR DESCRIPTION
https://trello.com/c/DL5omRGP/230-smokey-needs-java-and-a-glitchy-proxy-server-to-run-tests

This is potentially unnecessary given many of the tests now probe
via the CDN, and the low frequency these run at in general means
it's highly unlikely it will trip any reasonable rate limiting at
our origin servers or our publishing backend servers.

Tested and works in Integration (Jenkins Job) ✅
Tested and works in Integration (Smokey Loop) ✅ 

There's still a risk that this will cause an issue in another environment 
over a sustained period, but I think it's worth the risk to merge and 
revert if we find this happens in practice.