### PR TITLE
Use @puppeteer/browsers to install chromedriver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,20 +27,15 @@ ENV LD_PRELOAD=""
 
 # Install Google Chrome and the corresponding version of ChromeDriver.
 ARG google_package_keyring
-ARG chromedriver_url=https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing
 
 COPY --from=builder $google_package_keyring $google_package_keyring
 RUN arch=$(dpkg --print-architecture) && \
     echo "deb [arch=${arch} signed-by=${google_package_keyring}] https://dl.google.com/linux/chrome/deb/ stable main" \
         > /etc/apt/sources.list.d/google.list
 RUN install_packages dumb-init google-chrome-stable unzip
-# TODO: support arm64 when available (perhaps by just switching back to ChromiumDriver?).
-RUN chrome_ver=$(google-chrome --version | grep -Po '\d+\.\d+\.\d+\.\d+') && \
-        curl -o /tmp/chromedriver-linux64.zip "${chromedriver_url}/${chrome_ver}/linux64/chromedriver-linux64.zip" && \
-        unzip -j /tmp/chromedriver-linux64.zip chromedriver-linux64/chromedriver && \
-        mv chromedriver /usr/bin/ && \
-        chmod 755 /usr/bin/chromedriver && \
-        rm -fr /tmp/*
+RUN npm install @puppeteer/browsers && \
+  npx @puppeteer/browsers install chromedriver@stable --path / && \
+  mv /chromedriver/*/chromedriver-linux64/chromedriver /usr/bin/chromedriver
 
 
 WORKDIR $APP_HOME


### PR DESCRIPTION
This is the recommended approach for chromedriver versions 115 and onwards[^1], which are no longer available via the old route (therefore rendering our build script broken).

I have removed the version matching between chrome and chromedriver, because there is currently a version mismatch (the corresponding chromedriver for the current version of chrome isn't available yet). However, because we install the latest stable release of each, they _should_ be compatible with each other in most cases.

It _should_ be possible to install Chrome itself with the same npx script, but the script does not automatically install Chrome's dependencies (unlike the Ubuntu package that we currently use), so this would require other changes to our build script.

This is live in integration right now, and nothing appears to be broken 🤞 

[^1]: https://chromedriver.chromium.org/downloads/version-selection#h.4wiyvw42q63v