### PR TITLE
Fix Asset Manager errors

### DIFF
--- a/features/assets.feature
+++ b/features/assets.feature
@@ -9,11 +9,13 @@ Feature: Assets
 
   Scenario: Check an asset can be served
     Given I am testing "assets"
+    And I don't care about JavaScript errors
     When I request "/media/580768d940f0b64fbe000022/Target_incomes_calculator.xls"
     Then I should get a "Content-Type" header of "application/vnd.ms-excel"
 
   Scenario: Check a draft asset can be served
     Given I am testing "draft-assets"
+    And I don't care about JavaScript errors
     When I visit "/media/513a0efbed915d425e000002/120613_Albania_Travel_Advice_WEB_Ed2_jpeg.jpg"
     Then I should be redirected to signon
     When I log in using valid credentials


### PR DESCRIPTION
[Trello](https://trello.com/c/hrekcXsz/1414-fix-asset-manager-smokey-test)

We're seeing the following error in the "Check a draft asset can be served" scenario

```
Detected JS errors:

      https://draft-assets.integration.publishing.service.gov.uk/favicon.ico - Failed to load resource: the server responded with a status of 404 () (RuntimeError)
      ./features/support/hooks.rb:31:in `After'
```

Given this is effectively testing Asset Manager's use as an API, we think we can safely ignore JavaScript errors in these scenarios

This scenario seemed to start failing after this favicon-related change in Static: https://github.com/alphagov/static/pull/3443

## Testing

**You should manually test your PR before merging.**

See https://github.com/alphagov/smokey/blob/main/docs/deployment.md
