### PR TITLE
Fix deploy GitHub Action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -27,9 +27,10 @@ on:
 jobs:
   build-and-publish-image:
     name: Build and publish image
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     uses: alphagov/govuk-infrastructure/.github/workflows/ci-ecr.yaml@main
     with:
-      gitRef: ${{ github.event.inputs.gitRef }}
+      gitRef: ${{ github.event.inputs.gitRef || github.ref }}
     secrets:
       AWS_GOVUK_ECR_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
       AWS_GOVUK_ECR_SECRET_ACCESS_KEY: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
This updates the deploy GitHub Action workflow to correctly build and trigger a
deployment of the application to the EKS. This configuration may have been
incorrect as only subset of app originally were set up correctly. This is a
part of bulk set of PRs raises. The workflow is still configured to be
triggered on_push, until CI workflow has been configured correctly.
