### PR TITLE
Add test for media path

### DIFF
--- a/features/apps/frontend.feature
+++ b/features/apps/frontend.feature
@@ -21,9 +21,13 @@ Feature: Frontend
     When I try to post to "/find-licences/busking-licence" with "postcode=E20+2ST"
     Then I should see "Busking licence"
 
-  Scenario: Check the frontend can talk to Asset Manager
+  Scenario: Check the frontend can talk to Asset Manager with government upload path
     When I visit "/government/uploads/system/uploads/attachment_data/file/214962/passport-impact-indicat.csv/preview"
-    Then I should see "Passport impact indicators - CSV version" 
+    Then I should see "Passport impact indicators - CSV version"
+
+  Scenario: Check the frontend can talk to Asset Manager with media path
+    When I visit "/media/5a7b9f8ced915d4147621960/passport-impact-indicat.csv/preview"
+    Then I should see "Passport impact indicators - CSV version"
 
   Scenario: Check the frontend can talk to Locations API and Local Links Manager API
     When I visit "/pay-council-tax"

--- a/features/apps/frontend.feature
+++ b/features/apps/frontend.feature
@@ -21,6 +21,10 @@ Feature: Frontend
     When I try to post to "/find-licences/busking-licence" with "postcode=E20+2ST"
     Then I should see "Busking licence"
 
+  Scenario: Check the frontend can talk to Asset Manager
+    When I visit "/government/uploads/system/uploads/attachment_data/file/214962/passport-impact-indicat.csv/preview"
+    Then I should see "Passport impact indicators - CSV version" 
+
   Scenario: Check the frontend can talk to Locations API and Local Links Manager API
     When I visit "/pay-council-tax"
     Then I should see "Pay your Council Tax"


### PR DESCRIPTION
Frontend currently renders csv previews using `/government/uploads` path and `/media/:id/:filename` path.
This PR reverts the temporary commit to remove test for `/government/uploads` path and test for `/media/:id/:filename` path.

[Trello](https://trello.com/c/yDmtjPXG/199-task-frontend-smokey-tests-to-test-csv-preview-dependencies)