### PR TITLE
Fix cors problem reinstate rate limit support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "plek", "~> 4"
 gem "rest-client", "~> 2"
 gem "rspec", "~> 3"
 gem "selenium-webdriver", "~> 4"
+gem "selenium-devtools"
 
 group :development do
   gem "pry-byebug", "~> 3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,6 +163,8 @@ GEM
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
     rubyzip (2.3.2)
+    selenium-devtools (0.101.0)
+      websocket (~> 1.0)
     selenium-webdriver (4.1.0)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -189,6 +191,7 @@ GEM
       kgio (~> 2.6)
       raindrops (~> 0.7)
     webrick (1.7.0)
+    websocket (1.2.9)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.4.2)
@@ -206,6 +209,7 @@ DEPENDENCIES
   pry-byebug (~> 3)
   rest-client (~> 2)
   rspec (~> 3)
+  selenium-devtools
   selenium-webdriver (~> 4)
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -33,12 +33,14 @@ You can use the following environment variables to configure the tests:
 * `ENVIRONMENT`: controls domains returned by [Plek](https://github.com/alphagov/plek) (see [env.rb](https://github.com/alphagov/smokey/blob/19c21ac4be3f67ef994f327670121209c8632c0d/features/support/env.rb#L9-L21))
 * `SIGNON_EMAIL`: email of a Signon user in $ENVIRONMENT
 * `SIGNON_PASSWORD`: password of a Signon user in $ENVIRONMENT
+* `RATE_LIMIT_TOKEN`: (optional) a token used to bypass rate limiting if present on apps.
 
 You can try using your own Signon account, but this won't work if you have Multi Factor Auth enabled. Another option is to use the credentials for the Smokey test user in `govuk-secrets/puppet_aws`:
 
 ```
 bundle exec rake 'eyaml:decrypt_value[integration,smokey_signon_email]'
 bundle exec rake 'eyaml:decrypt_value[integration,smokey_signon_password]'
+bundle exec rake 'eyaml:decrypt_value[integration,smokey_rate_limit_token]'
 ```
 
 ## Further documentation

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -46,7 +46,19 @@ Capybara.register_driver :headless_chrome do |app|
     capabilities: [capabilities, options]
   }
 
-  Capybara::Selenium::Driver.new(app, browser_options)
+  driver = Capybara::Selenium::Driver.new(app, browser_options)
+
+  if ENV["RATE_LIMIT_TOKEN"]
+    driver.browser.devtools.send_cmd(
+      'Network.enable'
+    )
+    driver.browser.devtools.send_cmd(
+      'Network.setExtraHTTPHeaders',
+      headers: { 'Rate-Limit-Token': ENV["RATE_LIMIT_TOKEN"] }
+    )
+  end
+
+  driver
 end
 
 Capybara.default_driver = :headless_chrome

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -37,6 +37,7 @@ Capybara.register_driver :headless_chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new
   options.add_argument("--headless")
   options.add_argument("--disable-gpu")
+  options.add_argument("--disable-web-security")
   options.add_argument("--disable-xss-auditor")
   options.add_argument("--user-agent=Smokey\ Test\ \/\ Ruby")
   options.add_argument("--no-sandbox") if ENV.key?("NO_SANDBOX")


### PR DESCRIPTION
Reinstates the rate limit header support, with web security turned off to avoid CORS errors.

When you make a cross origin request, there are certain headers you’re
allowed to send with it, in an allowlist. If you send any other header,
the system assumes you’re trying to authenticate yourself somehow or do
other dangerous cross-origin things. Our our rate-limit-header is treated
like that, so we'll get CORS errors. They're not important, so we just
turn off web security to remove them (before we filtered them out, as:
https://github.com/alphagov/smokey/pull/921)

Details about what --disable-web-security does: 
https://groups.google.com/a/chromium.org/g/chromium-discuss/c/Wms-ZaAwA1Q
https://github.com/chromium/chromium/blob/main/content/public/common/content_switches.cc#L280

Has been tested on:
- Integration (https://deploy.integration.publishing.service.gov.uk/job/Smokey/40071/console) (which includes rate-limited feedback)
- Staging (https://deploy.blue.staging.govuk.digital/job/Smokey/19165/console)
- Production (https://deploy.blue.production.govuk.digital/job/Smokey/11804/console)

Note that this branch requires a relatively recent chromedriver, but monitoring and jenkins machines in all environments have been updated to Chromedriver 101

## Testing

**You should manually test your PR before merging.**

See https://github.com/alphagov/smokey/blob/main/docs/deployment.md
