### PR TITLE
Update postcode in frontend calls to avoid split-postcode page

### DIFF
--- a/features/apps/frontend.feature
+++ b/features/apps/frontend.feature
@@ -21,10 +21,10 @@ Feature: Frontend
     When I try to post to "/busking-licence" with "postcode=E20+2ST"
     Then I should see "Busking licence"
 
-  Scenario: Check the frontend can talk to Locations API
+  Scenario: Check the frontend can talk to Locations API and Local Links Manager API
     When I visit "/pay-council-tax"
     Then I should see "Pay your Council Tax"
-    When I try to post to "/pay-council-tax" with "postcode=WC2B+6SE"
+    When I try to post to "/pay-council-tax" with "postcode=WC2B+6NH"
     Then I should see "Camden"
 
   Scenario: Check the frontend can talk to Elections API

--- a/features/cdn.feature
+++ b/features/cdn.feature
@@ -15,7 +15,7 @@ Feature: CDN
 
   @replatforming
   Scenario: Check caching behaviour for POST requests
-    When I try to post to "/find-local-council" with "postcode=WC2B+6SE" without following redirects
+    When I try to post to "/find-local-council" with "postcode=WC2B+6NH" without following redirects
     Then I should not hit the cache
     Then I should see "camden"
 


### PR DESCRIPTION
This updates the postcode used in two frontend tests to WC2B 6NH, because we now have split postcode support and the previous postcode was a split one, complicating the output to test against (there's no big advantage from the point of view of the smokey test to making it use the old postcode and updating the checked output, so we just change to a non-split postcode).

## Testing

**You should manually test your PR before merging.** (DONE)

Run in integration against this branch: https://deploy.integration.publishing.service.gov.uk/job/Smokey/46012/console

See https://github.com/alphagov/smokey/blob/main/docs/deployment.md

