### PR TITLE
Stop grouping error reports in Sentry

### DIFF
--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -42,11 +42,8 @@ def capture_error(scenario, exception, js: false)
 
     # Adding the scenario supports further drill down using the
     # Sentry "tags" view. Substituting " is necessary for search.
-    # Using the feature (file) as the fingerprint means we only
-    # get one issue per feature, keeping the dashboard simple.
     GovukError.notify(
       message,
-      fingerprint: [scenario.location.file],
       backtrace: exception.backtrace,
       tags: {
         'cucumber.scenario': scenario.name.gsub('"', "'"),


### PR DESCRIPTION
[Trello card](https://trello.com/c/Eb4Nvyjg/3172-audit-and-identify-flakey-smokey-tests-3)

Currently, the events we send to Sentry are grouped by feature. This means that if a feature contains several flakey tests then the failures all get jumbled together and the only way to see them all is to click back/forward inside Sentry dozens/hundreds of times until you find something new.

## Testing

**You should manually test your PR before merging.**

See https://github.com/alphagov/smokey/blob/main/docs/deployment.md
