### PR TITLE
Fix static feature

### DIFF
--- a/features/step_definitions/feedback_steps.rb
+++ b/features/step_definitions/feedback_steps.rb
@@ -10,7 +10,7 @@ Then /^I see the report a problem form$/ do
     expect(page).to have_field("What went wrong?")
 
     # Regression test for scenario where wrong URL is set
-    url_input = page.find("form[action='/contact/govuk/problem_reports'] input[name=url]", visible: false)
+    url_input = page.find("form[action$='/contact/govuk/problem_reports'] input[name=url]", visible: false)
     expect(url_input.value).to eq(page.current_url)
   end
 end
@@ -39,7 +39,7 @@ Then /^I see the email survey signup form$/ do
     expect(page).to have_field("Email address")
 
     # Regression test for scenario where wrong URL is set
-    url_input = page.find("form[action='/contact/govuk/email-survey-signup'] input[name='email_survey_signup[survey_source]']", visible: false)
+    url_input = page.find("form[action$='/contact/govuk/email-survey-signup'] input[name='email_survey_signup[survey_source]']", visible: false)
     full_path = URI(page.current_url).request_uri
     expect(url_input.value).to eq(full_path)
   end


### PR DESCRIPTION
# What

Form actions can contain a domain name, but `feedback_steps.rb` does 
not take it into account and it assumes the action URL can only contain a path but not a domain. This PR fixes that by checking if the action url **ends with** (as opposed to be equal to) the path.

# Why

This is a proposed PR fixing an ongoing bug with the smokey test. It does not introduce new any functionalities. For this reason it does not contain the ticket reference.

## Testing

**You should manually test your PR before merging.**

See https://github.com/alphagov/smokey/blob/main/docs/deployment.md
