### PR TITLE
Remove uniqueness test for search results

### DIFF
--- a/features/apps/finder_frontend.feature
+++ b/features/apps/finder_frontend.feature
@@ -18,7 +18,6 @@ Feature: Finder Frontend
     Given I consent to cookies
     When I search for "<keywords>"
     Then I should see some search results
-    And the search results should be unique
 
     Examples:
     | keywords         |

--- a/features/step_definitions/finder_frontend_steps.rb
+++ b/features/step_definitions/finder_frontend_steps.rb
@@ -18,11 +18,3 @@ Then /^I should see some search results$/ do
   result_links = page.all(".finder-results li a")
   expect(result_links.count).to be >= 1
 end
-
-And /^the search results should be unique$/ do
-  results = []
-  page.all(".finder-results li a").each_with_index do |item, idx|
-    results << item.text + page.all(".finder-results li p")[idx].text
-  end
-  expect(results.uniq.count).to eq(results.count)
-end


### PR DESCRIPTION
- The finder-frontend scenario these are used in is "Check the frontend can talk to Search API", and that doesn't really need to prove uniqueness, only that _any_ results come back.
- The uniqueness test really seems to be about search _quality_, and the search team are already monitoring quality much more intensively than this simple test can.
- The tests as they are are a little fragile (they break if the result doesn't have descriptive text), and although they could easily be re-written to be less fragile, it's not clear they actually add anything.

## Testing

**You should manually test your PR before merging.**

See https://github.com/alphagov/smokey/blob/main/docs/deployment.md
