### PR TITLE
Add a Mainstream Publisher non-production test

### DIFF
--- a/features/apps/publisher.feature
+++ b/features/apps/publisher.feature
@@ -7,3 +7,12 @@ Feature: Publisher
     And I go to the "publisher" landing page
     Then I should see "Publisher"
     And I should see Publisher's publication index
+
+  @notproduction
+  Scenario: Can add and delete an artefact in publisher
+    When I go to the "publisher" landing page
+    And I try to login as a user
+    And I go to the "publisher" landing page
+    And I add an artefact
+    And I delete the artefact
+    Then I should see that the edition has been deleted

--- a/features/step_definitions/publisher_steps.rb
+++ b/features/step_definitions/publisher_steps.rb
@@ -15,3 +15,7 @@ end
 Then /^I should see that the edition has been deleted$/ do
   expect(page).to have_content("Edition deleted")
 end
+
+Then /^I should see Publisher's publication index$/ do
+  expect(page).to have_selector("#publication-list-container")
+end

--- a/features/step_definitions/publisher_steps.rb
+++ b/features/step_definitions/publisher_steps.rb
@@ -1,0 +1,17 @@
+When /^I add an artefact$/ do
+  click_link "Add artefact"
+  fill_in "Title", with: "Smokey Guide"
+  fill_in "Slug", with: "smokey-guide"
+  select "Guide", from: "Format"
+  click_button "Save and go to item"
+  expect(page).to have_selector("h1", text: "Smokey Guide")
+end
+
+When /^I delete the artefact$/ do
+  click_link "Admin"
+  click_button "Delete this edition – #1"
+end
+
+Then /^I should see that the edition has been deleted$/ do
+  expect(page).to have_content("Edition deleted")
+end

--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -177,10 +177,6 @@ When /^I try to post to "(.*)" with "(.*)" without following redirects$/ do |pat
   @response = post_request "#{@host}#{path}", :payload => "#{payload}", dont_follow_redirects: true
 end
 
-Then /^I should see Publisher's publication index$/ do
-  expect(page).to have_selector("#publication-list-container")
-end
-
 Then /^JSON is returned$/ do
   expect(JSON.parse(@response.body).class).to eq(Hash)
 end


### PR DESCRIPTION
## What

Add a test that will attempt to create an artefact in Mainstream Publisher and then delete it.

If this test fails it will mean that the artefact created will need manual deletion before the Smokey test can pass again, but this is deemed acceptable by the team as it should be a rare occurrence.

We will run this test in integration and staging, but NOT production, to avoid adding junk data into the production database (and the data in integration and staging is overwritten overnight).

## Why

The latest version of the mongo driver currently causes the app to fail in deployed environments when saving to the database. This issue does not occur locally, and so we have no way of testing the driver update is safe without manual deployment and testing.

While having a Smokey test is not ideal, since it happens post-deploy, it will at least give us feedback that integration is broken, which is more than we currently have.