### PR TITLE
Add tests for GOV.UK Chat

### DIFF
--- a/features/apps/govuk_chat.feature
+++ b/features/apps/govuk_chat.feature
@@ -1,0 +1,12 @@
+@app-govuk-chat
+Feature: GOV.UK Chat
+  Scenario: Can view a static page
+    When I visit the GOV.UK Chat about page
+    Then I should see "About GOV.UK Chat"
+
+  Scenario: Can log in to chat admin
+    Given I am testing "chat"
+    When I visit "/admin"
+    And I try to login as a user
+    And I visit "/admin"
+    Then I should see "GOV.UK Chat Admin"

--- a/features/step_definitions/govuk_chat_steps.rb
+++ b/features/step_definitions/govuk_chat_steps.rb
@@ -1,0 +1,11 @@
+When /^I visit the GOV.UK Chat about page$/ do
+  url = if ENV["ENVIRONMENT"] == "production"
+    application_external_url("chat")
+  else
+    application_internal_url("chat")
+  end
+
+  cache_busted_url = cache_bust("#{url}/chat/about")
+
+  step "I visit \"#{cache_busted_url}\""
+end


### PR DESCRIPTION
https://trello.com/c/bnG6AjtP/1937

Adds two simple tests:

1. For a non-signed in user viewing a static page. We use the about page here instead of the homepage as the Chat app can be turned on and off to allow and disallow public access while it's still in beta mode. So the homepage can change state, which is why we test against a static page that won't change.
2. For a signed-in user viewing the admin area

Chat is set up slightly differently on integration/staging vs prod currently. Chat is still in beta so it's only available via the external URL on prod.  So a custom step definition was needed here to set the external URL differently on integration. Once we've got all environments consistent, we can delete this whole step definition file and just use the existing "When I visit x" definition.