### PR TITLE
Remove redundant "puts" for async JS errors

### DIFF
--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -14,7 +14,6 @@ After do
     .select { |log| log.level == 'SEVERE' }
     .map(&:message)
 
-  errors.each(&$stderr.puts)
   next unless errors.any?
   messages = errors.join("\n")
 


### PR DESCRIPTION
This is a relic from the gem we used to use [^1]. It doesn't work,
and fixing it just leads to duplicated output, which is what we got
with the old gem* but isn't something we need / want to keep - the
"raise" causes output on $stdout anyway, so there's no regression.

*Tested by going back to d46d928 and creating a fake JS error.

[^1]: https://github.com/alphagov/smokey/pull/933/files#diff-2f93a30bfa1ff6bdac9d65681869e6395ec22b89c7560730cbe195d77961673cL22


## Testing

**You should manually test your PR before merging.**

See https://github.com/alphagov/smokey/blob/main/docs/deployment.md