### PR TITLE
Add tests for sidekiq-monitoring

### DIFF
--- a/features/apps/sidekiq_monitoring.feature
+++ b/features/apps/sidekiq_monitoring.feature
@@ -1,0 +1,66 @@
+@app-sidekiq-monitoring
+Feature: Sidekiq Monitoring
+  @app-sidekiq-monitoring
+  Scenario: Can open sidekiq-monitoring for Asset Manager
+    When I go to the sidekiq-monitoring page for "asset-manager"
+    Then I should see the dashboard
+  Scenario: Can open sidekiq-monitoring for Collections Publisher
+    When I go to the sidekiq-monitoring page for "collections-publisher"
+    Then I should see the dashboard
+  Scenario: Can open sidekiq-monitoring for Content Data Admin
+    When I go to the sidekiq-monitoring page for "content-data-admin"
+    Then I should see the dashboard
+  Scenario: Can open sidekiq-monitoring for Content Data API
+    When I go to the sidekiq-monitoring page for "content-data-api"
+    Then I should see the dashboard
+  Scenario: Can open sidekiq-monitoring for Content Publisher
+    When I go to the sidekiq-monitoring page for "content-publisher"
+    Then I should see the dashboard
+  Scenario: Can open sidekiq-monitoring for Content Tagger
+    When I go to the sidekiq-monitoring page for "content-tagger"
+    Then I should see the dashboard
+  Scenario: Can open sidekiq-monitoring for Email Alert API
+    When I go to the sidekiq-monitoring page for "email-alert-api"
+    Then I should see the dashboard
+  Scenario: Can open sidekiq-monitoring for Imminence
+    When I go to the sidekiq-monitoring page for "imminence"
+    Then I should see the dashboard
+  Scenario: Can open sidekiq-monitoring for Link Checker API
+    When I go to the sidekiq-monitoring page for "link-checker-api"
+    Then I should see the dashboard
+  Scenario: Can open sidekiq-monitoring for Locations API
+    When I go to the sidekiq-monitoring page for "locations-api"
+    Then I should see the dashboard
+  Scenario: Can open sidekiq-monitoring for Manuals Publisher
+    When I go to the sidekiq-monitoring page for "manuals-publisher"
+    Then I should see the dashboard
+  Scenario: Can open sidekiq-monitoring for Publisher
+    When I go to the sidekiq-monitoring page for "publisher"
+    Then I should see the dashboard
+  Scenario: Can open sidekiq-monitoring for Publishing API
+    When I go to the sidekiq-monitoring page for "publishing-api"
+    Then I should see the dashboard
+  Scenario: Can open sidekiq-monitoring for Search Admin
+    When I go to the sidekiq-monitoring page for "search-admin"
+    Then I should see the dashboard
+  Scenario: Can open sidekiq-monitoring for Search API
+    When I go to the sidekiq-monitoring page for "search-api"
+    Then I should see the dashboard
+  Scenario: Can open sidekiq-monitoring for Signon
+    When I go to the sidekiq-monitoring page for "signon"
+    Then I should see the dashboard
+  Scenario: Can open sidekiq-monitoring for Specialist Publisher
+    When I go to the sidekiq-monitoring page for "specialist-publisher"
+    Then I should see the dashboard
+  Scenario: Can open sidekiq-monitoring for Support API
+    When I go to the sidekiq-monitoring page for "support-api"
+    Then I should see the dashboard
+  Scenario: Can open sidekiq-monitoring for Transition
+    When I go to the sidekiq-monitoring page for "transition"
+    Then I should see the dashboard
+  Scenario: Can open sidekiq-monitoring for Travel Advice Publisher
+    When I go to the sidekiq-monitoring page for "travel-advice-publisher"
+    Then I should see the dashboard
+  Scenario: Can open sidekiq-monitoring for Whitehall
+    When I go to the sidekiq-monitoring page for "whitehall"
+    Then I should see the dashboard

--- a/features/step_definitions/sidekiq_monitoring_steps.rb
+++ b/features/step_definitions/sidekiq_monitoring_steps.rb
@@ -1,0 +1,7 @@
+When /^I go to the sidekiq-monitoring page for "(.*)"$/ do |term|
+  visit_path "#{application_internal_url('sidekiq-monitoring')}/#{term}"
+end
+
+Then /^I should see the dashboard$/ do
+  expect(page.body).to have_text('Dashboard')
+end


### PR DESCRIPTION
These ensure we are able to load the dashboard for the sidekiq monitoring of each application where it is used.

This has been tested in https://deploy.integration.publishing.service.gov.uk/job/Smokey/49158/console.

[Trello card](https://trello.com/c/aVx282Rt)