### PR TITLE
Use the default allocator instead of jemalloc.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Remove Cucumber advert.
 ENV CUCUMBER_PUBLISH_QUIET=true
+# Use the default glibc malloc.
+ENV LD_PRELOAD=""
 
 # Install Google Chrome and the corresponding version of ChromeDriver.
 ARG google_package_keyring


### PR DESCRIPTION
Chromedriver seems to be having a problem since we switched the base image to jemalloc. Let's see if it's causal.

This only affects the k8s environments.
