### PR TITLE
WIP: Run Smokey tests against the standby CDN

### DIFF
--- a/features/apps/collections.feature
+++ b/features/apps/collections.feature
@@ -1,6 +1,7 @@
 @app-collections @replatforming
 Feature: Collections
 
+  @bothcdns
   Scenario: Check the frontend can talk to Content Store
     When I visit "/browse/driving"
     And I should see "Teaching people to drive"

--- a/features/mirror.feature
+++ b/features/mirror.feature
@@ -1,13 +1,23 @@
 @local-network
 Feature: Mirror
-    @notintegration @notstaging
-    Scenario: Check homepage is served by all the mirrors
-      Given S3 mirrors
-      Then I should get a 200 response from "/www.gov.uk/index.html" on the mirrors
-      And I should see "Welcome to GOV.UK"
+  @notintegration @notstaging
+  Scenario Outline: Check homepage is served by all the mirrors
+    Given there is an S3 mirror <mirror>
+    Then I should get a 200 response from "/www.gov.uk/index.html" on the mirror
+    And I should see "Welcome to GOV.UK"
 
-    @notintegration @notstaging
-    Scenario: Check a deep-linked page is served by all the mirrors
-      Given S3 mirrors
-      Then I should get a 200 response from "/www.gov.uk/book-theory-test.html" on the mirrors
-      And I should see "Book your theory test"
+    Examples:
+      | mirror                                                   |
+      | https://govuk-production-mirror.s3.amazonaws.com         |
+      | https://govuk-production-mirror-replica.s3.amazonaws.com |
+
+  @notintegration @notstaging
+  Scenario Outline: Check a deep-linked page is served by all the mirrors
+    Given there is an S3 mirror <mirror>
+    Then I should get a 200 response from "/www.gov.uk/book-theory-test.html" on the mirror
+    And I should see "Book your theory test"
+
+    Examples:
+      | mirror                                                   |
+      | https://govuk-production-mirror.s3.amazonaws.com         |
+      | https://govuk-production-mirror-replica.s3.amazonaws.com |

--- a/features/step_definitions/ab_testing_steps.rb
+++ b/features/step_definitions/ab_testing_steps.rb
@@ -10,6 +10,13 @@ Given(/^I do not have any A\/B testing cookies set$/) do
   expect(all_cookies).to_not include("ABTest-Example")
 end
 
+When(/^multiple new users visit "(.*?)"$/) do |path|
+  @responses = []
+  20.times do
+    @responses << get_request("#{@host}#{path}", default_request_options)
+  end
+end
+
 Then(/^we have shown them all versions of the A\/B test$/) do
   buckets = @responses.map { |r| ab_bucket(r.body) }.to_set
   expect(buckets).to eq(Set.new ["A", "B"])

--- a/features/step_definitions/ab_testing_steps.rb
+++ b/features/step_definitions/ab_testing_steps.rb
@@ -29,7 +29,7 @@ Then(/^I am assigned to a test bucket$/) do
 end
 
 Then(/^I can see the bucket I am assigned to$/) do
-  bucket = ab_bucket(page.body)
+  bucket = ab_bucket(govuk_page.body)
   expect(["A", "B"]).to include(bucket)
 
   # Store bucket so that subsequent responses can be compared to the original

--- a/features/step_definitions/datagovuk_steps.rb
+++ b/features/step_definitions/datagovuk_steps.rb
@@ -3,7 +3,7 @@ When /^I search for "(.*)" in datasets$/ do |term|
 end
 
 Then /^I should see some dataset results$/ do
-  result_links = page.all(".dgu-results__result")
+  result_links = govuk_page.all(".dgu-results__result")
   expect(result_links.count).to be >= 1
 end
 
@@ -12,12 +12,12 @@ When /^I search for all datasets$/ do
 end
 
 When /^I save the dataset count$/ do
-  package_count_form = page.first(".search-form h1")
+  package_count_form = govuk_page.first(".search-form h1")
   @package_count = package_count_form.text.gsub(/[^\d^\.]/, '').to_i
 end
 
 Then /^I should see a similar dataset count$/ do
