### PR TITLE
Revert "Bump selenium-webdriver from 4.15.0 to 4.16.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -387,7 +387,7 @@ GEM
     rubyzip (2.3.2)
     selenium-devtools (0.119.0)
       selenium-webdriver (~> 4.2)
-    selenium-webdriver (4.16.0)
+    selenium-webdriver (4.15.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)


### PR DESCRIPTION
This reverts commit 171db8a7dbbbc017cad667fe8b8ba31960d66e16.

## Testing

**You should manually test your PR before merging.**

See https://github.com/alphagov/smokey/blob/main/docs/deployment.md
