### PR TITLE
Add `notreplatforming` tag to irrelevant scenarios

### DIFF
--- a/features/apps/government_frontend.feature
+++ b/features/apps/government_frontend.feature
@@ -6,7 +6,7 @@ Feature: Government Frontend
     Then I should see "Get involved"
     And I should see "Find out how you can engage with government directly, and take part locally, nationally or internationally."
 
-  @app-authenticating-proxy
+  @app-authenticating-proxy @notreplatforming
   Scenario: Check the frontend can talk to draft Content Store
     Given I am testing "draft-origin"
     When I try to login as a user

--- a/features/apps/publisher.feature
+++ b/features/apps/publisher.feature
@@ -1,6 +1,6 @@
 @app-publisher @replatforming
 Feature: Publisher
-  @app-publishing-api
+  @app-publishing-api @notreplatforming
   Scenario: Can log in to publisher
     When I go to the "publisher" landing page
     And I try to login as a user

--- a/features/apps/whitehall.feature
+++ b/features/apps/whitehall.feature
@@ -15,7 +15,7 @@ Feature: Whitehall
     When I visit "/government/uploads/system/uploads/attachment_data/file/214962/passport-impact-indicat.csv/preview"
     Then JavaScript should run without any errors
 
-  @app-publishing-api
+  @app-publishing-api @notreplatforming
   Scenario: Can log in to whitehall
     When I go to the "whitehall-admin" landing page
     And I try to login as a user

--- a/features/assets.feature
+++ b/features/assets.feature
@@ -1,6 +1,6 @@
 @replatforming @app-asset-manager
 Feature: Assets
-  @local-network
+  @local-network @notreplatforming
   Scenario: Check assets can be managed via the API
     Given I am testing "asset-manager" internally
     And I am an authenticated API client
@@ -12,6 +12,7 @@ Feature: Assets
     When I request "/media/580768d940f0b64fbe000022/Target_incomes_calculator.xls"
     Then I should get a "Content-Type" header of "application/vnd.ms-excel"
 
+  @notreplatforming
   Scenario: Check a draft asset can be served
     Given I am testing "draft-assets"
     When I visit "/media/513a0efbed915d425e000002/120613_Albania_Travel_Advice_WEB_Ed2_jpeg.jpg"

--- a/features/origin.feature
+++ b/features/origin.feature
@@ -25,7 +25,7 @@ Feature: Origin
     When I request "/"
     Then I should get a "Content-Type" header of "text/html; charset=utf-8"
 
-  @app-authenticating-proxy @replatforming
+  @app-authenticating-proxy @notreplatforming
   Scenario: Check visiting a draft page requires a signon session
     Given I am testing "draft-origin"
     When I attempt to go to a case study


### PR DESCRIPTION
The EKS platform is currently only running the frontend applications and serving traffic to frontend application. Smokey needs to ignore scenarios that involve user journeys other than request public frontend pages (i.e. not publishing).

See https://github.com/alphagov/smokey/blob/main/docs/deployment.md
