### PR TITLE
Remove finder frontend export features and corresponding steps

### DIFF
--- a/features/apps/finder_frontend.feature
+++ b/features/apps/finder_frontend.feature
@@ -8,33 +8,6 @@ Feature: Finder Frontend
     Then I should see "All ministers and senior officials on GOV.UK"
     And I should see an input field to search
 
-  # TODO: EXPORT this test as it does not meet the elgibility
-  # criteria in docs/writing-tests.md.
-  #
-  # - Covers site-wide config: N (not applicable)
-  # - Targets data transfer: N (already covered)
-  # - Second critical check: N (not tested in app)
-  #
-  # Data transfer with Content Store is already covered by
-  # "Check the frontend can talk to Content Store".
-  #
-  # Was and should be tested in Finder Frontend [^1].
-  #
-  # [^1]: https://github.com/alphagov/finder-frontend/pull/1054/files#diff-0822261922afb44074aad6403cc2a1d762f897995e9aa1c6a93ece100515117aL23
-  #
-  Scenario Outline: Check malicious code does not execute
-    When I visit the "<finder>" finder with keywords <keyword>
-    Then There should be no alert
-    When I visit the "<finder>" finder without keywords
-    And I fill in the keyword field with <keyword>
-    Then There should be no alert
-    And I should see the string <keyword>
-
-  Examples:
-    | keyword                     | finder                  |
-    | <script>alert(123)</script> | news-and-communications |
-    | <script>alert(123)</script> | all                     |
-
   @app-email-alert-frontend
   Scenario: Check the frontend can talk to Email Alert API
     When I visit "/search/research-and-statistics"
@@ -58,21 +31,3 @@ Feature: Finder Frontend
     | tax              |
     | passport         |
     | universal credit |
-
-  # TODO: EXPORT this test as it does not meet the elgibility
-  # criteria in docs/writing-tests.md.
-  #
-  # - Covers site-wide config: N (not applicable)
-  # - Targets data transfer: N (already covered)
-  # - Second critical check: N (not tested in app)
-  #
-  # Data transfer with Content Store is already covered by
-  # "Check the frontend can talk to Content Store".
-  #
-  # Should be tested in Finder Frontend [^1].
-  #
-  # [^1]: https://github.com/alphagov/finder-frontend/pull/480/files#diff-784cf53d64014a1a65ca518c1891efbc3fe9b4fb02d0e0e2dfed07acb9c5b0d1R3  #
-  #
-  Scenario: Check malicious code does not execute
-    When I search for "<script>alert(document.cookie)</script>"
-    Then I see the code returned in the page

--- a/features/step_definitions/feedback_steps.rb
+++ b/features/step_definitions/feedback_steps.rb
@@ -56,10 +56,6 @@ Then /^I see the feedback confirmation message$/ do
   expect(page).to have_content("Thank you for your feedback")
 end
 
-Then /^I see the code returned in the page$/ do
-  expect(page).to have_selector("input[value='<script>alert(document.cookie)</script>']")
-end
-
 Then /^a request is sent to the feedback app$/ do
   sought = "/contact/govuk/email-survey-signup"
   expect(browser_has_request_with_url_containing sought).to be(true)

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -61,31 +61,6 @@ When /^I visit "(.*)"$/ do |path_or_url|
   visit_path path_or_url
 end
 
-When /^I visit the "([^"]+)" finder with keywords (.*)$/ do |finder, keywords|
-  path = "/search/#{finder}?keywords=#{keywords}"
-  visit_path path
-end
-
-When /^I visit the "([^"]+)" finder without keywords$/ do |finder|
-  path = "/search/#{finder}"
-  visit_path path
-end
-
-And /^There should be no alert$/ do
-  expect {
-    page.driver.browser.switch_to.alert.accept
-  }.to raise_error(Selenium::WebDriver::Error::NoSuchAlertError)
-end
-
-And /^I should see the string (.+)$/ do |content|
-  expect(page.find('#finder-keyword-search').value).to eq(content)
-end
-
-And /^I fill in the keyword field with (.+)$/ do |content|
-  page.fill_in id: 'finder-keyword-search', with: "#{content}\n"
-end
-
-
 When /^I visit "(.*)" without following redirects$/ do |path|
   @response = single_http_request("#{@host}#{path}")
 end


### PR DESCRIPTION
This depends on https://github.com/alphagov/finder-frontend/pull/2815

These tests have been imported to Finder Frontend as they test code
local to that app and don't require the external view Smokey has.

## Testing

**You should manually test your PR before merging.**

See https://github.com/alphagov/smokey/blob/main/docs/deployment.md
