### PR TITLE
Fix an opaque step name.

### DIFF
--- a/features/origin.feature
+++ b/features/origin.feature
@@ -28,7 +28,7 @@ Feature: Origin
   @app-authenticating-proxy
   Scenario: Check visiting a draft page requires a signon session
     Given I am testing "draft-origin"
-    When I attempt to go to a case study
+    When I attempt to visit "government/case-studies/example-case-studies-eu-citizens-rights-in-the-uk"
     Then I should be prompted to log in
     When I log in using valid credentials
     Then I should be on the case study page

--- a/features/step_definitions/draft_environment_steps.rb
+++ b/features/step_definitions/draft_environment_steps.rb
@@ -1,7 +1,3 @@
-When /^I attempt to go to a case study$/ do
-  visit_path "government/case-studies/example-case-studies-eu-citizens-rights-in-the-uk"
-end
-
 When /^I attempt to visit "(.*?)"$/ do |path|
   visit_path path
 end


### PR DESCRIPTION
The `Check visiting a draft page requires a signon session` scenario contained the step `When I attempt to go to a case study`, which was unhelpful because it didn't say what page it was actually requesting.

It was also a redundant step definition, as it was just a special case of the `when I visit` step.

### Test runs

<details><summary>Output when succeeding</summary>

```
  @app-authenticating-proxy
  Scenario: Check visiting a draft page requires a signon session                                       # features/origin.feature:29
    Given I am testing "draft-origin"                                                                   # features/step_definitions/smokey_steps.rb:3
      application_external_url(draft-origin) = 'https://draft-origin.eks.integration.govuk.digital'
    When I attempt to visit "government/case-studies/example-case-studies-eu-citizens-rights-in-the-uk" # features/step_definitions/draft_environment_steps.rb:1
    Then I should be prompted to log in                                                                 # features/step_definitions/draft_environment_steps.rb:5
    When I log in using valid credentials                                                               # features/step_definitions/draft_environment_steps.rb:9
    Then I should be on the case study page                                                             # features/step_definitions/draft_environment_steps.rb:15
    And the page should contain the draft watermark                                                     # features/step_definitions/draft_environment_steps.rb:20
```
</details>

<details><summary>Output when failing</summary>

```
  @app-authenticating-proxy
  Scenario: Check visiting a draft page requires a signon session                                       # features/origin.feature:29
    Given I am testing "draft-origin"                                                                   # features/step_definitions/smokey_steps.rb:3
      application_external_url(draft-origin) = 'https://draft-origin.eks.staging.govuk.digital'
    When I attempt to visit "government/case-studies/example-case-studies-eu-citizens-rights-in-the-uk" # features/step_definitions/draft_environment_steps.rb:1
    Then I should be prompted to log in                                                                 # features/step_definitions/draft_environment_steps.rb:5
    When I log in using valid credentials                                                               # features/step_definitions/draft_environment_steps.rb:9
    Then I should be on the case study page                                                             # features/step_definitions/draft_environment_steps.rb:15
      
      expected: "/government/case-studies/example-case-studies-eu-citizens-rights-in-the-uk"
           got: "/settled-status-eu-citizens-families"
      
      (compared using ==)
       (RSpec::Expectations::ExpectationNotMetError)
      ./features/step_definitions/draft_environment_steps.rb:16:in `/^I should be on the case study page$/'
      features/origin.feature:34:in `I should be on the case study page'
    And the page should contain the draft watermark                                                     # features/step_definitions/draft_environment_steps.rb:20
```
</details>