### PR TITLE
Fix container image build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,45 @@
-FROM ruby:3.1.2
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential \
-  libpq-dev libxml2-dev libxslt1-dev dumb-init default-jre
+ARG base_image=ghcr.io/alphagov/govuk-ruby-base:3.1.2
+ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:3.1.2
 
-ENV APP_HOME /smokey
-RUN mkdir $APP_HOME
-
-ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE 1
-
-# Install Google Chrome
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
-RUN sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
-RUN apt-get update && apt-get install -y google-chrome-stable
+FROM $builder_image AS builder
 
 WORKDIR $APP_HOME
-ADD Gemfile* $APP_HOME/
-ADD .ruby-version $APP_HOME/
+COPY Gemfile* .ruby-version ./
 RUN bundle install
+COPY . ./
 
-ADD . $APP_HOME
 
-RUN bundle exec rake webdrivers:chromedriver:update
+FROM $base_image
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Allow root user to run Chromium in Docker
-ENV NO_SANDBOX 1
+# Remove Cucumber advert.
+ENV CUCUMBER_PUBLISH_QUIET=true
 
-# Remove Cucumber advert
-ENV CUCUMBER_PUBLISH_QUIET true
+# Install Google Chrome and the corresponding version of ChromeDriver.
+ARG chromedriver_url=https://chromedriver.storage.googleapis.com/
+ADD https://dl-ssl.google.com/linux/linux_signing_key.pub /tmp/google.pub
+RUN arch=$(dpkg --print-architecture) && \
+    keyring=/usr/share/keyrings/google-linux-signing.gpg && \
+    gpg --dearmor < /tmp/google.pub > "${keyring}" && \
+    echo "deb [arch=${arch} signed-by=${keyring}] https://dl.google.com/linux/chrome/deb/ stable main" \
+        > /etc/apt/sources.list.d/google.list && \
+    install_packages dumb-init google-chrome-stable unzip && \
+    rm -fr /tmp/*
+RUN chrome_ver=$(google-chrome --version | grep -Po '\d+\.\d+\.\d+') && \
+    chromedriver_ver=$(curl -LSfs "${chromedriver_url}LATEST_RELEASE_${chrome_ver}") && \
+    curl -LSfs "${chromedriver_url}${chromedriver_ver}/chromedriver_linux64.zip" \
+        | funzip >/usr/bin/chromedriver && \
+    chmod 755 /usr/bin/chromedriver
+
+WORKDIR $APP_HOME
+COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
+COPY --from=builder $APP_HOME ./
+# Chrome expects ~/.local/ to be writable.
+RUN ln -s /tmp .local
 
 STOPSIGNAL SIGINT
-
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
-
-# Users of the image are expected to override the default CMD and set env vars
-# ENVIRONMENT and a profile flag.
-
+USER app
+# Users are expected to override the default CMD and set the ENVIRONMENT env
+# var and optionally PROFILE to specify a Cucumber profile.
 CMD ["bundle", "exec", "cucumber", "--strict-undefined"]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,4 +203,4 @@ DEPENDENCIES
   selenium-webdriver (~> 4)
 
 BUNDLED WITH
-   2.1.4
+   2.3.13


### PR DESCRIPTION
- Don't try to run `rake webdrivers:chromedriver:update`, since that task and indeed the entire Rakefile were removed in https://github.com/alphagov/smokey/pull/893. Fixes the image build, which had been broken since https://github.com/alphagov/smokey/pull/1049.
- Actually install ChromeDriver, which had been missing since https://github.com/alphagov/smokey/pull/1049.

Other fixes and cleanup while we're there:

- Security fix: don't run as root by default.
- Security fix: don't defeat the Chrome sandbox by default.
- Use govuk-ruby-images, which gets rid of a ton of bad-practice `apt-get upgrade` and the like.
- Remove the JRE, as this was only needed for BrowserMob, which we're no longer using.
- Stop using deprecated `apt-key`.
- Update Bundler from 2.1 to 2.3, since 2.1 had some issues with Ruby 3.1.
- General Dockerfile good practices e.g. use COPY and not ADD for copying files locally, set `-o pipefail` when using shell pipelines, use WORKDIR to change/create directories, etc.

Rollout: will need to set `NO_SANDBOX` in govuk-puppet and govuk-docker if it's not already.

### Testing

[Output from test run on Jenkins](https://deploy.integration.publishing.service.gov.uk/job/Smokey/44041/console)

The [instructions](https://github.com/alphagov/smokey/#running-the-test-suite) for running in govuk-docker seem to be incomplete and I wasn't able to follow them. If it's supposed to be possible to run this in govuk-docker, let me know what I've missed and I can fix the README.