### PR TITLE
Remove analytics tests which are not appropriate for the GA4 world

### DIFF
--- a/features/apps/frontend.feature
+++ b/features/apps/frontend.feature
@@ -11,12 +11,6 @@ Feature: Frontend
     When I visit "/"
     Then I should see "Welcome to GOV.UK"
 
-  @notcloudfront
-  Scenario: Check the client can talk to Google Analytics
-    When I visit "/"
-    And I consent to cookies
-    Then the page view should be tracked
-
   Scenario: Check the frontend can talk to Licensing
     When I visit "/find-licences/busking-licence"
     Then I should see "Busking licence"

--- a/features/step_definitions/ab_testing_steps.rb
+++ b/features/step_definitions/ab_testing_steps.rb
@@ -43,11 +43,6 @@ Then(/^I can see the bucket I am assigned to$/) do
   @original_bucket = bucket
 end
 
-Then(/^the bucket is reported to Google Analytics$/) do
-  sought = "cd40=Example%3A#{@ab_cookie_value}"
-  expect(browser_has_analytics_request_containing sought).to be(true)
-end
-
 Then(/^I stay on the same bucket when I keep visiting "(.*?)"$/) do |path|
   20.times do
     request_options = default_request_options.merge(cookies: {"ABTest-Example": @ab_cookie_value})

--- a/features/step_definitions/analytics.rb
+++ b/features/step_definitions/analytics.rb
@@ -1,4 +1,0 @@
-Then /^the page view should be tracked$/ do
-  sought = "t=pageview"
-  expect(browser_has_analytics_request_containing sought).to be(true)
-end

--- a/features/support/browser.rb
+++ b/features/support/browser.rb
@@ -25,15 +25,6 @@ def browser_has_request_with_url_containing(sought)
   end
 end
 
-def browser_has_analytics_request_containing(sought)
-  wait_until do
-    browser_has_request_containing do |url, post_data|
-      url.start_with?("https://www.google-analytics.com") &&
-        (url.include?(sought) || post_data.include?(sought))
-    end
-  end
-end
-
 def browser_has_request_containing
   # Most logs look like this:
   #


### PR DESCRIPTION
These tests don't work without UA - there are no GA4 tests replacing them, so we can just remove them.

## Testing

**You should manually test your PR before merging.**

See https://github.com/alphagov/smokey/blob/main/docs/deployment.md
