### PR TITLE
Add comment about GA4 to user-agent lines

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -30,6 +30,7 @@ Capybara.register_driver :headless_chrome do |app|
   options.add_argument("--disable-gpu")
   options.add_argument("--disable-web-security")
   options.add_argument("--disable-xss-auditor")
+  # Note: the user agent is being used to filter GA4 data from production in govuk_publishing_components
   options.add_argument("--user-agent='Smokey Test / Ruby'")
   options.add_argument("--no-sandbox") if ENV.key?("NO_SANDBOX")
   options.add_argument("--ignore-certificate-errors") if ENV.key?("CHROME_ACCEPT_INSECURE_CERTS")

--- a/features/support/http_requests.rb
+++ b/features/support/http_requests.rb
@@ -73,6 +73,7 @@ def do_http_request(url, method = :get, options = {}, &block)
     options = options.merge(cookies: cookies)
   end
 
+  # Note: the user agent is being used to filter GA4 data from production in govuk_publishing_components
   headers = {
     'User-Agent' => 'Smokey Test / Ruby',
     'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',


### PR DESCRIPTION
## What
Adds a comment about how the user agent is now being used by GA4.

## Why
So that devs are aware if they want to change the value.

## Testing

**You should manually test your PR before merging.**

See https://github.com/alphagov/smokey/blob/main/docs/deployment.md
