### PR TITLE
Switch to Chrome to fix CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-ARG base_image=ruby:2.7.6
-FROM ${base_image}
+FROM ruby:3.1.2
 RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential \
   libpq-dev libxml2-dev libxslt1-dev dumb-init default-jre
 
@@ -8,8 +7,10 @@ RUN mkdir $APP_HOME
 
 ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE 1
 
-# Install Chromium and ChromiumDriver
-RUN apt-get update -qq && apt-get install -y chromium chromium-driver && apt-get clean
+# Install Google Chrome
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
+RUN apt-get update && apt-get install -y google-chrome-stable
 
 WORKDIR $APP_HOME
 ADD Gemfile* $APP_HOME/
@@ -17,6 +18,8 @@ ADD .ruby-version $APP_HOME/
 RUN bundle install
 
 ADD . $APP_HOME
+
+RUN bundle exec rake webdrivers:chromedriver:update
 
 # Allow root user to run Chromium in Docker
 ENV NO_SANDBOX 1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,7 +156,7 @@ GEM
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
     rubyzip (2.3.2)
-    selenium-devtools (0.105.0)
+    selenium-devtools (0.107.0)
       selenium-webdriver (~> 4.2)
     selenium-webdriver (4.5.0)
       childprocess (>= 0.5, < 5.0)

--- a/features/apps/smokey.feature
+++ b/features/apps/smokey.feature
@@ -7,3 +7,11 @@ Feature: Smokey
     When I request "https://www.gov.uk"
     Then I should get a 200 status code
     And I should see "Welcome to GOV.UK"
+
+  Scenario: Check that Smokey passes Rate Limit Token when set
+    Given the 'RATE_LIMIT_TOKEN' ENV variable is set
+    Then any request I make should include the 'Rate-Limit-Token' header
+
+  Scenario: Check that Smokey doesn't attempt to pass Rate Limit Token if not set
+    Given the 'RATE_LIMIT_TOKEN' ENV variable is NOT set
+    Then any request I make should NOT include the 'Rate-Limit-Token' header

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -32,32 +32,17 @@ Capybara.register_driver :headless_chrome do |app|
   )
 
   options = Selenium::WebDriver::Chrome::Options.new
-  options.add_argument("--headless")
-  options.add_argument("--disable-gpu")
+  options.headless!
   options.add_argument("--disable-web-security")
   options.add_argument("--disable-xss-auditor")
   options.add_argument("--user-agent=Smokey\ Test\ \/\ Ruby")
   options.add_argument("--no-sandbox") if ENV.key?("NO_SANDBOX")
 
-  browser_options = {
+  Capybara::Selenium::Driver.new(
+    app,
     browser: :chrome,
-    capabilities: [capabilities, options]
-  }
-
-  driver = Capybara::Selenium::Driver.new(app, browser_options)
-
-  driver.browser.devtools.send_cmd(
-    'Network.enable'
+    capabilities: [capabilities, options],
   )
-  
-  if ENV["RATE_LIMIT_TOKEN"]
-    driver.browser.devtools.send_cmd(
-      'Network.setExtraHTTPHeaders',
-      headers: { 'Rate-Limit-Token': ENV["RATE_LIMIT_TOKEN"] }
-    )
-  end
-
-  driver
 end
 
 Capybara.default_driver = :headless_chrome

--- a/features/support/http_requests.rb
+++ b/features/support/http_requests.rb
@@ -17,6 +17,12 @@ def try_get_request(url, options = {})
   }
 end
 
+def create_request(url, options = {})
+  do_http_request(url, :get, options) { |response, request, result|
+    request
+  }
+end
+
 def uri_escape(s)
   CGI.escape(s)
 end

--- a/features/support/http_requests.rb
+++ b/features/support/http_requests.rb
@@ -94,6 +94,9 @@ def do_http_request(url, method = :get, options = {}, &block)
   if options[:cookies]
     headers["Cookie"] = options[:cookies].map { |k, v| "#{k}=#{v}" }.join("; ")
   end
+  if ENV["RATE_LIMIT_TOKEN"]
+    headers["Rate-Limit-Token"] = ENV["RATE_LIMIT_TOKEN"]
+  end
 
   request_options = {
     url: url,


### PR DESCRIPTION
This PR drops Chromium/ChromiumDriver in favour of Chrome, which we'd successfully used in publishing-e2e-tests prior to its retirement. It modernises some of the configuration, and adds a test to ensure that "rate limit token" request header setting works correctly.

It has been tested on Integration and had a successful run: https://deploy.integration.publishing.service.gov.uk/job/Smokey/43515/console (after configuring the job to use the `fix-build` branch rather than `main`).

See commits for details. TLDR, this PR fixes the build issues that we'd started seeing on every PR in Smokey.