### PR TITLE
Rename scenarios to be more consistent

### DIFF
--- a/features/assets.feature
+++ b/features/assets.feature
@@ -4,7 +4,7 @@ Feature: Assets
   signon.
 
   @local-network
-  Scenario: Check an asset can be loaded
+  Scenario: Check assets can be managed via the API
     Given I am testing "asset-manager" internally
     And I am an authenticated API client
     When I request "/assets/513a0efbed915d425e000002"

--- a/features/assets.feature
+++ b/features/assets.feature
@@ -10,9 +10,7 @@ Feature: Assets
     When I request "/assets/513a0efbed915d425e000002"
     And I should see "120613_Albania_Travel_Advice_WEB_Ed2_jpeg.jpg"
 
-  # TODO: RENAME to clarify this is testing that an asset can be served.
-  #
-  Scenario: Check assets with an xls extension are served correctly
+  Scenario: Check an asset can be served
     Given I am testing "assets"
     When I request "/media/580768d940f0b64fbe000022/Target_incomes_calculator.xls"
     Then I should get a "Content-Type" header of "application/vnd.ms-excel"

--- a/features/caching.feature
+++ b/features/caching.feature
@@ -2,17 +2,11 @@
 Feature: Caching
   Tests that pages are correctly cached
 
-  # TODO: RENAME to clarify this is testing caching behaviour
-  # for POST requests.
-  #
-  Scenario: Check council lookup
+  Scenario: Check caching behaviour for POST requests
     When I try to post to "/find-local-council" with "postcode=WC2B+6SE" without following redirects
     Then I should not hit the cache
     Then I should see "camden"
 
-  # TODO: RENAME to clarify this is testing caching behaviour
-  # behaviour for GET requests.
-  #
-  Scenario: Check homepage is served by Varnish
+  Scenario: Check caching behaviour for GET requests
     When I request "/"
     Then I should hit the cache

--- a/features/collections.feature
+++ b/features/collections.feature
@@ -1,32 +1,17 @@
 @app-collections @replatforming
 Feature: Collections
 
-  # TODO: RENAME to clarify this is testing data transfer
-  # with Content Store (as the prime example for the app).
-  #
-  Scenario: Check mainstream browse page loads with links
+  Scenario: Check the frontend can talk to Content Store
     When I visit "/browse/driving"
     And I should see "Teaching people to drive"
     When I click on the section "Teaching people to drive"
     Then I should see "Apply to become a driving instructor"
 
-  # TODO: RENAME to clarify this is testing data transfer with
-  # Search API.
-  #
-  Scenario: Check services and information page loads correctly
+  Scenario: Check the frontend can talk to Search API
     When I visit "/government/organisations/hm-revenue-customs/services-information"
     Then I see links to pages per topic
 
-  # TODO: RENAME to clarify this is testing data transfer with
-  # Email Alert API (as the prime example for the app).
-  #
-  # Note: this scenario also covers legacy functionality in Email
-  # Alert Frontend [^1]. It's easier to make it the prime example
-  # than try to justify its removal.
-  #
-  # [^1]: https://github.com/alphagov/email-alert-frontend/tree/ffaba3f435bcddc8489ac8e3666008dd64ffddf4#signup
-  #
-  Scenario: Email signup from a taxon page
+  Scenario: Check the frontend can talk to Email Alert API
     When I visit "/education"
     Then I should see "Get emails for this topic"
     When I click on the link "Get emails for this topic"

--- a/features/content_data_admin.feature
+++ b/features/content_data_admin.feature
@@ -3,14 +3,14 @@ Feature: Content Data Admin
   Tests for the Content Data Admin application, which provides
   publishers with data about the content they manage
 
-  Scenario: Can access the Content Data Admin index page
+  Scenario: Check log in to content-data-admin
     When I go to the "content-data-admin" landing page
     And I try to login as a user
     And I go to the "content-data-admin" landing page
     Then I should see "Content Data"
     And I should see "Log out"
 
-  Scenario: Can access a Content Data Admin metrics page
+  Scenario: Check admin can talk to Content Data API
     When I try to login as a user
     And I visit "/metrics/government/organisations/government-digital-service" on the "content-data-admin" application
     Then I should see "Page data"