-  count_span = page.first(".dgu-results__summary")
+  count_span = govuk_page.first(".dgu-results__summary")
   count = count_span.text.gsub(/[^\d^\.]/, '').to_i
 
   # to account for a delay in the sync between CKAN and Find, we only check

--- a/features/step_definitions/draft_environment_steps.rb
+++ b/features/step_definitions/draft_environment_steps.rb
@@ -13,7 +13,7 @@ When /^I log in using valid credentials$/ do
 end
 
 Then /^I should be on the case study page$/ do
-  expect(page.current_path).to eq("/government/case-studies/primary-authority-helps-acorn-safeguard-its-business-reputation")
+  expect(govuk_page.current_path).to eq("/government/case-studies/primary-authority-helps-acorn-safeguard-its-business-reputation")
   expect(page).to have_content('Case study')
 end
 
@@ -22,7 +22,7 @@ Then /^the page should contain the draft watermark$/ do
 end
 
 Then /^I should see the draft image asset$/ do
-  image_src = page.find('img')['src']
+  image_src = govuk_page.find('img')['src']
   expect(image_src).to have_content('draft-assets')
   expect(image_src).to have_content('.jpg')
 end

--- a/features/step_definitions/feedback_steps.rb
+++ b/features/step_definitions/feedback_steps.rb
@@ -10,8 +10,8 @@ Then /^I see the report a problem form$/ do
     expect(page).to have_field("What went wrong?")
 
     # Regression test for scenario where wrong URL is set
-    url_input = page.find("form[action='/contact/govuk/problem_reports'] input[name=url]", visible: false)
-    expect(url_input.value).to eq(page.current_url)
+    url_input = govuk_page.find("form[action='/contact/govuk/problem_reports'] input[name=url]", visible: false)
+    expect(url_input.value).to eq(govuk_page.current_url)
   end
 end
 
@@ -39,8 +39,8 @@ Then /^I see the email survey signup form$/ do
     expect(page).to have_field("Email address")
 
     # Regression test for scenario where wrong URL is set
-    url_input = page.find("form[action='/contact/govuk/email-survey-signup'] input[name='email_survey_signup[survey_source]']", visible: false)
-    full_path = URI(page.current_url).request_uri
+    url_input = govuk_page.find("form[action='/contact/govuk/email-survey-signup'] input[name='email_survey_signup[survey_source]']", visible: false)
+    full_path = URI(govuk_page.current_url).request_uri
     expect(url_input.value).to eq(full_path)
   end
 end

--- a/features/step_definitions/finder_frontend_steps.rb
+++ b/features/step_definitions/finder_frontend_steps.rb
@@ -1,5 +1,5 @@
 Then /^I should see an input field to search$/ do
-  expect(page.body).to have_field('keywords')
+  expect(govuk_page.body).to have_field('keywords')
 end
 
 When /^I search for "(.*)"$/ do |term|
@@ -15,14 +15,14 @@ When /^I click result (.*)$/ do |num|
 end
 
 Then /^I should see some search results$/ do
-  result_links = page.all(".finder-results li a")
+  result_links = govuk_page.all(".finder-results li a")
   expect(result_links.count).to be >= 1
 end
 
 And /^the search results should be unique$/ do
   results = []
-  page.all(".finder-results li a").each_with_index do |item, idx|
-    results << item.text + page.all(".finder-results li p")[idx].text
+  govuk_page.all(".finder-results li a").each_with_index do |item, idx|
+    results << item.text + govuk_page.all(".finder-results li p")[idx].text
   end
   expect(results.uniq.count).to eq(results.count)
 end

--- a/features/step_definitions/frontend_steps.rb
+++ b/features/step_definitions/frontend_steps.rb
@@ -1,9 +1,9 @@
 When /^I click on the section "(.*?)"$/ do |section_name|
-  link_href = Nokogiri::HTML.parse(page.body).at_xpath("//a[text()='#{section_name}']/@href")
+  link_href = Nokogiri::HTML.parse(govuk_page.body).at_xpath("//a[text()='#{section_name}']/@href")
   expect(link_href).not_to be_nil
   step "I visit \"#{link_href.value}\""
 end
 
 Then /^I should see an input field for postcode$/ do
