### PR TITLE
Fix container image build.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,12 @@
+*.log
 .git
 .github
-bug.log
+Dockerfile
+Jenkinsfile
+README.md
+deploy.sh
 docs
+jenkins.sh
 log
+nagios_check_cache.py
+tests_json_output.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,4 +47,4 @@ ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 USER app
 # Users are expected to override the default CMD and set the ENVIRONMENT env
 # var and optionally PROFILE to specify a Cucumber profile.
-CMD ["bundle", "exec", "cucumber", "--strict-undefined"]
+CMD ["cucumber", "--strict-undefined"]

--- a/features/support/base_urls.rb
+++ b/features/support/base_urls.rb
@@ -17,9 +17,13 @@ DEFAULT_PATHS = {
 }
 
 def application_external_url(app_name)
-  "#{Plek.new.external_url_for(app_name)}#{DEFAULT_PATHS.fetch(app_name,'')}"
+  url = "#{Plek.new.external_url_for(app_name)}#{DEFAULT_PATHS.fetch(app_name,'')}"
+  log "application_external_url(#{app_name}) = '#{url}'"
+  url
 end
 
 def application_internal_url(app_name)
-  "#{Plek.new.find(app_name)}"
+  url = "#{Plek.new.find(app_name)}"
+  log "application_internal_url(#{app_name}) = '#{url}'"
+  url
 end


### PR DESCRIPTION
Avoid trying to use `gpg` in the final stage; it's not installed in the govuk-ruby-images base image and we don't actually need it there.

Also some minor cleanup / improvements:
- Omit the `bundle exec` from the default command, now that it's no longer needed.
- Add some files to `.dockerignore`.
- Log the base URLs from Plek that we browse to in the tests, so that it's much easier to debug when a name resolution fails.

Rollout: depends on https://github.com/alphagov/govuk-ruby-images/pull/30