### PR TITLE
Speed up sitemap test by only checking one link

### DIFF
--- a/features/search_api.feature
+++ b/features/search_api.feature
@@ -3,4 +3,4 @@ Feature: Search API
   Scenario: Check sitemap
     When I visit "/sitemap.xml"
     Then it should contain a link to at least one sitemap file
-    And I should be able to get all the referenced sitemap files
+    And I should be able to get the referenced sitemap files

--- a/features/step_definitions/search_api_steps.rb
+++ b/features/step_definitions/search_api_steps.rb
@@ -7,9 +7,7 @@ Then /^it should contain a link to at least one sitemap file$/ do
   expect(@sitemap_links.size).to be >= 1
 end
 
-Then /^I should be able to get all the referenced sitemap files$/ do
-  @sitemap_links.each do |link|
-    # doing a HEAD request because the referenced files are fairly large.
-    head_request(link.text, default_request_options)
-  end
+Then /^I should be able to get the referenced sitemap files$/ do
+  # doing a HEAD request because the referenced files are fairly large.
+  head_request(@sitemap_links.first.text, default_request_options)
 end


### PR DESCRIPTION
The sitemap is a critical feature of GOV.UK. However, we really,
_really_ don't need to check the whole thing to prove it works.

Before this change, the scenario would take ~40s to run, which is
about 25% of the total runtime of all Smokey tests - this was by
far the slowest test in the whole suite. Now it will only take ~3s
to run - a significant improvement.