### PR TITLE
Remove references to feedback form from feature tests

### DIFF
--- a/features/apps/feedback.feature
+++ b/features/apps/feedback.feature
@@ -10,6 +10,4 @@ Feature: Feedback
   Scenario: Check "is this page useful?" email survey
     When I visit "/"
     And I click to say the page is not useful
-    And I submit the email survey signup form
-    Then I see the feedback confirmation message
-    And a request is sent to the feedback app
+    Then I see a survey link

--- a/features/apps/static.feature
+++ b/features/apps/static.feature
@@ -7,7 +7,6 @@ Feature: Static
     Then I see the report a problem form
     When I close the open feedback form
     And I click to say the page is not useful
-    Then I see the email survey signup form
     When I close the open feedback form
     And I click to say the page is useful
     Then I see the feedback confirmation message

--- a/features/step_definitions/feedback_steps.rb
+++ b/features/step_definitions/feedback_steps.rb
@@ -33,30 +33,10 @@ When /^I click to say the page is useful$/ do
   end
 end
 
-Then /^I see the email survey signup form$/ do
-  within(".gem-c-feedback") do
-    expect(page).to have_content("Help us improve GOV.UK")
-    expect(page).to have_field("Email address")
-
-    # Regression test for scenario where wrong URL is set
-    url_input = page.find("form[action$='/contact/govuk/email-survey-signup'] input[name='email_survey_signup[survey_source]']", visible: false)
-    full_path = URI(page.current_url).request_uri
-    expect(url_input.value).to eq(full_path)
-  end
-end
-
-When /^I submit the email survey signup form$/ do
-  within(".gem-c-feedback") do
-    fill_in "Email address", with: "simulate-delivered@notifications.service.gov.uk"
-    click_on "Send me the survey"
-  end
-end
-
 Then /^I see the feedback confirmation message$/ do
   expect(page).to have_content("Thank you for your feedback")
 end
 
-Then /^a request is sent to the feedback app$/ do
-  sought = "/contact/govuk/email-survey-signup"
-  expect(browser_has_request_with_url_containing sought).to be(true)
+Then /^I see a survey link$/ do
+  expect(page).to have_link("Please fill in this survey", href: /smartsurvey/)
 end


### PR DESCRIPTION
Recent changes to the `govuk_publishing_components` removed the ability to input an email address in the feedback form, linking instead straight to the smart survey. These changes were intentional.

Removing the references to the form from the feature and steps.

## Testing

**You should manually test your PR before merging.**

See https://github.com/alphagov/smokey/blob/main/docs/deployment.md
