### PR TITLE
Change feedback close button text to cancel

### DIFF
--- a/features/step_definitions/feedback_steps.rb
+++ b/features/step_definitions/feedback_steps.rb
@@ -17,7 +17,7 @@ end
 
 When /^I close the open feedback form$/ do
   within(".gem-c-feedback") do
-    click_on("Close")
+    click_on("Cancel")
   end
 end
 


### PR DESCRIPTION
In a recent change to the site wide feedback form, the text for the close button was changed from 'Close' to 'Cancel'. This resulted in "I close the open feedback form" to fail because it was clicking on a button with "Close" text. The label of this button has been updated in the test, so the button can now be found.


[Link to change in PR](https://github.com/alphagov/govuk_publishing_components/pull/2894/commits/595432dc2739523c026d25786a6c6ae3ad1c3152)

[Trello Card for Original Task](https://trello.com/c/kHCz2XVL/1046-iterate-and-implement-the-design-update-to-the-feedback-component-l)
