### PR TITLE
Automatically spin up proxy when running proxy-based Smokey tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,13 @@ Read "[Environment variables](#environment-variables)" for an explanation of the
 *Run Smokey against Production*:
 
 ```sh
-export ENVIRONMENT=production
-
+ENVIRONMENT=production
 SIGNON_EMAIL="<email-address>" \
 SIGNON_PASSWORD="<password>" \
-bundle exec cucumber --tags="not @not$ENVIRONMENT"
+bundle exec cucumber --profile=production
 ```
 
-You can test integration or staging by changing the value of `ENVIRONMENT`, but you need to be connected to the VPN.
+You can test integration or staging by changing the value of the `ENVIRONMENT` variable and `profile` argument (see profiles in [`config/cucumber.yml`](./config/cucumber.yml)), but you need to be connected to the VPN.
 
 You can run Smokey against the GOV.UK mirrors. The mirror tests are tagged `@worksonmirror`.
 
@@ -60,13 +59,12 @@ bundle exec cucumber --tags="@worksonmirror"
 *Run Smokey against the failover CDN*:
 
 ```sh
-ENVIRONMENT=production
-
+ENVIRONMENT=production \
 FAILOVER_CDN_HOST="<distribution>.cloudfront.net" \
 GOVUK_PROXY_PROFILE=failoverCDN \
 SIGNON_EMAIL="<email-address>" \
 SIGNON_PASSWORD="<password>" \
-bundle exec cucumber --tags="not @not$ENVIRONMENT and not @notcloudfront"
+bundle exec cucumber --tags="not @notproduction and not @notcloudfront"
 ```
 
 ### Run the proxy in isolation

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -23,6 +23,16 @@ end
 if ENV.has_key?("GOVUK_PROXY_PROFILE")
   ENV["GOVUK_WEBSITE_ROOT"] = "http://127.0.0.1:8080"
   GovukProxyProfiles.validate_profile!
+
+  pid = Process.fork do
+    puts "Starting proxy in background process: pid #{Process.pid}."
+    require_relative "../../govuk_proxy_runner.rb"
+    puts "Proxy exited."
+  end
+
+  at_exit do
+    Process.kill("INT", pid)
+  end
 end
 
 # Set up error reporting (using SENTRY_CURRENT_ENV for the environment).

--- a/features/support/govuk_proxy_profiles.rb
+++ b/features/support/govuk_proxy_profiles.rb
@@ -18,7 +18,7 @@ module GovukProxyProfiles
       host: "www.gov.uk",
       headers: {
         "User-Agent": "Smokey Test / Ruby",
-        "Backend-Override": "mirrorS3",
+        "Backend-Override": "mirrorS3Replica",
       },
       spoofAssets: true,
     },
@@ -26,7 +26,7 @@ module GovukProxyProfiles
       host: "www.gov.uk",
       headers: {
         "User-Agent": "Smokey Test / Ruby",
-        "Backend-Override": "mirrorS3",
+        "Backend-Override": "mirrorGCS",
       },
       spoofAssets: true,
     },


### PR DESCRIPTION
## What

- Cucumber now calls `govuk_proxy_runner.rb` when the proxy is required for the tests.
- README has been updated accordingly.
- Also fixes some misconfigurations for the govuk proxy profiles

See commits for details.

## Why

Makes it easier to run the proxy tests. Depended on by https://github.com/alphagov/govuk-helm-charts/pull/1774

Trello: https://trello.com/c/2XwAz6JD/3365-run-automatic-smokey-tests-against-the-standby-cdn-5