### PR TITLE
Remove legacy CSV preview test from frontend

### DIFF
--- a/features/apps/frontend.feature
+++ b/features/apps/frontend.feature
@@ -21,10 +21,6 @@ Feature: Frontend
     When I try to post to "/find-licences/busking-licence" with "postcode=E20+2ST"
     Then I should see "Busking licence"
 
-  Scenario: Check the frontend can talk to Asset Manager with government upload path
-    When I visit "/government/uploads/system/uploads/attachment_data/file/214962/passport-impact-indicat.csv/preview"
-    Then I should see "Passport impact indicators - CSV version"
-
   Scenario: Check the frontend can talk to Asset Manager with media path
     When I visit "/media/5a7b9f8ced915d4147621960/passport-impact-indicat.csv/preview"
     Then I should see "Passport impact indicators - CSV version"


### PR DESCRIPTION
Legacy preview endpoint for frontend is already removed, so we can remove the test as well.

[Trello card](https://trello.com/c/Kp9nquOr/71-task-remove-whitehallasset-concept-from-asset-manager-and-gds-api-adapters)