### PR TITLE
Chromedriver 115 fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,18 +27,21 @@ ENV LD_PRELOAD=""
 
 # Install Google Chrome and the corresponding version of ChromeDriver.
 ARG google_package_keyring
-ARG chromedriver_url=https://chromedriver.storage.googleapis.com/
+ARG chromedriver_url=https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing
+
 COPY --from=builder $google_package_keyring $google_package_keyring
 RUN arch=$(dpkg --print-architecture) && \
     echo "deb [arch=${arch} signed-by=${google_package_keyring}] https://dl.google.com/linux/chrome/deb/ stable main" \
         > /etc/apt/sources.list.d/google.list
 RUN install_packages dumb-init google-chrome-stable unzip
 # TODO: support arm64 when available (perhaps by just switching back to ChromiumDriver?).
-RUN chrome_ver=$(google-chrome --version | grep -Po '\d+\.\d+\.\d+') && \
-    chromedriver_ver=$(curl -LSfs "${chromedriver_url}LATEST_RELEASE_${chrome_ver}") && \
-    curl -LSfs "${chromedriver_url}${chromedriver_ver}/chromedriver_linux64.zip" \
-        | funzip >/usr/bin/chromedriver && \
-    chmod 755 /usr/bin/chromedriver
+RUN chrome_ver=$(google-chrome --version | grep -Po '\d+\.\d+\.\d+\.\d+') && \
+        curl -o /tmp/chromedriver-linux64.zip "${chromedriver_url}/${chrome_ver}/linux64/chromedriver-linux64.zip" && \
+        unzip -j /tmp/chromedriver-linux64.zip chromedriver-linux64/chromedriver && \
+        mv chromedriver /usr/bin/ && \
+        chmod 755 /usr/bin/chromedriver && \
+        rm -fr /tmp/*
+
 
 WORKDIR $APP_HOME
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/


### PR DESCRIPTION
Chromedriver distribution has changed - the base URL for chromedriver packages has been updated, and the files that are downloaded have changed structure. They now include an internal directory, and the order is licence file first, then chromedriver. 

This means we can't use funzip, since that will only unzip the first file in a zip file. Unzip will handle it more gracefully, but can't take an input from stdin. So we download the file to /tmp, unzip the chromedriver from it, move it to the correct directory, then delete the tmp zipfile.

## Testing

**You should manually test your PR before merging.**

See https://github.com/alphagov/smokey/blob/main/docs/deployment.md
