### PR TITLE
Fix Collections steps

### DIFF
--- a/features/step_definitions/frontend_steps.rb
+++ b/features/step_definitions/frontend_steps.rb
@@ -1,5 +1,5 @@
 When /^I click on the section "(.*?)"$/ do |section_name|
-  link_href = Nokogiri::HTML.parse(page.body).at_xpath("//h3[text()='#{section_name}']/../@href")
+  link_href = Nokogiri::HTML.parse(page.body).at_xpath("//a[text()='#{section_name}']/@href")
   expect(link_href).not_to be_nil
   step "I visit \"#{link_href.value}\""
 end


### PR DESCRIPTION
We are removing the Miller Column style template for gov.uk/browse and replacing it with a new template. The markup for this smoke test is changed.

[Trello](https://trello.com/c/RDZA1vJ7/1109-build-iteration-of-level-2-browse-curated-topic-template-b-c-test-xl)

