### PR TITLE
Fix internal URL for GOV.UK Chat test

### DIFF
--- a/features/step_definitions/govuk_chat_steps.rb
+++ b/features/step_definitions/govuk_chat_steps.rb
@@ -2,7 +2,7 @@ When /^I visit the GOV.UK Chat about page$/ do
   url = if ENV["ENVIRONMENT"] == "production"
     application_external_url("chat")
   else
-    application_internal_url("chat")
+    Plek.website_root
   end
 
   cache_busted_url = cache_bust("#{url}/chat/about")


### PR DESCRIPTION
Using `application_internal_url("chat")` returns a url of "https://chat". Instead we want the actual full URL of "https://www.integration.publishing.service.gov.uk"