### PR TITLE
Revert "Add special case for imminence landing page"

### DIFF
--- a/features/step_definitions/smokey_steps.rb
+++ b/features/step_definitions/smokey_steps.rb
@@ -43,10 +43,6 @@ And /^I consent to cookies$/ do
   @consent_cookie_value = consent_cookie[:value]
 end
 
-When /^I go to the "imminence" landing page$/ do
-  visit_path application_external_url("places-manager")
-end
-
 When /^I go to the "([^"]*)" landing page$/ do |app_name|
   visit_path application_external_url(app_name)
 end


### PR DESCRIPTION
Reverts alphagov/smokey#1279

Not needed now that Imminence has moved through the stack.