### PR TITLE
Include scenario in Sentry issue fingerprint

### DIFF
--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -36,20 +36,17 @@ end
 def capture_error(scenario, exception)
   Sentry.with_scope do |scope|
     # First line of the message becomes the issue title, which
-    # we want to be the feature (file) to support drilling down.
-    message = scenario.location.file + "\n\n" + exception.to_s
+    # we want to be the feature / scenario.
+    message = "#{scenario.location.file} (#{scenario.name})"
+    message += "\n\n" + exception.to_s
 
-    # Adding the scenario supports further drill down within the
-    # scenarios for a particular apps / functionality.
-    scope.set_tags('cucumber.scenario': scenario.name)
-
-    # Using the feature (file) as the fingerprint means we only
-    # get one issue per feature, keeping the dashboard simple.
+    # Using the feature / scenario as the fingerprint means we only
+    # get one issue per scenario, keeping the dashboard simple.
     # The hint is used by govuk_app_config, which will emit stats
     # for the error class, in addition to what we get in Sentry.
     Sentry.capture_message(
       message,
-      fingerprint: [scenario.location.file],
+      fingerprint: [scenario.location.file, scenario.name],
       backtrace: exception.backtrace,
       hint: { exception: exception }
     )


### PR DESCRIPTION
https://trello.com/c/LnE7dZdj/257-survey-actions-for-smokey

The Sentry plan we use doesn't provide any export / reporting tools,
which makes it hard to analyse failures of unrelated scenarios in the
same feature. Including the scenario makes analysis practical within
Sentry itself, assuming most scenarios fail for the same reason each
time. Note that this may lead to lots of issues if entire apps fail,
but that arguably reflects their flakiness being a priority to fix.


## Testing

**You should manually test your PR before merging.**

See https://github.com/alphagov/smokey/blob/main/docs/deployment.md