### PR TITLE
Update options so the new chrome driver version 120 will work

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -24,7 +24,7 @@ GovukError.configure
 
 Capybara.register_driver :headless_chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new
-  options.add_argument("--headless")
+  options.add_argument("--headless=new")
   options.add_argument("--disable-dev-shm-usage")
   options.add_argument("--disable-extensions")
   options.add_argument("--disable-gpu")


### PR DESCRIPTION
Within the cucumber tests, fetching logs from the driver is broken with the new chrome version 119 -> 120 upgrade. This issue seems to be solved in this github issue thread by updating the options to '--headless=new' SeleniumHQ/selenium#13112

This is from the [same issue in another repo](https://github.com/alphagov/govuk_test/pull/68)
