### PR TITLE
Update collections.feature test to test new stable page

### DIFF
--- a/features/apps/collections.feature
+++ b/features/apps/collections.feature
@@ -10,8 +10,8 @@ Feature: Collections
 
   @worksonmirror
   Scenario: Check the frontend can talk to Search API
-    When I visit "/government/organisations/hm-revenue-customs/services-information"
-    Then I see links to pages per topic
+    When I visit "/world/afghanistan/news"
+    Then I see the links pulled form search_api
 
   @app-email-alert-frontend
   Scenario: Check the frontend can talk to Email Alert API

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -185,10 +185,13 @@ Then /^JSON is returned$/ do
   expect(JSON.parse(@response.body).class).to eq(Hash)
 end
 
-When /^I see links to pages per topic$/ do
-  pages = Nokogiri::HTML.parse(page.body).css(".browse-container a")
-  unless pages.any?
-    fail "There are no links on this Services and Information page"
+When /^I see the links pulled form search_api$/ do
+  latest_section = Nokogiri::HTML.parse(page.body).css("#latest")
+  latest_items_list = latest_section.css(".gem-c-document-list ul")
+  latest_items = latest_items_list.css(".gem-c-document-list__item-metadata")
+
+  unless latest_items.any?
+    fail `There are no "latest" links pulled in from the search api`
   end
 end
 


### PR DESCRIPTION
## Testing

**You should manually test your PR before merging.**

See https://github.com/alphagov/smokey/blob/main/docs/deployment.md


- This example page pulls data in from the `Services.search_api.search` in the collections app https://www.integration.publishing.service.gov.uk/world/afghanistan/news
-  The `app/models/world_location_news.rb` file makes a number of calls to this api pulling in different collections here https://github.com/alphagov/collections/blob/main/app/models/world_location_news.rb#L69-L83. 
- Here is where the call is made `app/services/search_documents.rb`. 
- When testing locally and removing these calls we don't see the various sections on this page https://www.integration.publishing.service.gov.uk/world/afghanistan/news


Ticket: https://trello.com/c/nGHmbA30/2332-update-smokey-before-we-retire-hmrc-services-and-information-page-l
