### PR TITLE
Remove workaround for Chrome writing to `~/.local`.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,6 @@ RUN chrome_ver=$(google-chrome --version | grep -Po '\d+\.\d+\.\d+') && \
 WORKDIR $APP_HOME
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 COPY --from=builder $APP_HOME ./
-# Chrome expects ~/.local/ to be writable.
-RUN ln -s /tmp .local
 
 STOPSIGNAL SIGINT
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]


### PR DESCRIPTION
This is no longer necessary now that we're setting `XDG_DATA_HOME` in the base image.

This doesn't affect the EC2/Jenkins setup.

Tested: deployed to integration, got identical test results as the trunk build.