### PR TITLE
Set cache bypass to false on failing test

### DIFF
--- a/features/data_gov_uk.feature
+++ b/features/data_gov_uk.feature
@@ -28,6 +28,7 @@ Feature: Data.gov.uk
   @notintegration @notstaging
   Scenario: Check CKAN action api's search works
     Given I am testing "ckan"
+    And I try not to bypass caching
     When I request "/api/action/package_search?q=data"
     Then I should get a 200 status code
     And JSON is returned

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -25,6 +25,10 @@ Given /^I am an authenticated API client$/ do
   @authenticated_as_client = true
 end
 
+Given /^I try not to bypass caching$/ do
+  @bypass_caching = false
+end
+
 And /^I consent to cookies$/ do
   visit_path "/"
   click_button "Accept"


### PR DESCRIPTION
Since we [bypass the cache by default](https://github.com/alphagov/smokey/pull/967), this CKAN search test was broken as it did not allow the `cache_bust` url param through.

## Testing

[This build](https://deploy.blue.production.govuk.digital/job/Smokey/11834/console) passes the [CKAN related failure](https://deploy.blue.production.govuk.digital/job/Smokey/11832/console ). 