### PR TITLE
Update search result selector

### DIFF
--- a/features/step_definitions/finder_frontend_steps.rb
+++ b/features/step_definitions/finder_frontend_steps.rb
@@ -11,7 +11,7 @@ When /^I go to the next page$/ do
 end
 
 When /^I click result (.*)$/ do |num|
-  all(".finder-results li a.gem-c-document-list__item-title a")[num.to_i - 1].click
+  all(".finder-results li .gem-c-document-list__item-title a")[num.to_i - 1].click
 end
 
 Then /^I should see some search results$/ do


### PR DESCRIPTION
We don't have `a` tags nested in each other. This means the test can't find the search result to click on.

The search result markup looks like this (trimmed for brevity):

```
<div class="gem-c-document-list__item-title">
  <a class="  govuk-link" href="/pay-dartford-crossing-charge">Pay the Dartford Crossing charge (Dart Charge)</a>
</div>
```

so removing the first `a`, should fix things.

