### PR TITLE
Update structure of selecting element for clicking on a result

### DIFF
--- a/features/step_definitions/finder_frontend_steps.rb
+++ b/features/step_definitions/finder_frontend_steps.rb
@@ -11,7 +11,7 @@ When /^I go to the next page$/ do
 end
 
 When /^I click result (.*)$/ do |num|
-  all(".finder-results li a.gem-c-document-list__item-title")[num.to_i - 1].click
+  all(".finder-results li a.gem-c-document-list__item-title a")[num.to_i - 1].click
 end
 
 Then /^I should see some search results$/ do


### PR DESCRIPTION
Updating this for the same reason a test was recently updated in a [Finder Frontend PR](https://github.com/alphagov/finder-frontend/commit/f49a2d9c6544f866461b83c805e697efb2e41e70) 'Document list structure recently changed, __item-title is no longer the link but contains the link'.

This is in response to a [smoke test failure](https://argo-workflows.eks.production.govuk.digital/workflows/apps/finder-frontend-post-sync-j8qmp[…]-sync-j8qmp-3226574498&nodePanelView=containers) which was blocking deploys to staging and prod. 

## Testing

**You should manually test your PR before merging.**

See https://github.com/alphagov/smokey/blob/main/docs/deployment.md
