### PR TITLE
Tag asset manager in relevant whitehall tests

### DIFF
--- a/features/apps/whitehall.feature
+++ b/features/apps/whitehall.feature
@@ -4,11 +4,13 @@ Feature: Whitehall
     When I request "/government/ministers"
     Then I should see "Ministers by department"
 
+  @app-asset-manager
   Scenario: Check whitehall assets are redirected to and served from the asset host
     When I request an attachment
     Then I should be redirected to the asset host
     And the attachment should be served successfully
 
+  @app-asset-manager
   Scenario: Check the frontend can talk to Asset Manager
     When I visit "/government/uploads/system/uploads/attachment_data/file/214962/passport-impact-indicat.csv/preview"
     Then JavaScript should run without any errors


### PR DESCRIPTION
As part of enabling CD for asset manager, this PR tags a few Whitehall tests that interact with asset manager so that we can ensure they are run as part of asset manager's deploy.

Tested on integration: https://deploy.integration.publishing.service.gov.uk/job/Smokey/40649/
(currently failing for unrelated reasons that can be seen on other earlier builds)

Trello: https://trello.com/c/Sj4UTatV/126-enable-continuous-deployment-for-asset-manager

## Testing

**You should manually test your PR before merging.**

See https://github.com/alphagov/smokey/blob/main/docs/deployment.md