-  expect(page.body).to have_field('postcode')
+  expect(govuk_page.body).to have_field('postcode')
 end

--- a/features/step_definitions/mirror_steps.rb
+++ b/features/step_definitions/mirror_steps.rb
@@ -3,8 +3,6 @@ Given /^there is an S3 mirror (.+)/ do |mirror|
 end
 
 Then /^I should get a (\d+) response from "(.*)" on the mirror$/ do |status, path|
-  response = single_http_request(
-    "#{@mirror_host}#{path}"
-  )
-  expect(response.code.to_i).to eq(status.to_i)
+  get_request("#{@mirror_host}#{path}", default_request_options.merge(dont_follow_redirects: true))
+  expect(govuk_page.status_code).to eq(status.to_i)
 end

--- a/features/step_definitions/mirror_steps.rb
+++ b/features/step_definitions/mirror_steps.rb
@@ -1,16 +1,10 @@
-Given /^S3 mirrors/ do
-  @hosts = Array.new()
-  @hosts.push("https://govuk-production-mirror.s3.amazonaws.com")
-  @hosts.push("https://govuk-production-mirror-replica.s3.amazonaws.com")
+Given /^there is an S3 mirror (.+)/ do |mirror|
+  @mirror_host = mirror
 end
 
-Then /^I should get a (\d+) response from "(.*)" on the mirrors$/ do |status, path|
-  @responses = []
-  @hosts.each do |mirror_host|
-    response = single_http_request(
-      "#{mirror_host}#{path}"
-    )
-    expect(response.code.to_i).to eq(status.to_i)
-    @responses << response
-  end
+Then /^I should get a (\d+) response from "(.*)" on the mirror$/ do |status, path|
+  response = single_http_request(
+    "#{@mirror_host}#{path}"
+  )
+  expect(response.code.to_i).to eq(status.to_i)
 end

--- a/features/step_definitions/search_api_steps.rb
+++ b/features/step_definitions/search_api_steps.rb
@@ -1,7 +1,7 @@
 Then /^it should contain a link to at least one sitemap file$/ do
   # Chrome returns XML inside an HTML wrapper, so this JavaScript snippet
   # extracts the XML (see https://stackoverflow.com/questions/44370831)
-  xml_body = page.execute_script('return document.getElementById("webkit-xml-viewer-source-xml").innerHTML')
+  xml_body = govuk_page.execute_script('return document.getElementById("webkit-xml-viewer-source-xml").innerHTML')
   @sitemap_doc = Nokogiri.XML(xml_body)
   @sitemap_links = @sitemap_doc.xpath("/xmlns:sitemapindex/xmlns:sitemap/xmlns:loc")
   expect(@sitemap_links.size).to be >= 1

--- a/features/step_definitions/sidekiq_monitoring_steps.rb
+++ b/features/step_definitions/sidekiq_monitoring_steps.rb
@@ -3,5 +3,5 @@ When /^I go to the sidekiq-monitoring page for "(.*)"$/ do |term|
 end
 
 Then /^I should see the dashboard$/ do
-  expect(page.body).to have_text('Dashboard')
+  expect(govuk_page.body).to have_text('Dashboard')
 end

--- a/features/step_definitions/signon_steps.rb
+++ b/features/step_definitions/signon_steps.rb
@@ -3,7 +3,7 @@ When /^I try to login as a user$/ do
 
   visit application_external_url("signon")
 
-  if page.has_content?("Sign in")
+  if govuk_page.has_content?("Sign in")
     fill_in "Email", :with => ENV["SIGNON_EMAIL"]
     fill_in "Password", :with => ENV["SIGNON_PASSWORD"]
     click_button "Sign in"
@@ -16,5 +16,5 @@ end
 Then(/^I should be redirected to signon$/) do
   signon_url = application_external_url("signon")
 
-  expect(page.current_url).to match(signon_url)
+  expect(govuk_page.current_url).to match(signon_url)
 end

--- a/features/step_definitions/smartanswers_steps.rb
+++ b/features/step_definitions/smartanswers_steps.rb
@@ -1,5 +1,5 @@
 Then /^I should see a populated country select$/ do
