### PR TITLE
Update/Remove licence-finder tests

### DIFF
--- a/features/apps/frontend.feature
+++ b/features/apps/frontend.feature
@@ -15,10 +15,10 @@ Feature: Frontend
     Then the page view should be tracked
 
   Scenario: Check the frontend can talk to Licensing
-    When I visit "/busking-licence"
+    When I visit "/find-licences/busking-licence"
     Then I should see "Busking licence"
     And I should see an input field for postcode
-    When I try to post to "/busking-licence" with "postcode=E20+2ST"
+    When I try to post to "/find-licences/busking-licence" with "postcode=E20+2ST"
     Then I should see "Busking licence"
 
   Scenario: Check the frontend can talk to Asset Manager

--- a/features/apps/licence_finder.feature
+++ b/features/apps/licence_finder.feature
@@ -1,6 +1,0 @@
-@app-licencefinder @replatforming
-Feature: Licence Finder
-
-  Scenario: Check licence finder returns licences
-    When I visit "/licence-finder/licences?activities=149&location=wales&sectors=59"
-    Then I should see "A premises licence is for carrying out 'licensable activities' at a particular venue"


### PR DESCRIPTION
Licence Finder is being retired, and licence URLs are going to update (although redirects will be in place for them).

- Remove licence finder test (it no longer exists)
- Update URL in frontend test to check it can talk to licensing so that it doesn't go through the redirect.

https://trello.com/c/VWSPy1u4/2055-create-pr-updating-smokey-test

Has been tested locally against integration - the updated test as expected fails when the new licence finder licence urls are not present, but passes when the licence data import task has been run.

## Testing

**You should manually test your PR before merging.**

See https://github.com/alphagov/smokey/blob/main/docs/deployment.md
