### PR TITLE
Remove unhelpful assertions from smoke tests.

### DIFF
--- a/features/apps/collections_publisher.feature
+++ b/features/apps/collections_publisher.feature
@@ -6,6 +6,4 @@ Feature: Collections Publisher
     And I try to login as a user
     And I go to the "collections-publisher" landing page
     Then I should see "Collections Publisher"
-    And I should see "Log out"
-    And I should see "Mainstream browse pages"
     And I should see "Add a mainstream browse page"

--- a/features/apps/contacts_admin.feature
+++ b/features/apps/contacts_admin.feature
@@ -5,7 +5,5 @@ Feature: Contacts Admin
     When I go to the "contacts-admin" landing page
     And I try to login as a user
     And I go to the "contacts-admin" landing page
-    Then I should see "GOV.UK Contacts"
-    And I should see "Sign out"
-    And I should see "Contacts"
+    Then I should see "Contacts"
     And I should see "Add contact"

--- a/features/apps/content_data_admin.feature
+++ b/features/apps/content_data_admin.feature
@@ -5,10 +5,8 @@ Feature: Content Data Admin
     And I try to login as a user
     And I go to the "content-data-admin" landing page
     Then I should see "Content Data"
-    And I should see "Log out"
 
   Scenario: Check admin can talk to Content Data API
     When I try to login as a user
     And I visit "/metrics/government/organisations/government-digital-service" on the "content-data-admin" application
     Then I should see "Page data"
-    And I should see "Organisation"

--- a/features/apps/content_publisher.feature
+++ b/features/apps/content_publisher.feature
@@ -6,5 +6,4 @@ Feature: Content Publisher
     And I try to login as a user
     And I go to the "content-publisher" landing page
     Then I should see "Content Publisher"
-    And I should see "Log out"
     And I should see "Documents"

--- a/features/apps/content_tagger.feature
+++ b/features/apps/content_tagger.feature
@@ -6,5 +6,4 @@ Feature: Content Tagger
     And I try to login as a user
     And I go to the "content-tagger" landing page
     Then I should see "Content Tagger"
-    And I should see "Sign out"
     And I should see "Taxons"

--- a/features/apps/imminence.feature
+++ b/features/apps/imminence.feature
@@ -5,6 +5,5 @@ Feature: Imminence
     When I go to the "imminence" landing page
     And I try to login as a user
     And I go to the "imminence" landing page
-    Then I should see "GOV.UK Imminence"
-    And I should see "Sign out"
+    Then I should see "Imminence"
     And I should see "All services"

--- a/features/apps/local_links_manager.feature
+++ b/features/apps/local_links_manager.feature
@@ -6,5 +6,4 @@ Feature: Local Links Manager
     And I try to login as a user
     And I go to the "local-links-manager" landing page
     Then I should see "Local Links Manager"
-    And I should see "Sign out"
     And I should see "Council"

--- a/features/apps/manuals_publisher.feature
+++ b/features/apps/manuals_publisher.feature
@@ -6,7 +6,5 @@ Feature: Manuals Publisher
     And I try to login as a user
     And I go to the "manuals-publisher" landing page
     Then I should see "Manuals Publisher"
-    And I should see "Log out"
-    And I should see "Your manuals"
     And I should see "New manual"
 

--- a/features/apps/maslow.feature
+++ b/features/apps/maslow.feature
@@ -5,6 +5,5 @@ Feature: Maslow
     When I go to the "maslow" landing page
     And I try to login as a user
     And I go to the "maslow" landing page
-    Then I should see "GOV.UK Maslow"
-    And I should see "Sign out"
+    Then I should see "Maslow"
     And I should see "All needs"

--- a/features/apps/publisher.feature
+++ b/features/apps/publisher.feature
@@ -5,6 +5,5 @@ Feature: Publisher
     When I go to the "publisher" landing page
     And I try to login as a user
     And I go to the "publisher" landing page
-    Then I should see "GOV.UK Publisher"
-    And I should see "Sign out"
+    Then I should see "Publisher"
     And I should see Publisher's publication index

--- a/features/apps/service_manual_publisher.feature
+++ b/features/apps/service_manual_publisher.feature
@@ -5,6 +5,5 @@ Feature: Service Manual Publisher
     When I go to the "service-manual-publisher" landing page
     And I try to login as a user
     And I go to the "service-manual-publisher" landing page
-    Then I should see "GOV.UK Service Manual Publisher"
-    And I should see "Sign out"
+    Then I should see "Service Manual Publisher"
     And I should see "Create a Guide"

--- a/features/apps/short_url_manager.feature
+++ b/features/apps/short_url_manager.feature
@@ -5,7 +5,5 @@ Feature: Short URL Manager
     When I go to the "short-url-manager" landing page
     And I try to login as a user
     And I go to the "short-url-manager" landing page
-    Then I should see "Short URL manager"
-    And I should see "Sign out"
-    And I should see "Dashboard"
-    And I should see "Request a new URL redirect or short URL"
+    Then I should see "Short URL"
+    And I should see "Request a new"

--- a/features/apps/specialist_publisher.feature
+++ b/features/apps/specialist_publisher.feature
@@ -5,7 +5,5 @@ Feature: Specialist Publisher
     When I go to the "specialist-publisher" landing page
     And I try to login as a user
     And I go to the "specialist-publisher" landing page
-    Then I should see "GOV.UK Specialist Publisher"
-    And I should see "Sign out"
-    And I should see "CMA Cases"
-    And I should see "Add another CMA Case"
+    Then I should see "Specialist Publisher"
+    And I should see "Add another"

--- a/features/apps/travel_advice_publisher.feature
+++ b/features/apps/travel_advice_publisher.feature
@@ -5,6 +5,5 @@ Feature: Travel Advice Publisher
     When I go to the "travel-advice-publisher" landing page
     And I try to login as a user
     And I go to the "travel-advice-publisher" landing page
-    Then I should see "GOV.UK Travel Advice Publisher"
-    And I should see "Log out"
+    Then I should see "Travel Advice Publisher"
     And I should see "All countries"


### PR DESCRIPTION
These end-to-end tests contained unnecessary [change detectors](https://testing.googleblog.com/2015/01/testing-on-toilet-change-detector-tests.html), which are of negative value because they break unexpectedly for reasons unrelated to the behaviours that they're trying to test.

These tests are all meant simply to assert that a user was able to see the logged-in front page of each app. One of them recently broke because the string "Sign out" was changed to "Log out".

Tested: no new test failures in integration.