### PR TITLE
Update Dockerfile to use new GOV.UK Ruby base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-ARG base_image=ruby:2.7.6
+ARG base_image=ghcr.io/alphagov/govuk-ruby-base:2.7.6
 FROM ${base_image}
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential \
-  libpq-dev libxml2-dev libxslt1-dev dumb-init default-jre
-
-ENV APP_HOME /smokey
-RUN mkdir $APP_HOME
 
 ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE 1
 
-# Install Chromium and ChromiumDriver
-RUN apt-get update -qq && apt-get install -y chromium chromium-driver && apt-get clean
+# Install dependencies, Chrimium and ChromiumDriver
+RUN install_packages build-essential \
+  libpq-dev libxml2-dev libxslt1-dev dumb-init default-jre \
+  chromium chromium-driver
+
+ENV APP_HOME /smokey
+RUN mkdir $APP_HOME
 
 WORKDIR $APP_HOME
 ADD Gemfile* $APP_HOME/


### PR DESCRIPTION
Updates the Dockerfile to use the new [GOV.UK Ruby base images](https://github.com/alphagov/govuk-ruby-images). Also updates the .ruby-version file to not specify a patch version, to allow for easier Ruby patching.

Context: https://trello.com/c/Zy0fd25w/970-use-base-builder-images-in-all-the-app-dockerfiles

## Testing

**You should manually test your PR before merging.**

See https://github.com/alphagov/smokey/blob/main/docs/deployment.md
