### PR TITLE
Make Google Analytics assertion less brittle

### DIFF
--- a/features/step_definitions/analytics.rb
+++ b/features/step_definitions/analytics.rb
@@ -1,5 +1,5 @@
 Then /^search analytics for "(.*)" are reported$/ do |term|
-  sought = "dp=#{CGI::escape("/search/all?keywords=#{term.sub(' ', '+')}")}"
+  sought = CGI::escape("/search/all?keywords=#{term.sub(' ', '+')}")
   expect(browser_has_analytics_request_containing sought).to be(true)
 end
 


### PR DESCRIPTION
According to the [Google Analytics documentation][1], events are tracked by calling the endpoint `https://www.google-analytics.com/j/collect`

To track a 'pageview' event, the request must include either the `dl` parameter, or both the `dh` and `dp` parameters.

For example, a page view of `http://example.com/foobar` could be tracked with either of the following:

- `dl=http%3A%2F%2Fexample.com%2Ffoobar`
- `dh=example.com&dp=%2Ffoobar`

Our Smokey test was trying to assert that a pageview event had been tracked for the search page by looking for the `dp` parameter:

```
dp=%2Fsearch%2Fall%3Fkeywords%3Dexample
```

However, something seems to have changed in the way Google Analytics is tracking these page views. Instead of submitting the `dh` + `dp` parameters, it now seems to be using the `dl` parameter to record the entire page URL.

Therefore, rather than seeing a `dp` parameter like the above, the request now includes the `dl` parameter:

```
dl=https%3A%2F%2Fwww.gov.uk%2Fsearch%2Fall%3Fkeywords%3Dexample
```

Which was causing the Smokey assertion to fail, because the `dp` parameter isn't sent.

To work around this, I've changed the assertion so that it only looks for the presence of the expected path in the requested URL. This should make the test suite compatible with both the `dl` and `dh` + `dp` approaches.

[1]: https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#content

## Testing

**You should manually test your PR before merging.**

See https://github.com/alphagov/smokey/blob/main/docs/deployment.md
