### PR TITLE
Remove the search-analytics smokey tests

### DIFF
--- a/features/apps/finder_frontend.feature
+++ b/features/apps/finder_frontend.feature
@@ -19,12 +19,6 @@ Feature: Finder Frontend
     When I search for "<keywords>"
     Then I should see some search results
     And the search results should be unique
-    And search analytics for "<keywords>" are reported
-    When I go to the next page
-    Then the "contentsClicked" event is reported
-    When I click result 1
-    Then the "navFinderLinkClicked" event for result Search.1 is reported
-    And the "UX" event for result click is reported
 
     Examples:
     | keywords         |

--- a/features/step_definitions/analytics.rb
+++ b/features/step_definitions/analytics.rb
@@ -1,18 +1,3 @@
-Then /^search analytics for "(.*)" are reported$/ do |term|
-  sought = CGI::escape("/search/all?keywords=#{term.sub(' ', '+')}")
-  expect(browser_has_analytics_request_containing sought).to be(true)
-end
-
-Then /^the "(.*)" event is reported$/ do |event|
-  sought = "ec=#{event}"
-  expect(browser_has_analytics_request_containing sought).to be(true)
-end
-
-Then /^the "(.*)" event for result (.*) is reported$/ do |event, n|
-  sought = "ec=#{event}&ea=#{n}"
-  expect(browser_has_analytics_request_containing sought).to be(true)
-end
-
 Then /^the page view should be tracked$/ do
   sought = "t=pageview"
   expect(browser_has_analytics_request_containing sought).to be(true)


### PR DESCRIPTION
The three search queries used in these smokey tests are inflating and polluting the clickboost search data.

The GA4/Analytics team tried to filter out the Smokey data at the GA4 end but weren't fully able to.

The test can be removed for a few reasons:

1. The clickboost data is being used to evaluate the new search product and that can't happen effectively if the clickboost data thinks pages are popular based on clicks occurring in tests. Once the new product is live it will continue to effect the results that users see.
2. search-analytics hasn't worked properly since the move to kubernetes, though work is being done to retify this.
3. These tests check for Univeral Analytics which is being removed, so the tests will need to br written anyhow.

## Testing

**You should manually test your PR before merging.**

See https://github.com/alphagov/smokey/blob/main/docs/deployment.md

Unrelated Feedback test fails in [integration](https://argo.eks.integration.govuk.digital/applications/cluster-services/smokey?orphaned=false&node=batch%2FJob%2Fapps%2Fsmokey-28412250&tab=logs&resource=).