### PR TITLE
Reapply licence smoke test in integration

### DIFF
--- a/features/apps/frontend.feature
+++ b/features/apps/frontend.feature
@@ -14,7 +14,6 @@ Feature: Frontend
     And I consent to cookies
     Then the page view should be tracked
 
-  @notintegration
   Scenario: Check the frontend can talk to Licensing
     When I visit "/find-licences/busking-licence"
     Then I should see "Busking licence"


### PR DESCRIPTION
We disabled the busking-licence test as there was datasync issues, however this seems to be resolved now so we can reapply the test in integration.

https://www.integration.publishing.service.gov.uk/find-licences/busking-licence

## Testing

**You should manually test your PR before merging.**

See https://github.com/alphagov/smokey/blob/main/docs/deployment.md
