### PR TITLE
Remove signon secure cookie test

### DIFF
--- a/features/apps/signon.feature
+++ b/features/apps/signon.feature
@@ -3,18 +3,3 @@ Feature: Signon
   Scenario: Check log in to signon
     When I try to login as a user
     Then I should see "Your applications"
-
-  # TODO: EXPORT this test as it does not meet the elgibility
-  # criteria in docs/writing-tests.md.
-  #
-  # - Covers site-wide config: N (not applicable)
-  # - Targets data transfer: N (no other apps involved)
-  # - Second critical check: N (not tested in app)
-  #
-  # Should be tested in Signon [^1].
-  #
-  # [^1]: https://github.com/alphagov/signon/blob/c9f9c829f7c1a8fc6712cd6c15c2c2f5412db02d/config/initializers/session_store.rb#L5
-  #
-  Scenario: Check signon cookies are marked as secure
-    When I go to the "signon" landing page
-    Then I should receive a "_signonotron2_session" cookie which is "secure"

--- a/features/step_definitions/cookie_steps.rb
+++ b/features/step_definitions/cookie_steps.rb
@@ -1,6 +1,0 @@
-Then /^I should receive a "([a-z0-9_]+)" cookie which is "([a-zA-Z]+)"$/ do |cookie_name, cookie_property|
-  browser = Capybara.current_session.driver.browser.manage
-  cookie = browser.cookie_named(cookie_name)
-  assert cookie, "No cookie called #{cookie_name} is being set"
-  assert_equal true, cookie[cookie_property.to_sym], "The cookie #{cookie_name} does not have property #{cookie_property}"
-end


### PR DESCRIPTION
This test is being removed because it doesn't meet the eligibility
criteria for this repository.

I investigated whether it could be imported to signon, but this is not a
simple task as the "secure" property is defined by the environment the
code is executing in [1].

With this knowledge I decided we could delete this for a few reasons:

1) It's unconventional for us to test convention in this way
2) The risks of this cookie not being secure are very low due to HSTS
   making it very difficult to visit the site without HTTPS
3) There are various cookie tests in signon, which make the likelihood
   of a regression low

If we were to want to test this Smokey could be the place if we were to
define an eligibility criteria of environment configuration. As this
test seems to be the lone case of this need, this step seems
superfluous.

[1]: https://github.com/alphagov/signon/blob/e2d48a22a2afe1842cf88921da67490f04582cf2/config/initializers/session_store.rb#L5
[2]: https://github.com/alphagov/signon/blob/e335543918e9e1e189a8791f26a85de3a39dd534/test/integration/cookies_security_test.rb#L4-L11

## Testing

**You should manually test your PR before merging.**

See https://github.com/alphagov/smokey/blob/main/docs/deployment.md