-  countries = Nokogiri::HTML.parse(@response.body)
+  countries = Nokogiri::HTML.parse(govuk_page.body)
     .css("#current-question select option")
 
   # Check that we have a sensible-looking number of countries, with

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -131,17 +131,11 @@ Then /^I should be able to visit:$/ do |table|
 end
 
 Then /^I should get a (\d+) status code$/ do |expected_status|
-  if @response
-    actual_status = govuk_page.status_code
-    url = @response['location']
-  else
-    actual_status = govuk_page.status_code.to_i
-    url = govuk_page.current_url
-  end
+  actual_status = govuk_page.status_code
 
   expect(expected_status.to_i).to(
     eq(actual_status),
-    "#{url}: expected status #{expected_status.to_i} got #{actual_status}"
+    "#{govuk_page.current_url}: expected status #{expected_status.to_i} got #{actual_status}"
   )
 end
 
@@ -178,13 +172,8 @@ Then /^I should either see "(.*)" or "(.*)"$/ do |content, other_content|
 end
 
 Then /^I should be at a location path of "(.*)"$/ do |location_path|
-  if @response
-    uri = URI(@response['location'])
-    expect(uri.path).to eq(location_path)
-  else
-    uri = URI(govuk_page.current_url)
-    expect(uri.path).to eq(location_path)
-  end
+  uri = URI(govuk_page.current_url)
+  expect(uri.path).to eq(location_path)
 end
 
 When /^I try to post to "(.*)" with "(.*)"$/ do |path, payload|

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -113,7 +113,7 @@ end
 
 def should_visit(path)
   @response = get_request("#{@host}#{path}", default_request_options)
-  expect(@response.code).to eq(200)
+  expect(govuk_page.status_code).to eq(200)
 end
 
 def should_see(text)
@@ -132,7 +132,7 @@ end
 
 Then /^I should get a (\d+) status code$/ do |expected_status|
   if @response
-    actual_status = @response.code.to_i
+    actual_status = govuk_page.status_code
     url = @response['location']
   else
     actual_status = govuk_page.status_code.to_i

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -117,7 +117,7 @@ def should_visit(path)
 end
 
 def should_see(text)
-  expect(@response.body).to have_content(text)
+  expect(govuk_page.body).to have_content(text)
 end
 
 And /^I don't care about JavaScript errors/ do
@@ -162,9 +162,7 @@ Then /^I should see "(.*)"$/ do |content|
     @responses.each do |response|
       expect(response.body).to include(content)
     end
-  elsif @response
-    expect(@response.body).to include(content)
-  elsif page
+  else
     expect(govuk_page.body).to include(content)
   end
 end
@@ -174,9 +172,7 @@ Then /^I should either see "(.*)" or "(.*)"$/ do |content, other_content|
     @responses.each do |response|
       expect((response.body.include?(content) || response.body.include?(other_content))).to be true
     end
-  elsif @response
-    expect((@response.body.include?(content) || @response.body.include?(other_content))).to be true
-  elsif page
+  else
     expect((govuk_page.body.include?(content) || govuk_page.include?(other_content))).to be true
   end
 end
@@ -204,7 +200,7 @@ Then /^I should see Publisher's publication index$/ do
 end
 
 Then /^JSON is returned$/ do
-  expect(JSON.parse(@response.body).class).to eq(Hash)
+  expect(JSON.parse(govuk_page.body).class).to eq(Hash)
 end
 
 When /^I see links to pages per topic$/ do

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -62,7 +62,7 @@ When /^I visit "(.*)"$/ do |path_or_url|
 end
 
 When /^I visit "(.*)" without following redirects$/ do |path|
