### PR TITLE
Add test for passing of Rate-Limit-Token request header

### DIFF
--- a/features/apps/smokey.feature
+++ b/features/apps/smokey.feature
@@ -7,3 +7,11 @@ Feature: Smokey
     When I request "https://www.gov.uk"
     Then I should get a 200 status code
     And I should see "Welcome to GOV.UK"
+
+  Scenario: Check that Smokey passes Rate Limit Token when set
+    Given the 'RATE_LIMIT_TOKEN' ENV variable is set
+    Then any request I make should include the 'Rate-Limit-Token' header
+
+  Scenario: Check that Smokey doesn't attempt to pass Rate Limit Token if not set
+    Given the 'RATE_LIMIT_TOKEN' ENV variable is NOT set
+    Then any request I make should NOT include the 'Rate-Limit-Token' header

--- a/features/support/http_requests.rb
+++ b/features/support/http_requests.rb
@@ -17,6 +17,12 @@ def try_get_request(url, options = {})
   }
 end
 
+def create_request(url, options = {})
+  do_http_request(url, :get, options) { |response, request, result|
+    request
+  }
+end
+
 def uri_escape(s)
   CGI.escape(s)
 end


### PR DESCRIPTION
We have some logic to add a `Rate-Limit-Token` request header when a particular environment variable is present: https://github.com/alphagov/smokey/blob/22072e261b38da114015a81f8cd73392331d74a5/features/support/env.rb#L49-L58

Prior to this commit, there were no tests in place to prevent the functionality from being removed or accidentally broken. It's not hugely clear from the PR where it was added (#940) why the feature was introduced in the first place, so it's also not clear where we might see breakages were this code to be removed.

Assuming it is important, this is a quick sense-check Smokey CI test that ensures that the request header is sent when the `RATE_LIMIT_TOKEN` ENV variable is set. This frees us up to refactor Smokey's networking with more confidence.

## Testing

**You should manually test your PR before merging.**

See https://github.com/alphagov/smokey/blob/main/docs/deployment.md
