### PR TITLE
Use old headless chrome

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -24,7 +24,7 @@ GovukError.configure
 
 Capybara.register_driver :headless_chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new
-  options.add_argument("--headless=new")
+  options.add_argument("--headless=old")
   options.add_argument("--disable-dev-shm-usage")
   options.add_argument("--disable-extensions")
   options.add_argument("--disable-gpu")


### PR DESCRIPTION
This switches our selenium driver to start chrome in the old headless mode. Using the new headless mode Chrome fails to start.
