### PR TITLE
Add spec to handle Reshuffle Mode

### DIFF
--- a/features/apps/whitehall.feature
+++ b/features/apps/whitehall.feature
@@ -2,7 +2,7 @@
 Feature: Whitehall
   Scenario: Check the frontend can talk to Content Store
     When I request "/government/ministers"
-    Then I should see "Ministers by department"
+    Then I should either see "Ministers by department" or "This page is being updated."
 
   @app-asset-manager
   Scenario: Check whitehall assets are redirected to and served from the asset host

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -148,6 +148,18 @@ Then /^I should see "(.*)"$/ do |content|
   end
 end
 
+Then /^I should either see "(.*)" or "(.*)"$/ do |content, other_content|
+  if @responses
+    @responses.each do |response|
+      expect((response.body.include?(content) || response.body.include?(other_content))).to be true
+    end
+  elsif @response
+    expect((@response.body.include?(content) || @response.body.include?(other_content))).to be true
+  elsif page
+    expect((page.body.include?(content) || page.include?(other_content))).to be true
+  end
+end
+
 Then /^I should be at a location path of "(.*)"$/ do |location_path|
   if @response
     uri = URI(@response['location'])


### PR DESCRIPTION
When we are in Reshuffle Mode, the Ministers page has different content and the smoke test for it fails.

## Testing

**You should manually test your PR before merging.**

See https://github.com/alphagov/smokey/blob/main/docs/deployment.md