--- a/features/csv_preview.feature
+++ b/features/csv_preview.feature
@@ -2,6 +2,6 @@
 Feature: CSV preview
   Tests to check CSV previews in whitehall.
 
-  Scenario: Accessing a CSV preview
+  Scenario: Check the frontend can talk to Asset Manager (for Whitehall)
     When I visit "/government/uploads/system/uploads/attachment_data/file/214962/passport-impact-indicat.csv/preview"
     Then JavaScript should run without any errors

--- a/features/draft_environment.feature
+++ b/features/draft_environment.feature
@@ -16,7 +16,7 @@ Feature: Draft environment
     And the page should contain the draft watermark
 
   @app-government-frontend
-  Scenario: Check visiting a page served by government-frontend
+  Scenario: Check the frontend can talk to draft Content Store (for Government Frontend)
     When I try to login as a user
     When I attempt to visit "government/case-studies/example-case-studies-eu-citizens-rights-in-the-uk"
     Then I should see "Case study"

--- a/features/feedback.feature
+++ b/features/feedback.feature
@@ -31,7 +31,7 @@ Feature: Feedback
     Then I see the feedback confirmation message
     And a request is sent to the feedback app
 
-  Scenario: Check the frontend can talk to Static
+  Scenario: Check the feedback component loads
     When I visit "<url>"
     And I confirm it is rendered by "<application>"
     And I click to report a problem with the page

--- a/features/feedback.feature
+++ b/features/feedback.feature
@@ -1,10 +1,7 @@
 @replatforming @app-feedback
 Feature: Feedback
 
-  # TODO: RENAME to clarify this is testing data transfer with
-  # Content Store (as the prime example for this app).
-  #
-  Scenario: Check the "Contact GOV.UK" page loads correctly
+  Scenario: Check the frontend can talk to Content Store
     When I visit "/contact/govuk"
     Then I should see "Contact GOV.UK"
 
@@ -16,7 +13,7 @@ Feature: Feedback
   # - Second critical check: N (not tested in app)
   #
   # Data transfer with Content Store is already covered by
-  # "Check the "Contact GOV.UK" page loads correctly".
+  # "Check the frontend can talk to Content Store".
   #
   # Should be tested in Feedback [^1].
   #
@@ -34,10 +31,7 @@ Feature: Feedback
     Then I see the feedback confirmation message
     And a request is sent to the feedback app
 
-  # TODO: RENAME to clarify this is testing data transfer with
-  # Static (as the prime example for each app listed below).
-  #
-  Scenario: Check feedback component behaviour
+  Scenario: Check the frontend can talk to Static
     When I visit "<url>"
     And I confirm it is rendered by "<application>"
     And I click to report a problem with the page

--- a/features/finder_frontend.feature
+++ b/features/finder_frontend.feature
@@ -5,10 +5,7 @@ Feature: Finder Frontend
   Background:
     Given I consent to cookies
 
-  # TODO: RENAME to clarify this is testing data transfer with
-  # Content Store (as the prime example for this app).
-  #
-  Scenario: Check people page loads correctly
+  Scenario: Check the frontend can talk to Content Store
     When I visit "/government/people"
     Then I should see "All ministers and senior officials on GOV.UK"
     And I should see an input field to search
@@ -21,7 +18,7 @@ Feature: Finder Frontend
   # - Second critical check: N (not tested in app)
   #
   # Data transfer with Content Store is already covered by
-  # "Check the "Contact GOV.UK" page loads correctly".
+  # "Check the frontend can talk to Content Store".
   #
   # Was and should be tested in Finder Frontend [^1].
   #
@@ -40,22 +37,13 @@ Feature: Finder Frontend
     | <script>alert(123)</script> | news-and-communications |
     | <script>alert(123)</script> | all                     |
 
-  # TODO: RENAME to clarify this is testing data transfer with
-  # Email Alert API (as the prime example for the app).
-  #
-  # Note: this scenario covers additional selection functionality
-  # compared to others, hence making it the prime example.
-  #
-  Scenario: Email signup from the statistics finder
+  Scenario: Check the frontend can talk to Email Alert API
     When I visit "/search/research-and-statistics"
     And I click on the link "Get emails"
     And I choose the checkbox "Statistics (published)" and click on "Continue"
     Then I should see "How often do you want to get emails?"
 
