### PR TITLE
Improve test for visiting a draft asset

### DIFF
--- a/features/assets.feature
+++ b/features/assets.feature
@@ -15,7 +15,9 @@ Feature: Assets
     When I request "/media/580768d940f0b64fbe000022/Target_incomes_calculator.xls"
     Then I should get a "Content-Type" header of "application/vnd.ms-excel"
 
-  Scenario: Check draft assets require authentication
+  Scenario: Check a draft asset can be served
     Given I am testing "draft-assets"
-    When I visit "/media/123/filename.extension"
+    When I visit "/media/513a0efbed915d425e000002/120613_Albania_Travel_Advice_WEB_Ed2_jpeg.jpg"
     Then I should be redirected to signon
+    When I log in using valid credentials
+    And I should see the draft image asset

--- a/features/step_definitions/draft_environment_steps.rb
+++ b/features/step_definitions/draft_environment_steps.rb
@@ -24,3 +24,9 @@ end
 Then /^the page should contain the draft watermark$/ do
   expect(page).to have_css('body.draft')
 end
+
+Then /^I should see the draft image asset$/ do
+  image_src = page.find('img')['src']
+  expect(image_src).to have_content('draft-assets')
+  expect(image_src).to have_content('.jpg')
+end


### PR DESCRIPTION
Previously we would try to view a non-existent asset, which didn't
matter as we were only checking the redirect to Signon, which works
irrespective of the asset existing [^1].

Now we test the full journey of viewing a draft asset*. I've chosen
to use an image because this will preview in the headless browser,
which is easier to check and avoids an actual download.

*Note: the asset is published but, like published documents, also
exists in draft as well.

Tested and works on [Integration Jenkins](https://deploy.integration.publishing.service.gov.uk/job/Smokey/40521/console) ✅.

[^1]: https://github.com/alphagov/asset-manager/blob/1e88cd5b71b8ac6f73a079176b9f74c57b608d1c/app/controllers/media_controller.rb#L54