### PR TITLE
Fix failing checkbox test in click_button_steps

### DIFF
--- a/features/step_definitions/click_button_steps.rb
+++ b/features/step_definitions/click_button_steps.rb
@@ -1,5 +1,5 @@
 When /^I choose radio button "(.*?)" and click on "(.*?)"$/ do |option, button_text|
-  choose(option, visible: false)
+  choose(option, visible: false, allow_label_click: true)
   step "I click on the button \"#{button_text}\""
 end
 
@@ -8,7 +8,7 @@ When /^I click on the link "(.*?)"$/ do |link_text|
 end
 
 When /^I choose the checkbox "(.*)" and click on "(.*)"$/ do |option, button_text|
-  check(option, visible: false)
+  check(option, visible: false, allow_label_click: true)
   step "I click on the button \"#{button_text}\""
 end
 


### PR DESCRIPTION
Fix failing tests with radio and checkbox inputs
Version 5.1.0 of govuk-frontend contains refactoring to the CSS for radio buttons and checkboxes, this change resulted in tests throwing an `ElementClickInterceptedError`.

This was logged as a GitHub issue in govuk-frontend
 - https://github.com/alphagov/govuk-frontend/issues/4762

This issue was fixed in version 5.2.0 - https://github.com/alphagov/govuk-frontend/pull/4768