-  # TODO: RENAME to clarify this is testing data transfer
-  # with Search API (as the prime example for this app).
-  #
-  Scenario Outline: Check search results and analytics
+  Scenario Outline: Check the frontend can talk to Search API
     When I search for "<keywords>"
     Then I should see some search results
     And the search results should be unique
@@ -80,7 +68,7 @@ Feature: Finder Frontend
   # - Second critical check: N (not tested in app)
   #
   # Data transfer with Content Store is already covered by
-  # "Check the "Contact GOV.UK" page loads correctly".
+  # "Check the frontend can talk to Content Store".
   #
   # Should be tested in Finder Frontend [^1].
   #

--- a/features/foreign_travel_advice.feature
+++ b/features/foreign_travel_advice.feature
@@ -1,18 +1,18 @@
 @replatforming
 Feature: Foreign Travel Advice
 
-  Scenario: Check the index page loads correctly
+  Scenario: Check the index page loads
     When I visit "/foreign-travel-advice"
     Then I should see "Foreign travel advice"
     And I should see "Afghanistan"
     And I should see "Luxembourg"
 
-  Scenario: Check a country page loads correctly
+  Scenario: Check a country page loads
     When I visit "/foreign-travel-advice/luxembourg"
     Then I should see "Luxembourg"
     And I should see "Summary"
 
-  Scenario: Email signup from foreign travel advice
+  Scenario: Check the frontend can talk to Email Alert API
     When I visit "/foreign-travel-advice/turkey"
     And I click on the link "Get email alerts"
     And I click on the button "Continue"

--- a/features/frontend.feature
+++ b/features/frontend.feature
@@ -1,41 +1,41 @@
 @replatforming @app-frontend
 Feature: Frontend
 
-  Scenario: Check robots.txt
+  Scenario: Check robots.txt loads
     When I request "/robots.txt"
     Then I should see "User-agent:"
 
-  Scenario: Check help page loads correctly
+  Scenario: Check help page loads
     When I visit "/help"
     Then I should see "Help using GOV.UK"
 
-  Scenario: Check homepage content type and charset
+  Scenario: Check homepage loads
     When I request "/"
     Then I should get a "Content-Type" header of "text/html; charset=utf-8"
 
-  Scenario: Check homepage sends an event to Google Analytics
+  Scenario: Check the client can talk to Google Analytics
     When I visit "/"
     And I consent to cookies
     Then the page view should be tracked
 
-  Scenario: Check 404 page content type and charset
+  Scenario: Check 404 page loads
     When I visit a non-existent page
     Then I should get a "Content-Type" header of "text/html; charset=utf-8"
 
-  Scenario: Check licences load
+  Scenario: Check the frontend can talk to Licensing
     When I visit "/busking-licence"
     Then I should see "Busking licence"
      And I should see an input field for postcode
     When I try to post to "/busking-licence" with "postcode=E20+2ST"
     Then I should see "Busking licence"
 
-  Scenario: Check local transactions load
+  Scenario: Check the frontend can talk to Mapit
     When I visit "/pay-council-tax"
     Then I should see "Pay your Council Tax"
     When I try to post to "/pay-council-tax" with "postcode=WC2B+6SE"
     Then I should see "Camden"
 
-  Scenario: Check electoral pages load
+  Scenario: Check the frontend can talk to Elections API
     When I visit "/contact-electoral-registration-office"
     Then I should see "Electoral Registration Office"
     When I visit "/contact-electoral-registration-office?postcode=sw1a+1aa"
@@ -43,7 +43,7 @@ Feature: Frontend
     When I visit "/contact-electoral-registration-office?postcode=WV148TU"
     Then I should see "Choose your address"
 
-  Scenario: Check "find my nearest" returns results
+  Scenario: Check the frontend can talk to Imminence
     When I visit "/ukonline-centre-internet-access-computer-training"
     And I should see "Online Centres Network"
     When I try to post to "/ukonline-centre-internet-access-computer-training" with "postcode=WC2B+6NH"

--- a/features/gov_uk.feature
+++ b/features/gov_uk.feature
@@ -11,7 +11,7 @@ Feature: Core GOV.UK behaviour
   #
   # This page is rendered by Frontend. Data transfer for this
   # app with Static is already covered by
