### PR TITLE
Remove licence finder from base paths now it's retired.

### DIFF
--- a/features/support/base_urls.rb
+++ b/features/support/base_urls.rb
@@ -4,7 +4,6 @@ DEFAULT_PATHS = {
   'contacts' => '/hm-revenue-customs',
   'contacts-admin' => '/admin',
   'imminence' => '/admin',
-  'licensefinder' => '/licence-finder',
   'licensify-admin' => '/login',
   'licensing' => '/apply-for-a-license',
   'maslow' => '/needs',


### PR DESCRIPTION
https://trello.com/c/1VXQW5I1/2127-epic-retire-original-licence-finder-application

## Testing

**You should manually test your PR before merging.**

See https://github.com/alphagov/smokey/blob/main/docs/deployment.md
