### PR TITLE
Ignore javascript errors for licensify

### DIFF
--- a/features/licensing.feature
+++ b/features/licensing.feature
@@ -9,6 +9,7 @@ Feature: Licensing
       | /apply-for-a-licence/forms/bury/test-licence/9999-7-1,0-1         |
 
   Scenario: Check log in to licensify-admin
+    Given I don't care about JavaScript errors
     When I try to login as a user
     And I login to Licensify
     Then I should see "Sign Out"


### PR DESCRIPTION
It fails to load the favicon, which doesn't impact on user experience.
