### PR TITLE
Move CSV Preview test from Whitehall to Frontend

### DIFF
--- a/features/apps/frontend.feature
+++ b/features/apps/frontend.feature
@@ -21,6 +21,10 @@ Feature: Frontend
     When I try to post to "/busking-licence" with "postcode=E20+2ST"
     Then I should see "Busking licence"
 
+  Scenario: Check the frontend can talk to Asset Manager
+    When I visit "/government/uploads/system/uploads/attachment_data/file/214962/passport-impact-indicat.csv/preview"
+    Then I should see "Passport impact indicators - CSV version" 
+
   Scenario: Check the frontend can talk to Locations API and Local Links Manager API
     When I visit "/pay-council-tax"
     Then I should see "Pay your Council Tax"

--- a/features/apps/whitehall.feature
+++ b/features/apps/whitehall.feature
@@ -10,11 +10,6 @@ Feature: Whitehall
     Then I should be redirected to the asset host
     And the attachment should be served successfully
 
-  @app-asset-manager
-  Scenario: Check the frontend can talk to Asset Manager
-    When I visit "/government/uploads/system/uploads/attachment_data/file/214962/passport-impact-indicat.csv/preview"
-    Then JavaScript should run without any errors
-
   @app-publishing-api
   Scenario: Can log in to whitehall
     When I go to the "whitehall-admin" landing page


### PR DESCRIPTION
CSV Previews are now rendered by Frontend, instead of Asset Manager, so we need to test that application instead.

Depends on https://github.com/alphagov/govuk-helm-charts/pull/1186.

[Trello card](https://trello.com/c/1kmt0VHe)
