### PR TITLE
Remove incorrect authenticating-proxy tag

### DIFF
--- a/features/assets.feature
+++ b/features/assets.feature
@@ -15,7 +15,6 @@ Feature: Assets
     When I request "/media/580768d940f0b64fbe000022/Target_incomes_calculator.xls"
     Then I should get a "Content-Type" header of "application/vnd.ms-excel"
 
-  @app-authenticating-proxy
   Scenario: Check draft assets require authentication
     Given I am testing "draft-assets"
     When I visit "/media/123/filename.extension"


### PR DESCRIPTION
This app is not involved in the scenario. Unlike documents, where
the request goes via Varnish to authenticating-proxy [^1], a request
for a draft asset goes directly to asset manager [^2].

It's possible for authenticating-proxy to be involved with requests
for draft assets, but that's a different scenario e.g. viewing an
image via a draft document with an auth bypass token [^3].

[^1]: https://github.com/alphagov/govuk-puppet/blob/fd12c90c7d0efe1328774a8c6dfd383594100959/modules/govuk/manifests/node/s_cache.pp#L94
[^2]: https://github.com/alphagov/govuk-puppet/blob/33c3adbfef8b7d9791ca846c2ac2871551e45ae4/modules/router/templates/draft-assets.conf.erb#L56
[^3]: https://github.com/alphagov/asset-manager/blob/1e88cd5b71b8ac6f73a079176b9f74c57b608d1c/app/controllers/media_controller.rb#L71