### PR TITLE
Fix assertion about the assets domain name.

### DIFF
--- a/features/step_definitions/whitehall_steps.rb
+++ b/features/step_definitions/whitehall_steps.rb
@@ -6,7 +6,8 @@ end
 Then(/^I should be redirected to the asset host$/) do
   asset_hosts = [
     application_external_url("assets-origin"),
-    application_external_url("assets")
+    application_external_url("assets-eks"),
+    application_external_url("assets"),
   ]
   uri = URI(@response.request.url)
   asset_url = "#{uri.scheme}://#{uri.host}"


### PR DESCRIPTION
The "Check whitehall assets are redirected to and served from the asset host" scenario can't pass on the Replatforming clusters (before going live) otherwise.