### PR TITLE
Remove dangling reference to a deleted Analytics step.

### DIFF
--- a/features/cdn.feature
+++ b/features/cdn.feature
@@ -12,7 +12,6 @@ Feature: CDN
     When I visit "/help/ab-testing"
     Then I am assigned to a test bucket
     And I can see the bucket I am assigned to
-    And the bucket is reported to Google Analytics
     And I stay on the same bucket when I keep visiting "/help/ab-testing"
 
   @notcloudfront


### PR DESCRIPTION
Since #1310, `cdn.feature` has been failing with:

```
Undefined Scenarios:
cucumber -p production features/cdn.feature:9 # Scenario: Check an A/B test is persistent
...
You can implement step definitions for undefined steps with these snippets:
Then('the bucket is reported to Google Analytics') do
...
```