### PR TITLE
Test HSTS header for 404 status codes

### DIFF
--- a/features/cdn.feature
+++ b/features/cdn.feature
@@ -51,3 +51,9 @@ Feature: CDN
     Then I should get a 302 status code
     And I should get a "Location" header of "https://www.gov.uk"
     And I should get a "Strict-Transport-Security" header of "max-age=63072000; includeSubDomains; preload"
+
+  Scenario: Check HSTS header is enabled for URls that do not exist
+    Given I am testing "https://www.gov.uk"
+    When I visit "/this-page-should-404" without following redirects
+    Then I should get a 404 status code
+    And I should get a "Strict-Transport-Security" header of "max-age=31536000; preload"


### PR DESCRIPTION

Check HSTS header is present in 404 pages.

Related to PR: https://github.com/alphagov/govuk-fastly/pull/62

Tested branch shown here https://argo.eks.integration.govuk.digital/applications/smokey?orphaned=false&resource=&node=batch%2FJob%2Fapps%2Fsmokey-28477000%2F0

Trello: https://trello.com/c/0TgCOgbX/3397-3-configure-fastly-to-always-append-an-hsts-header

See https://github.com/alphagov/smokey/blob/main/docs/deployment.md
