### PR TITLE
Add guidance for installing Ruby / Chromedriver

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,30 @@ The tests also run in [a continuous Smokey loop](https://github.com/alphagov/gov
 
 ## Installation
 
+### chromedriver
+
+You will need to have the Chrome browser installed on your machine, as well as the `chromedriver` package, which Selenium uses to communicate with Chrome.
+
+```
+brew install chromedriver
+
+# trust chromedriver (in Preferences > Security)
+xattr -d com.apple.quarantine $(which chromedriver)
+```
+
+As your version of Chrome updates, you may need to run `brew upgrade chromedriver`, as the package will only work with a fairly narrow range of Chrome versions.
+
+### Ruby
+
+Install [Rbenv](https://github.com/rbenv/rbenv) and then the required version of Ruby:
+
+```
+rbenv install
+gem install bundler
+```
+
+Finally, install the required gems:
+
 ```
 bundle install
 ```


### PR DESCRIPTION
This repo isn't covered by GOV.UK Docker, which takes care of both
of these setup concerns. My quick attempt at adding it was partly
successful, but when running the tests the latter ~half fail e.g.

    Then I should be able to visit:                 # features/step_definitions/smokey_steps.rb:162
      | Path                           |
      | /government/announcements.atom |
      | /government/statistics.atom  |
      invalid session id (Selenium::WebDriver::Error::InvalidSessionIdError)

For now it makes sense to at least offer guidance on running this repo
natively. Hopefully we can add it to GOV.UK Docker in future though.