-  @response = single_http_request("#{@host}#{path}")
+  get_request("#{@host}#{path}", default_request_options.merge(dont_follow_redirects: true, cache_bust: false))
 end
 
 When /^I visit "([^"]*)" on the "([^"]*)" application$/ do |path, application|

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -140,15 +140,7 @@ Then /^I should get a (\d+) status code$/ do |expected_status|
 end
 
 Then /^I should get a "(.*)" header of "(.*)"$/ do |header_name, header_value|
-  header_as_symbol = header_name.gsub('-', '_').downcase.to_sym
-
-  if @response.respond_to? :headers
-    expect(@response.headers[header_as_symbol]).to eq(header_value)
-  elsif @response[header_name]
-    expect(@response[header_name]).to eq(header_value)
-  else
-    raise "Couldn't find header '#{header_name}' in response"
-  end
+  expect(govuk_page.header(header_name)).to eq(header_value)
 end
 
 Then /^I should see "(.*)"$/ do |content|

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -135,8 +135,8 @@ Then /^I should get a (\d+) status code$/ do |expected_status|
     actual_status = @response.code.to_i
     url = @response['location']
   else
-    actual_status = page.status_code.to_i
-    url = page.current_url
+    actual_status = govuk_page.status_code.to_i
+    url = govuk_page.current_url
   end
 
   expect(expected_status.to_i).to(
@@ -165,7 +165,7 @@ Then /^I should see "(.*)"$/ do |content|
   elsif @response
     expect(@response.body).to include(content)
   elsif page
-    expect(page.body).to include(content)
+    expect(govuk_page.body).to include(content)
   end
 end
 
@@ -177,7 +177,7 @@ Then /^I should either see "(.*)" or "(.*)"$/ do |content, other_content|
   elsif @response
     expect((@response.body.include?(content) || @response.body.include?(other_content))).to be true
   elsif page
-    expect((page.body.include?(content) || page.include?(other_content))).to be true
+    expect((govuk_page.body.include?(content) || govuk_page.include?(other_content))).to be true
   end
 end
 
@@ -186,7 +186,7 @@ Then /^I should be at a location path of "(.*)"$/ do |location_path|
     uri = URI(@response['location'])
     expect(uri.path).to eq(location_path)
   else
-    uri = URI(page.current_url)
+    uri = URI(govuk_page.current_url)
     expect(uri.path).to eq(location_path)
   end
 end
@@ -208,7 +208,7 @@ Then /^JSON is returned$/ do
 end
 
 When /^I see links to pages per topic$/ do
-  pages = Nokogiri::HTML.parse(page.body).css(".browse-container a")
+  pages = Nokogiri::HTML.parse(govuk_page.body).css(".browse-container a")
   unless pages.any?
     fail "There are no links on this Services and Information page"
   end

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -144,23 +144,7 @@ Then /^I should get a "(.*)" header of "(.*)"$/ do |header_name, header_value|
 end
 
 Then /^I should see "(.*)"$/ do |content|
-  if @responses
-    @responses.each do |response|
-      expect(response.body).to include(content)
-    end
-  else
-    expect(govuk_page.body).to include(content)
-  end
-end
-
-Then /^I should either see "(.*)" or "(.*)"$/ do |content, other_content|
-  if @responses
-    @responses.each do |response|
-      expect((response.body.include?(content) || response.body.include?(other_content))).to be true
-    end
-  else
-    expect((govuk_page.body.include?(content) || govuk_page.include?(other_content))).to be true
-  end
+  expect(govuk_page.body).to include(content)
 end
 
 Then /^I should be at a location path of "(.*)"$/ do |location_path|

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -70,13 +70,6 @@ When /^I visit "([^"]*)" on the "([^"]*)" application$/ do |path, application|
   visit_path "#{application_host}#{path}"
 end
 
-When(/^multiple new users visit "(.*?)"$/) do |path|
-  @responses = []
-  20.times do
-    @responses << get_request("#{@host}#{path}", default_request_options)
-  end
-end
-
 When /^I visit a non-existent page$/ do
   @response = get_request("#{@host}/404", default_request_options.merge(return_response_on_error: true))
 end

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -54,7 +54,7 @@ When /^I (try to )?request "(.*)"$/ do |attempt_only, path_or_url|
     "#{@host}#{path_or_url}"
   end
   request_method = attempt_only ? :try_get_request : :get_request
-  @response = send(request_method, url, default_request_options)
+  send(request_method, url, default_request_options)
 end
 
 When /^I visit "(.*)"$/ do |path_or_url|
@@ -71,7 +71,7 @@ When /^I visit "([^"]*)" on the "([^"]*)" application$/ do |path, application|
 end
 
 When /^I visit a non-existent page$/ do
-  @response = get_request("#{@host}/404", default_request_options.merge(return_response_on_error: true))
+  get_request("#{@host}/404", default_request_options.merge(return_response_on_error: true))
 end
 
 When /^I request "(.*)" from Bouncer directly$/ do |url|
@@ -80,7 +80,7 @@ When /^I request "(.*)" from Bouncer directly$/ do |url|
   bouncer_url += "?#{parsed_url.query}" if parsed_url.query
   request_host = parsed_url.host
 
-  @response = try_get_request(bouncer_url, host_header: request_host)
+  try_get_request(bouncer_url, host_header: request_host)
 end
 
 $original_env_var = ENV["RATE_LIMIT_TOKEN"] # retain original value so we can reset it after the tests
@@ -105,7 +105,7 @@ Then /^any request I make should NOT include the 'Rate-Limit-Token' header$/ do
 end
 
 def should_visit(path)
-  @response = get_request("#{@host}#{path}", default_request_options)
+  get_request("#{@host}#{path}", default_request_options)
   expect(govuk_page.status_code).to eq(200)
 end
 
@@ -169,28 +169,11 @@ When /^I see links to pages per topic$/ do
 end
 
 Then /^I should hit the cache$/ do
-  cache_hits = cache_hits_value(@response)
-
-  expect(cache_hits).not_to be nil
-  expect(cache_hits).not_to be("0")
+  expect(govuk_page.header("X-Cache-Hits")).not_to be nil
+  expect(govuk_page.header("X-Cache-Hits")).not_to be("0")
 end
 
 Then /^I should not hit the cache$/ do
-  cache_hits = cache_hits_value(@response)
-
-  expect(cache_hits).not_to be nil
-  expect(cache_hits).to eq("0")
-end
-
-def cache_hits_value(response)
-  header_name = 'X-Cache-Hits'
-  header_as_symbol = header_name.gsub('-', '_').downcase.to_sym
-
-  if response.respond_to? :headers
-    response.headers[header_as_symbol]
-  elsif response['X-Cache-Hits'].present?
-    response[header_name].to_i
-  else
-    raise "Couldn't find X-Cache-Hits header in response"
-  end
+  expect(govuk_page.header("X-Cache-Hits")).not_to be nil
+  expect(govuk_page.header("X-Cache-Hits")).to eq("0")
 end

--- a/features/step_definitions/waf_steps.rb
+++ b/features/step_definitions/waf_steps.rb
@@ -4,7 +4,7 @@ Given /^I set header ([^\s]+) to ([^\s]+)/ do |header_name, header_value|
 end
 
 When /^I send a (\w+) request to "(.*?)"$/ do |method, path|
-  @response = do_http_request(
+  do_http_request(
     "#{@host}#{path}", method.downcase.to_sym, default_request_options.merge(
       { headers: @headers, return_response_on_error: true }
     )

--- a/features/step_definitions/whitehall_steps.rb
+++ b/features/step_definitions/whitehall_steps.rb
@@ -16,5 +16,5 @@ end
 
 Then(/^the attachment should be served successfully$/) do
   expect(@response.request.url).to match(@attachment_path)
-  expect(@response.code).to eq(200)
+  expect(govuk_page.status_code).to eq(200)
 end

--- a/features/step_definitions/whitehall_steps.rb
+++ b/features/step_definitions/whitehall_steps.rb
@@ -9,12 +9,12 @@ Then(/^I should be redirected to the asset host$/) do
     application_external_url("assets-eks"),
     application_external_url("assets"),
   ]
-  uri = URI(@response.request.url)
+  uri = URI(govuk_page.current_url)
   asset_url = "#{uri.scheme}://#{uri.host}"
   assert asset_hosts.include?(asset_url), "Asset host #{asset_url} is not valid"
 end
 
 Then(/^the attachment should be served successfully$/) do
-  expect(@response.request.url).to match(@attachment_path)
+  expect(govuk_page.current_url).to match(@attachment_path)
   expect(govuk_page.status_code).to eq(200)
 end

--- a/features/support/http_requests.rb
+++ b/features/support/http_requests.rb
@@ -28,6 +28,7 @@ def uri_escape(s)
 end
 
 def default_request_options
+  # TODO: this duplicates the `smokey_cachebust` logic in `visiting_pages.rb`
   { cache_bust: @bypass_caching, client_auth: @authenticated_as_client }
 end
 

--- a/features/support/http_requests.rb
+++ b/features/support/http_requests.rb
@@ -107,12 +107,12 @@ def do_http_request(url, method = :get, options = {}, &block)
     payload: options[:payload],
     verify_ssl: options[:verify_ssl],
   }
-  RestClient::Request.new(request_options).execute &block
+  @response = RestClient::Request.new(request_options).execute &block
 rescue RestClient::Unauthorized => e
   raise "Unable to fetch '#{url}' due to '#{e.message}'."
 rescue RestClient::Exception => e
   if options[:return_response_on_error]
-    e.response
+    @response = e.response
   else
     finished_at = Time.now
     message = ["Unable to fetch '#{url}'"]

--- a/features/support/visiting_pages.rb
+++ b/features/support/visiting_pages.rb
@@ -4,3 +4,7 @@ def visit_path(path)
   url_param_joiner = path.match(%r[\?]) ? "&" : "?"
   visit "#{path}#{url_param_joiner}smokey_cachebust=#{rand.to_s}"
 end
+
+def govuk_page
+  page
+end

--- a/features/support/visiting_pages.rb
+++ b/features/support/visiting_pages.rb
@@ -53,6 +53,19 @@ class GovukPage
     # TODO: support `@response` version
     @page.execute_script(script_contents)
   end
+
+  def header(header_name)
+    # TODO: support `@page` version
+    header_as_symbol = header_name.gsub('-', '_').downcase.to_sym
+
+    if @response.respond_to? :headers
+      @response.headers[header_as_symbol]
+    elsif @response[header_name]
+      @response[header_name]
+    else
+      raise "Couldn't find header '#{header_name}' in response"
+    end
+  end
 end
 
 def govuk_page

--- a/features/support/visiting_pages.rb
+++ b/features/support/visiting_pages.rb
@@ -29,7 +29,7 @@ class GovukPage
   end
 
   def current_url
-    return @response.request.url if @response
+    return (@response['location'].nil? ? @response.request.url : @response['location']) if @response
 
     @page.current_url
   end

--- a/features/support/visiting_pages.rb
+++ b/features/support/visiting_pages.rb
@@ -29,7 +29,8 @@ class GovukPage
   end
 
   def current_url
-    # TODO: support `@response` version
+    return @response.request.url if @response
+
     @page.current_url
   end
 

--- a/features/support/visiting_pages.rb
+++ b/features/support/visiting_pages.rb
@@ -1,9 +1,6 @@
 require 'base64'
 
 def visit_path(path)
-  if path.match(%r[\?])
-    visit "#{path}&smokey_cachebust=#{rand.to_s}"
-  else
-    visit "#{path}?smokey_cachebust=#{rand.to_s}"
-  end
+  url_param_joiner = path.match(%r[\?]) ? "&" : "?"
+  visit "#{path}#{url_param_joiner}smokey_cachebust=#{rand.to_s}"
 end

--- a/features/support/visiting_pages.rb
+++ b/features/support/visiting_pages.rb
@@ -6,5 +6,7 @@ def visit_path(path)
 end
 
 def govuk_page
+  return @response if @response
+
   page
 end

--- a/features/support/visiting_pages.rb
+++ b/features/support/visiting_pages.rb
@@ -5,8 +5,55 @@ def visit_path(path)
   visit "#{path}#{url_param_joiner}smokey_cachebust=#{rand.to_s}"
 end
 
-def govuk_page
-  return @response if @response
+class GovukPage
+  def initialize(page, response)
+    @page = page
+    @response = response
+  end
 
-  page
+  def body
+    return @response.body if @response
+
+    @page.body
+  end
+
+  def status_code
+    return @response.code.to_i if @response
+
+    @page.status_code.to_i
+  end
+
+  def current_path
+    # TODO: support `@response` version
+    @page.current_path
+  end
+
+  def current_url
+    # TODO: support `@response` version
+    @page.current_url
+  end
+
+  def has_content?(content)
+    # TODO: support `@response` version
+    @page.has_content?(content)
+  end
+
+  def all(selector)
+    # TODO: support `@response` version
+    @page.all(selector)
+  end
+
+  def find(selector, **options)
+    # TODO: support `@response` version
+    @page.find(selector, **options)
+  end
+
+  def execute_script(script_contents)
+    # TODO: support `@response` version
+    @page.execute_script(script_contents)
+  end
+end
+
+def govuk_page
+  GovukPage.new(page, @response)
 end

--- a/features/support/visiting_pages.rb
+++ b/features/support/visiting_pages.rb
@@ -1,5 +1,15 @@
 require 'base64'
 
+# TODO: replace all `visit_path` occurrences with calls to `do_http_request` (under the hood)
+# so that we can provide custom request headers, which was the whole point of this refactoring
+# exercise.
+# The main motivation is that Selenium webdriver doesn't allow you to provide custom request
+# headers without the use of a proxy like browsermob-proxy. I _really_ don't want to add
+# a proxy just to be able to do that. Someone has already gone to the effort of building
+# a set of utility methods that perform HTTP requests and can have the response code and
+# response body queried, so I'm hoping to consolidate all step definitions to use those
+# utility methods so we no longer have two approaches, and then my change to run tests against
+# the failover CDN will look relatively modest.
 def visit_path(path)
   url_param_joiner = path.match(%r[\?]) ? "&" : "?"
   visit "#{path}#{url_param_joiner}smokey_cachebust=#{rand.to_s}"


### PR DESCRIPTION
This is turning out to be a bigger piece of work than hoped!

1. I want to tag up all scenarios that should pass when run against the failover CDN (Cloudfront), so that we have tests in place that prevent regressions to the CDN configuration. (Tag name undecided, but let's say `@bothcdns`).
2. I'll then programmatically run each tagged scenario twice (once against primary CDN, once against failover CDN), or else [tweak the places where we run Cucumber](https://github.com/search?q=repo%3Aalphagov%2Fgovuk-helm-charts%20cucumber&type=code) to perform an additional run against `@bothcdns`-tagged scenarios.

The key bit is the "against failover CDN" bit, which should just be a case of changing the host we send requests to, and ensuring we pass a header of `Host: www.gov.uk` (see [failover PR](https://github.com/alphagov/govuk-dns-tf/pull/69)). But [Selenium doesn't support setting request headers](https://stackoverflow.com/a/15647143), and thus requires use of a proxy like browsermob-proxy, to inject headers.

~~I _really_ don't want to do that, when someone has already gone to the trouble of writing [HTTP request support methods in Smokey](https://github.com/alphagov/smokey/blob/2319cca9a815ff40ba5eed8483bfc4089a04a480/features/support/http_requests.rb) which let us provide custom headers with our requests. Let's just use those methods!~~

~~However, only a portion of Smokey tests use those methods - the rest use standard Capybara/Selenium methods like `visit` and `page`. If we attempt to run those tests against the failover CDN, we'll find that the custom request header was not set and the test will fail.~~

~~So this PR aims to do two things:~~

~~1. Consistent use of custom HTTP request support methods, and phase out of the Selenium / Capybara methods~~
~~2. Enabling of automatically running tests against both primary and failover CDNs~~

In writing this out, I think the above is unfeasible in hindsight. We will of course need to retain Selenium / Capybara for things like clicking buttons, and we _won't_ want to recreate that in our `GovukPage` proxy class. A better approach to pivot to tomorrow:

1. Set up browsermob-proxy
2. Enable automatically running tests against both primary and failover CDNs
3. Delete as much custom HTTP request support method code as possible (have our tests use the proxy instead)

That said, [Smokey used to have browsermob-proxy, and it was removed](https://github.com/alphagov/smokey/pull/924), so need to give this more thought.

Trello: https://trello.com/c/2XwAz6JD/3365-run-automatic-smokey-tests-against-the-standby-cdn-5