-  # "Check feedback component behaviour".
+  # "Check the frontend can talk to Static".
   #
   # Should be tested in Static [^1].
   #

--- a/features/government_frontend.feature
+++ b/features/government_frontend.feature
@@ -1,7 +1,7 @@
 @app-government-frontend @replatforming
 Feature: Government Frontend
 
-  Scenario: Ensure static content is rendered
+  Scenario: Check the frontend can talk to Content Store
     When I visit "/government/get-involved"
     Then I should see "Get involved"
     And I should see "Find out how you can engage with government directly, and take part locally, nationally or internationally."
@@ -14,8 +14,8 @@ Feature: Government Frontend
   # - Second critical check: N (not tested in app)
   #
   # Data transfer with Content Store is already covered by
-  # "Ensure static content is rendered". These links are not a
-  # critical feature of GOV.UK.
+  # "Check the frontend can talk to Content Store". These links
+  # are not a critical feature of GOV.UK.
   #
   # Should be tested in app [^1].
   #
@@ -40,7 +40,7 @@ Feature: Government Frontend
   # - Second critical check: N (not tested in app)
   #
   # Data transfer with Search API is already covered by
-  # "Ensure we can see three consultations that were recently opened".
+  # "Check the frontend can talk to Search API".
   #
   # Should be tested in app [^1], but only partially tested [^2].
   #
@@ -67,7 +67,7 @@ Feature: Government Frontend
   # - Second critical check: N (not tested in app)
   #
   # Data transfer with Search API is already covered by
-  # "Ensure we can see three consultations that were recently opened".
+  # "Check the frontend can talk to Search API".
   #
   # Should be tested in app [^1], but only partially tested [^2].
   #
@@ -87,7 +87,7 @@ Feature: Government Frontend
   # - Second critical check: N (not tested in app)
   #
   # Data transfer with Content Store is already covered by
-  # "Ensure static content is rendered".
+  # "Check the frontend can talk to Content Store".
   #
   # This test also fails frequently due to the unconventional
   # test approach of actually clicking the links [^1].

--- a/features/government_frontend.feature
+++ b/features/government_frontend.feature
@@ -54,10 +54,7 @@ Feature: Government Frontend
     When I click the next closing response link
     Then I should see the next closing consultation
 
-  # TODO: RENAME to clarify this is testing data transfer with
-  # Search API (as the prime example for this app).
-  #
-  Scenario: Ensure we can see three consultations that were recently opened
+  Scenario: Check the frontend can talk to Search API
     When I visit "/government/get-involved"
     Then I should see "Recently opened"
     And it should be populated with three open consultations

--- a/features/info_frontend.feature
+++ b/features/info_frontend.feature
@@ -1,6 +1,6 @@
 @app-info-frontend @replatforming
 Feature: Info Frontend
 
-  Scenario: Check the info page for the benefits mainstream browse page
+  Scenario: Check the frontend can talk to Content Store
     When I visit "/info/browse/benefits"
     Then I should see "Benefits"

--- a/features/licensing.feature
+++ b/features/licensing.feature
@@ -2,7 +2,7 @@
 Feature: Licensing
   Tests for the Licensify app.
 
-  Scenario: Check licensing app is present
+  Scenario: Check licensing pages load
     Given I don't care about JavaScript errors
     Then I should be able to visit:
       | Path                                                              |
@@ -11,7 +11,7 @@ Feature: Licensing
       | /apply-for-a-licence/forms/bury/test-licence/9999-7-1,0-1         |
 
   @notreplatforming
-  Scenario: Check signing in to licensify-admin
+  Scenario: Check log in to licensify-admin
     When I try to login as a user
     And I login to Licensify
     Then I should see "Sign Out"

--- a/features/public_api.feature
+++ b/features/public_api.feature
@@ -1,7 +1,7 @@
 @replatforming
 Feature: Public API
 
-  Scenario: Check the content store returns data
+  Scenario: Check the app is routable (for Content Store)
     When I request "/api/content/help"
     Then I should get a 200 status code
     And JSON is returned

--- a/features/search_api.feature
+++ b/features/search_api.feature
@@ -1,6 +1,6 @@
 @app-search-api
 Feature: Search API
