### PR TITLE
Disable CKAN probes on Kubernetes for now.

### DIFF
--- a/features/data_gov_uk.feature
+++ b/features/data_gov_uk.feature
@@ -17,13 +17,13 @@ Feature: Data.gov.uk
     When I request "/dataset/lidar-composite-dtm-2017-1m.rdf"
     Then I should get a 200 status code
 
-  @notintegration @notstaging
+  @notintegration @notstaging @notreplatforming
   Scenario: Check CKAN loads correctly
     Given I am testing "ckan"
     When I request "/"
     Then I should see "Data publisher"
 
-  @notintegration @notstaging
+  @notintegration @notstaging @notreplatforming
   Scenario: Check CKAN action api's search works
     Given I am testing "ckan"
     And I try not to bypass caching


### PR DESCRIPTION
We're not running CKAN on Kubernetes in production just yet.