### PR TITLE
Added application tagging to the content store healthcheck

### DIFF
--- a/features/apps/content_store.feature
+++ b/features/apps/content_store.feature
@@ -1,4 +1,4 @@
-@replatforming
+@app-content-store @replatforming
 Feature: Content Store
   Scenario: Check the app is routable
     When I request "/api/content/help"


### PR DESCRIPTION
Added application tagging to the content store healthcheck, in line with
CD requirements.

Trello: https://trello.com/c/aDiHro0u/26-enable-continuous-deployment-for-content-store

## Testing

**You should manually test your PR before merging.**

See https://github.com/alphagov/smokey/blob/main/docs/deployment.md
