### PR TITLE
Add missing tags for Email Alert Frontend

### DIFF
--- a/features/apps/collections.feature
+++ b/features/apps/collections.feature
@@ -11,6 +11,7 @@ Feature: Collections
     When I visit "/government/organisations/hm-revenue-customs/services-information"
     Then I see links to pages per topic
 
+  @app-email-alert-frontend
   Scenario: Check the frontend can talk to Email Alert API
     When I visit "/education"
     Then I should see "Get emails for this topic"

--- a/features/apps/finder_frontend.feature
+++ b/features/apps/finder_frontend.feature
@@ -35,6 +35,7 @@ Feature: Finder Frontend
     | <script>alert(123)</script> | news-and-communications |
     | <script>alert(123)</script> | all                     |
 
+  @app-email-alert-frontend
   Scenario: Check the frontend can talk to Email Alert API
     When I visit "/search/research-and-statistics"
     And I click on the link "Get emails"

--- a/features/apps/government_frontend.feature
+++ b/features/apps/government_frontend.feature
@@ -14,6 +14,7 @@ Feature: Government Frontend
     Then I should see "Case study"
     And the page should contain the draft watermark
 
+  @app-email-alert-frontend
   Scenario: Check the frontend can talk to Email Alert API
     When I visit "/foreign-travel-advice/turkey"
     And I click on the link "Get email alerts"


### PR DESCRIPTION
These scenarios cover part of the app by loading the page where we
ask how often a user wants to receive emails.

The Collections scenario also covers a legacy type of page rendered
by Email Alert Frontend [^1].

Tested and works on [Integration Jenkins](https://deploy.integration.publishing.service.gov.uk/job/Smokey/40690/console) ✅.

[^1]: https://github.com/alphagov/email-alert-frontend#signup