### PR TITLE
Fix local council CDN test

### DIFF
--- a/features/cdn.feature
+++ b/features/cdn.feature
@@ -19,7 +19,7 @@ Feature: CDN
   Scenario: Check caching behaviour for POST requests
     When I try to post to "/find-local-council" with "postcode=E1+8QS" without following redirects
     Then I should not hit the cache
-    Then I should see "tower hamlets"
+    And I should get a 302 status code
 
   @notcloudfront
   Scenario: Check caching behaviour for GET requests


### PR DESCRIPTION
The happy path for getting a /find-local-council result is:

1. --> `POST` postcode (eg "E1 8QS") to /find-local-council
2. <-- 302 redirect to the page for the council(s) (eg "/find-local-council/tower-hamlets")
3. --> `GET` /find-local-council/tower-hamlets
4. <-- 200 response containing the council details

The current test disables following redirects, so that we can examine the cache headers for the response. This means we never get to step 3 (which is fine because we're just checking that the CDN isn't caching stuff)

The last step then tries to check for content on a page that only exists if you _do_ follow the redirect (that is, render the page at step 4). I'm not sure how this would work.

Instead, we'll just check that we get the 302 response that is received at step 2. This shows that things are working and we're not just getting a lovely uncached 5XX error.

## Testing

**You should manually test your PR before merging.**

Done 👉 [Smokey test run](https://argo.eks.integration.govuk.digital/applications/cluster-services/smokey?orphaned=false&node=%2FPod%2Fapps%2Fsmokey-202402121103-xjsmj%2F0&tab=logs&resource=)

