### PR TITLE
Remove Feedback export feature and corresponding steps

### DIFF
--- a/features/apps/feedback.feature
+++ b/features/apps/feedback.feature
@@ -5,25 +5,6 @@ Feature: Feedback
     When I visit "/contact/govuk"
     Then I should see "Contact GOV.UK"
 
-  # TODO: EXPORT this test as it does not meet the elgibility
-  # criteria in docs/writing-tests.md.
-  #
-  # - Covers site-wide config: N (not applicable)
-  # - Targets data transfer: N (already covered)
-  # - Second critical check: N (not tested in app)
-  #
-  # Data transfer with Content Store is already covered by
-  # "Check the frontend can talk to Content Store".
-  #
-  # Should be tested in Feedback [^1].
-  #
-  # [^1]: https://github.com/alphagov/feedback/blob/d2e8d8286fffec6b6093eecd5ed2d38f2c245e9e/app/models/contact_ticket.rb#L16
-  #
-  Scenario: Check malicious code does not execute
-    When I visit "/contact/govuk"
-    And I input malicious code in the email field
-    Then I see the code returned in the page
-
   Scenario: Check "is this page useful?" email survey
     When I visit "/"
     And I click to say the page is not useful

--- a/features/step_definitions/feedback_steps.rb
+++ b/features/step_definitions/feedback_steps.rb
@@ -1,9 +1,3 @@
-When /^I input malicious code in the (.*) field$/ do |field|
-  page.execute_script("document.querySelector('.contact-form').setAttribute('novalidate', 'novalidate')")
-  find("#email").set("<script>alert(document.cookie)</script>")
-  click_button("Send message")
-end
-
 When /^I click to report a problem with the page$/ do
   within(".gem-c-feedback") do
     click_on("Report a problem with this page")


### PR DESCRIPTION
This can be removed now that the feature has been imported into Feedback
[1].

Note: I'm not able to remove the step definition for "I see the code
returned in the page" as this is still used by finder-frontend [2].
However once this PR is merged I should be able to add that onto [3].

[1]: https://github.com/alphagov/feedback/pull/1454
[2]: https://github.com/alphagov/smokey/blob/7553a432259d785fb6d4fb81cfd4fe3572185ad3/features/apps/finder_frontend.feature#L77
[3]: https://github.com/alphagov/smokey/pull/990

## Testing

**You should manually test your PR before merging.**

See https://github.com/alphagov/smokey/blob/main/docs/deployment.md
