### PR TITLE
Update foreign-travel-advice test to look for correct text

### DIFF
--- a/features/apps/government_frontend.feature
+++ b/features/apps/government_frontend.feature
@@ -32,7 +32,7 @@ Feature: Government Frontend
   Scenario: Check a travel advice country page loads
     When I visit "/foreign-travel-advice/luxembourg"
     Then I should see "Luxembourg"
-    And I should see "Summary"
+    And I should see "Warnings and insurance"
 
   @worksonmirror
   Scenario: Check that Service Manuals load


### PR DESCRIPTION
- Summary hasn't been available on these pages since 17/08/2023, replacing with Warnings and insurance

## Testing

**You should manually test your PR before merging.**

Confirmed this removes the government-frontend travel advice error in Smokey in integration.

See https://github.com/alphagov/smokey/blob/main/docs/deployment.md
