### PR TITLE
Don't probe sidekiq dashboard app on k8s.

### DIFF
--- a/features/apps/sidekiq_monitoring.feature
+++ b/features/apps/sidekiq_monitoring.feature
@@ -1,6 +1,5 @@
-@app-sidekiq-monitoring
+@app-sidekiq-monitoring @notreplatforming
 Feature: Sidekiq Monitoring
-  @app-sidekiq-monitoring
   Scenario: Can open sidekiq-monitoring for Asset Manager
     When I go to the sidekiq-monitoring page for "asset-manager"
     Then I should see the dashboard


### PR DESCRIPTION
We're not running the [sidekiq-monitoring dashboard app](https://github.com/alphagov/sidekiq-monitoring) in k8s.

Test run passed on the integration cluster.