### PR TITLE
Rename licensify tests

### DIFF
--- a/features/licensing.feature
+++ b/features/licensing.feature
@@ -1,4 +1,4 @@
-@app-licensing
+@app-licensify
 Feature: Licensing
   Scenario: Check licensing pages load
     Given I don't care about JavaScript errors


### PR DESCRIPTION
This renames the test label for licensify so that they are correct referenced in the post sync workflow, which expected them to match the ArgoCD App name.
