### PR TITLE
Update manuals publisher test following update to MP

### DIFF
--- a/features/apps/manuals_publisher.feature
+++ b/features/apps/manuals_publisher.feature
@@ -6,7 +6,7 @@ Feature: Manuals Publisher
     And I try to login as a user
     And I go to the "manuals-publisher" landing page
     Then I should see "Manuals Publisher"
-    And I should see "Sign out"
+    And I should see "Log out"
     And I should see "Your manuals"
     And I should see "New manual"
 


### PR DESCRIPTION
The text for the sign out link in the manuals publisher header has changed from "Sign out" to "Log out" as part of the transition to using the GDS design system. Update the smokey test to expect the new text.
