### PR TITLE
Have headless Chrome use /tmp instead of shared memory.

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -33,9 +33,12 @@ Capybara.register_driver :headless_chrome do |app|
 
   options = Selenium::WebDriver::Chrome::Options.new
   options.headless!
+  options.add_argument("--disable-dev-shm-usage")
+  options.add_argument("--disable-extensions")
+  options.add_argument("--disable-gpu")
   options.add_argument("--disable-web-security")
   options.add_argument("--disable-xss-auditor")
-  options.add_argument("--user-agent=Smokey\ Test\ \/\ Ruby")
+  options.add_argument("--user-agent='Smokey Test / Ruby'")
   options.add_argument("--no-sandbox") if ENV.key?("NO_SANDBOX")
 
   Capybara::Selenium::Driver.new(


### PR DESCRIPTION
This allows running the WebDriver tests in a container without needing to tune sysctls on the node and reserve a ton of RAM.

Also disable GPU acceleration and the ability to load Chrome extensions while we're at it, since we don't need/want either of those.