### PR TITLE
Add Licence reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,7 @@ bundle exec rake 'eyaml:decrypt_value[integration,smokey_rate_limit_token]'
 - [tagging](docs/tagging.md)
 - [writing tests](docs/writing-tests.md)
 - [pr-template](.github/pull_request_template.md)
+
+## Licence
+
+[MIT License](LICENCE)


### PR DESCRIPTION
We want to make the reference to the licence in the README consistent with the GDS Way.

Trello card: https://trello.com/c/P0DpFcwW/260-standardise-all-license-files-names-to-licence