-  Scenario: Check sitemap
+  Scenario: Check the app is routable
     When I visit "/sitemap.xml"
     Then it should contain a link to at least one sitemap file
     And I should be able to get the referenced sitemap files

--- a/features/service_manual.feature
+++ b/features/service_manual.feature
@@ -1,6 +1,6 @@
 @replatforming @app-service-manual-frontend
 Feature: Service Manual
 
-  Scenario: Check Service Manual loads correctly
+  Scenario: Check the frontend can talk to Content Store
     When I visit "/service-manual"
     Then I should see "Service Manual"

--- a/features/signon.feature
+++ b/features/signon.feature
@@ -2,7 +2,7 @@
 Feature: Signon
   Tests for signon, the GOV.UK single sign-on service.
 
-  Scenario: Check logging in works
+  Scenario: Check log in to signon
     When I try to login as a user
     Then I should see "Your applications"
 

--- a/features/smartanswers.feature
+++ b/features/smartanswers.feature
@@ -9,13 +9,6 @@ Feature: Smart Answers
     | /vat-payment-deadlines/y/2000-01-31         |
     | /vat-payment-deadlines/y/2000-01-31/cheque  |
 
-  # TODO: RENAME to clarify this is testing data transfer with
-  # Worldwide API.
-  #
-  Scenario Outline: Check viewing countries in a select element
-    When I request "<Path>"
+  Scenario: Check the frontend can talk to Worldwide API
+    When I request "/check-uk-visa/y"
     Then I should see a populated country select
-
-    Examples:
-      | Path                                                       |
-      | /check-uk-visa/y                                           |

--- a/features/smartanswers.feature
+++ b/features/smartanswers.feature
@@ -1,7 +1,7 @@
 @app-smartanswers @replatforming
 Feature: Smart Answers
 
-  Scenario: Check stepping through a smart answer
+  Scenario: Check the app is routable for a Smart Answer
     Then I should be able to visit:
     | Path                                        |
     | /vat-payment-deadlines                      |

--- a/features/transition.feature
+++ b/features/transition.feature
@@ -1,7 +1,7 @@
 Feature: Transition
   Tests for the transition management tools, including the transition app.
 
-  Scenario: Check logging in to the transition app works
+  Scenario: Check log in to transition
     When I go to the "transition" landing page
       And I try to login as a user
       And I go to the "transition" landing page

--- a/features/whitehall.feature
+++ b/features/whitehall.feature
@@ -3,19 +3,9 @@ Feature: Whitehall
   Tests for the whitehall application that powers some pages under
   www.gov.uk/government and www.gov.uk/world.
 
-  # TODO: RENAME to clarify this is testing data transfer with
-  # Content Store (as the prime example for this app).
-  #
-  # This test is poor quality as content is not explicitly tested,
-  # but there are no better tests to choose from.
-  #
-  Scenario Outline: Check whitehall pages load
-    When I request "<Path>"
-    Then I should get a 200 status code
-
-    Examples:
-      | Path                             |
-      | /government/ministers            |
+  Scenario: Check the frontend can talk to Content Store
+    When I request "/government/ministers"
+    Then I should see "Ministers by department"
 
   Scenario: Check whitehall assets are redirected to and served from the asset host
     When I request an attachment


### PR DESCRIPTION
https://trello.com/c/fRihmgQ8/266-add-top-level-guidance-about-where-we-write-tests-on-govuk

Another follow-up PR to #965. I've gone a bit further and looked at all the 
scenarios to see where the names could be better. Please see the commits 
for more details. After this we will have a minimal set of TODOs remaining 
and can move on to other work e.g. clarifying which files tests should be in.

If you're wondering about some of the claims of which app talks to which 
other app, [the original Smokey audit](https://docs.google.com/spreadsheets/d/1i2k4WexywoJurdFddOxiNICN-Elv1D5Mb2sdaCjF1t0/edit?disco=AAAASMdZEUQ) has links to supporting evidence for 
most of the tests ([example](https://docs.google.com/spreadsheets/d/1i2k4WexywoJurdFddOxiNICN-Elv1D5Mb2sdaCjF1t0/edit?disco=AAAASMdZEUQ)).

Tested and works on [Integration Jenkins](https://deploy.integration.publishing.service.gov.uk/job/Smokey/40478/console) ✅*.

*The failures are also on `main` and unrelated to these changes.